### PR TITLE
Fix compiler warnings about constructor templates

### DIFF
--- a/docs/changelog/0-sample-topic.md
+++ b/docs/changelog/0-sample-topic.md
@@ -1,0 +1,24 @@
+## Short descriptive title
+
+This is a sample release note for the change in a topic.
+Developers should add similar notes for each topic branch
+making a noteworthy change.  Each document should be named
+and titled to match the topic name to avoid merge conflicts.
+
+Tips for writing a good release note:
+
+* Prefer active voice:
+
+  ** Bad: A function to X was added to VTK.
+
+  ** Good: VTK now provides function X.
+
+* Write to the user, not about the user.
+
+  ** Bad: Users can now do X with Y.
+
+  ** Good: You can now do X with filter Y.
+
+* Avoid referring to the current commit or merge request
+
+* Add images to Documentation/release/dev

--- a/docs/changelog/ci-warnings.md
+++ b/docs/changelog/ci-warnings.md
@@ -1,0 +1,5 @@
+## Fixing of CI Warnings
+
+The new CI builds of Viskores identified some compiler
+warnings that were not present before. Many of these
+compiler warnings have been fixed.

--- a/viskores/cont/openmp/internal/RuntimeDeviceConfigurationOpenMP.h
+++ b/viskores/cont/openmp/internal/RuntimeDeviceConfigurationOpenMP.h
@@ -39,7 +39,7 @@ class RuntimeDeviceConfiguration<viskores::cont::DeviceAdapterTagOpenMP>
   : public viskores::cont::internal::RuntimeDeviceConfigurationBase
 {
 public:
-  RuntimeDeviceConfiguration<viskores::cont::DeviceAdapterTagOpenMP>()
+  RuntimeDeviceConfiguration()
     : HardwareMaxThreads(InitializeHardwareMaxThreads())
     , CurrentNumThreads(this->HardwareMaxThreads)
   {


### PR DESCRIPTION
It is not valid to add template parameters to a constructor definition. This functionality will be removed in C++20. Remove an instance of that.