### PR TITLE
add transition script for VTK-m apps

### DIFF
--- a/Utilities/Scripts/update_project_to_viskores.bash
+++ b/Utilities/Scripts/update_project_to_viskores.bash
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+##============================================================================
+##  The contents of this file are covered by the Viskores license. See
+##  LICENSE.txt for details.
+##
+##  By contributing to this file, all contributors agree to the Developer
+##  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+##============================================================================
+
+SCRIPT_DIRNAME=$(dirname "$0")
+
+function usage()
+{
+  echo "Usage: $(basename "$0") [options] directory..."
+  echo "Transition source files in a given directory from VTK-m to Viskores"
+  echo "Options:"
+  echo "    -j <JOBS> number of simultaneous processes to use."
+  exit 0
+}
+
+function die()
+{
+  echo "ERROR: $*"
+  usage
+}
+
+command -v nproc &> /dev/null || die "nproc needed"
+command -v parallel &> /dev/null || die "GNU parallel needed"
+
+NJOBS="$(nproc)"
+while getopts "j:h" o
+do
+  case "${o}" in
+    j)
+      NJOBS="${OPTARG}"
+      shift
+      ;;
+    h|*)
+      usage
+      ;;
+  esac
+done
+shift $((OPTIND-1))
+readonly PROJECT_PATH=("$@")
+
+(( $# == 0 )) && die "input directory required"
+
+# Get me all the non-binary files
+sources=$(grep -rIl "." "${PROJECT_PATH[@]}")
+parallel \
+  --progress \
+  -j"${NJOBS}" \
+   "${SCRIPT_DIRNAME}/vtkm_to_viskores_file.bash -f {} > {}.tmp && mv {}.tmp {}" ::: "${sources[@]}"

--- a/Utilities/Scripts/vtkm_to_viskores_file.bash
+++ b/Utilities/Scripts/vtkm_to_viskores_file.bash
@@ -10,9 +10,9 @@
 
 
 read -r -d '' SEDRULES << EOF
-s/vtk-m|vtkm|vtk_m/viskores/g
-s/VTK-M|VTK-m|VTKm|Vtk-m|Vtkm/Viskores/g
-s/VTKM|VTK_M/VISKORES/g
+s/\b(vtk-m|vtkm|vtk_m)\b/viskores/g
+s/\b(VTK-M|VTK-m|VTKm|Vtk-m|Vtkm)\b/Viskores/g
+s/\b(VTKM|VTK_M)\b/VISKORES/g
 s/vtkmdiy/viskoresdiy/g
 EOF
 


### PR DESCRIPTION
Adding an additional script for helping transitioning to Viskores VTK-m apps. The existing `Utilities/Scripts/vtkm_to_viskores_project.bash` while using a more sophisticated approach with clang-rename is hard to setup in our dependencies since it needs external dependencies in conjunction of needing to cmake to configure the project with `-DCMAKE_EXPORT_COMPILE_COMMANDS`

Most of our users would be benefits from a simpler regex replace script as the one introduced here. I develop this script while transitioning Fides to Viskores.