### PR TITLE
Suppress warning from loguru and snprintf

### DIFF
--- a/CTestCustom.cmake.in
+++ b/CTestCustom.cmake.in
@@ -56,6 +56,11 @@ list(APPEND CTEST_CUSTOM_WARNING_EXCEPTION
   # OLCF Ascent/Summit
   ".*viskores/thirdparty.*"
 
+  # Disable warning that can happen in the standard lib from the loguru
+  # third party library. This is a note that can get flagged because it
+  # happens in a file outside of the thirdparty directory.
+  ".*'__builtin___snprintf_chk' output between 5 and 12 bytes.*"
+
   ".*warning: template-id not allowed for constructor.*"
 )
 


### PR DESCRIPTION
This should remove the following warning begin reported from the CI in builds such as ubuntu2404_gcc13:

```
/usr/include/x86_64-linux-gnu/bits/stdio2.h:54:35: note: '__builtin___snprintf_chk' output between 5 and 12 bytes into a destination of size 5
```

This warning is caused by loguru and should be ignored.