### PR TITLE
docs: update README|CONTRIBUTING  to reflect github and viskores

### DIFF
--- a/.gitlab/ci/doxygen.yml
+++ b/.gitlab/ci/doxygen.yml
@@ -18,10 +18,6 @@
 ##
 ##=============================================================================
 
-.upload_doxygen_script: &upload_doxygen_script
-  - chmod 400 $DOC_KEY_FILE
-  - rsync -rtv --delete -e "ssh -i $DOC_KEY_FILE -o StrictHostKeyChecking=no" build/docs/doxygen/html/ "kitware@web.kitware.com:vtkm_documentation/$DOXYGEN_UPLOAD_REMOTE_PATH"
-
 .build_doxygen_script: &build_doxygen_script
   - cmake --build "${CI_PROJECT_DIR}/build" --target docs/doxygen
   - cmake --build "${CI_PROJECT_DIR}/build" --target ViskoresUsersGuideHTML
@@ -48,39 +44,3 @@ docs-continuous:
     - .cmake_build_artifacts
     - .run_automatically
     - .ubuntu2004_doxygen
-
-docs-master:
-  script:
-    - *build_doxygen_script
-    - *upload_doxygen_script
-  environment:
-    name: doxygen-nightly
-    url: https://docs-m.vtk.org/nightly/
-  rules:
-    - if: '$CI_PROJECT_PATH == "viskores/viskores" && $CI_COMMIT_REF_NAME == "master"'
-      when: on_success
-    - when: never
-  extends:
-    - .build_docs
-    - .cmake_build_artifacts
-    - .ubuntu2004_doxygen
-  variables:
-    DOXYGEN_UPLOAD_REMOTE_PATH: "nightly"
-
-docs-latest:
-  script:
-    - *build_doxygen_script
-    - *upload_doxygen_script
-  environment:
-    name: doxygen-latest
-    url: https://docs-m.vtk.org/latest/index.html
-  rules:
-    - if: '$CI_PROJECT_PATH == "viskores/viskores" && $CI_COMMIT_TAG'
-      when: on_success
-    - when: never
-  extends:
-    - .build_docs
-    - .cmake_build_artifacts
-    - .ubuntu2004_doxygen
-  variables:
-    DOXYGEN_UPLOAD_REMOTE_PATH: "latest"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -237,7 +237,7 @@ will be filled out for you.
 
         Cc: @user1 @user2
 
-6.  The "**Assign to**", "**Milestone**", and "**Labels**" fields may be
+6.  The "**Assignees**", "**Milestone**", and "**Labels**" fields may be
     left blank.
 
 7.  Enable the "** Allow edits and access to secrets by maintainers.**" option,
@@ -405,8 +405,8 @@ history.
 ## Merge a Topic ##
 
 After a topic has been reviewed and approved in a GitHub pull request,
-authorized developers may accept the pull request and merge clicking the merge
-button.
+authorized developers may accept the pull request and merge by clicking the
+merge button.
 
 ### Merge Success ###
 
@@ -415,9 +415,8 @@ If the merge succeeds the topic will appear in the upstream repository
 
 ### Merge Failure ###
 
-If the merge fails (likely due to a conflict), a comment will be added
-describing the failure. In the case of a conflict, fetch the latest
-upstream history and rebase on it:
+If the merge fails (likely due to a conflict), fetch the latest upstream
+history and rebase on it:
 
     $ git fetch origin
     $ git rebase origin/main

--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ computing by providing abstract models for data and execution that can be
 applied to a variety of algorithms across many different processor
 architectures.
 
-You can find out more about the design of Viskores on the [Viskores Wiki].
-
 ## Current Status
 
 Viskores is a adopting the functionality of [Viskores] as a part of the [High
@@ -44,11 +42,10 @@ the project.
       + Algorithm development with Viskores.
       + Writing new Viskores filters.
 
-  + Community discussion takes place on the [Viskores users email list].
+  + Community discussion takes place on the [Viskores users discussion].
 
-  + Doxygen-generated reference documentation is available for both:
-    + Last Nightly build [Viskores Doxygen nightly]
-    + Last release [Viskores Doxygen latest]
+  + Doxygen-generated reference documentation is available for the tip of the
+    release branch at [Viskores Doxygen latest]
 
 
 ## Contributing ##
@@ -56,7 +53,7 @@ the project.
 There are many ways to contribute to [Viskores], with varying levels of
 effort.
 
-  + Ask a question on the [Viskores users email list].
+  + Ask a question on the [Viskores users discussion].
 
   + Submit new or add to discussions of a feature requests or bugs on the
     [Viskores Issue Tracker].
@@ -275,16 +272,14 @@ See [LICENSE.txt](LICENSE.txt) for details.
 
 [Viskores]:                             https://github.com/Viskores/viskores
 [Viskores Coding Conventions]:          docs/CodingConventions.md
-[Viskores Doxygen latest]:              https://docs-m.vtk.org/latest/index.html
-[Viskores Doxygen nightly]:             https://docs-m.vtk.org/nightly/
+[Viskores Doxygen latest]:              https://viskores.github.io/viskores-doxygen/
 [Viskores download page]:               https://github.com/Viskores/viskores/releases
 [Viskores git repository]:              https://github.com/Viskores/viskores
 [Viskores Issue Tracker]:               https://github.com/Viskores/viskores/issues
 [Viskores Overview]:                    http://m.vtk.org/images/2/29/ViskoresVis2016.pptx
-[Viskores Users Guide]:                 https://github.com/Viskores/viskores-user-guide/-/wikis/home
-[Viskores users email list]:            http://vtk.org/mailman/listinfo/viskores
-[Viskores Wiki]:                        http://m.vtk.org/
-[Viskores Tutorial]:                    http://m.vtk.org/index.php/Tutorial
+[Viskores Users Guide]:                 https://viskores.readthedocs.io/en/latest/
+[Viskores users discussion]:            https://github.com/Viskores/viskores/discussions
+[Viskores Tutorial]:                    tutorial/README.md
 [CONTRIBUTING.md]:                      CONTRIBUTING.md
 [High Performance Software Foundation]: https://hpsf.io/
 [technical charter]:                    docs/technical-charter.pdf


### PR DESCRIPTION
This PR have a few changes that further rebrand the existing docs to Viskores:

Changes:
- Removed unused gitlab ci doxygen upload job
- Updates links in README and CONTRIBUTING file.
- Changes the wording to reflect the developing workflow in Github (as opposed to Gitlab)