### PR TITLE
ci: add cdash status

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,16 @@
+version: 2
+jobs:
+  "post-cdash-status":
+    docker:
+      - image: cimg/base:2024.12
+    steps:
+      - checkout
+      - run:
+          name: CDash
+          command: ./scripts/ci/circle/post-cdash-status
+
+workflows:
+  version: 2
+  utils:
+    jobs:
+      - "post-cdash-status"

--- a/.circleci/post-cdash-status
+++ b/.circleci/post-cdash-status
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -eo pipefail
+
+readonly API_BASE="https://api.github.com/repos/viskores/viskores"
+readonly USER=${STATUS_ROBOT_NAME}
+readonly TOKEN=${STATUS_ROBOT_KEY}
+readonly COMMIT=${CIRCLE_SHA1}
+readonly CDASH_STATUS_CONTEXT="cdash"
+
+#==============================================================================
+
+function build_status_body() {
+  cat <<EOF
+{
+  "state": "success",
+  "target_url": "https://open.cdash.org/index.php?compare1=61&filtercount=1&field1=revision&project=Viskores&showfilters=0&limit=100&value1=${COMMIT}&showfeed=0",
+  "description": "Build and test results available on CDash",
+  "context": "${CDASH_STATUS_CONTEXT}"
+}
+EOF
+}
+
+#==============================================================================
+
+statuses=$(curl -q -s \
+                -H "Content-Type: application/json" \
+                -H "Accept: application/vnd.github+json" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                "${API_BASE}/commits/${COMMIT}/statuses" |\
+                jq -r '[.[].context] | @json')
+
+if jq -re 'all(. != "dash")' <<<"${statuses}"; then
+  echo "Need to post a status for context ${CDASH_STATUS_CONTEXT}"
+
+  postBody="$(build_status_body)"
+  postUrl="${API_BASE}/statuses/${COMMIT}"
+
+  curl -X POST -q -s \
+       -H "Authorization: Bearer ${TOKEN}" \
+       -H "Content-Type: application/json" \
+       -H "Accept: application/vnd.github+json" \
+       -H "X-GitHub-Api-Version: 2022-11-28" \
+       -d "${postBody}" "${postUrl}"
+fi
+


### PR DESCRIPTION
This will be provided by circle CI so that even if your Github actions jobs allocation is saturated we still get responsive cdash status.