### PR TITLE
ci: only run on main,release* branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@
 name: CI
 on:
   push:
+    branches:
+      - main
+      - 'release**'
   pull_request:
 
 concurrency:


### PR DESCRIPTION
This is needed to avoid running twice the CI when the branch of Pull request exist in the viskores main repo. Observed from the automated dependbot pull requests.