### PR TITLE
ViskoresDetermineVersion: apply the `export-subst` attribute

### DIFF
--- a/CMake/.gitattributes
+++ b/CMake/.gitattributes
@@ -1,0 +1,2 @@
+# Replace `$Format:…$` placeholders.
+ViskoresDetermineVersion.cmake  export-subst


### PR DESCRIPTION
This causes Git to replace the `$Format:$` expansion in the file so that the code can determine whether the source is from a Git checkout or an exported tarball (using `git archive`).