### PR TITLE
Adding new members to the TSC

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,11 +45,15 @@ developers and stakeholders of Viskores.
 The TSC voting members are listed below along with their GitHub usernames.
 
   * Kenneth Moreland (@kmorel) -- Chair
+  * Jefferson Amstutz (@jeffamstutz)
   * Mark Bolstad (@renderdude)
   * Hank Childs (@hankchilds)
   * Berk Geveci (@berkgeveci)
+  * Nicole Marsaglia (@nicolemarsaglia)
   * Li-Ta "Ollie" Lo (@ollielo)
   * David Pugmire (@dpugmire)
+  * Silvio Rizzi (@srizzi88)
+  * Gunther Weber (@ghweber)
 
 A TSC voting member may be added by a majority approval of the existing
 members. A TSC member may be removed by self-request, they have remained


### PR DESCRIPTION
These members were voted in by the current members of the TSC. See meeting notes at:

  https://github.com/Viskores/viskores-tsc/wiki/Meeting-2024%E2%80%9010%E2%80%9029