### PR TITLE
Change the README to reference an example

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,107 +156,11 @@ Viskores examples is to illustrate specific Viskores concepts in a consistent an
 simple format. However, these examples cover only a small portion of the
 capabilities of Viskores.
 
-Below is a simple example of using Viskores to create a simple data set and use Viskores's rendering
-engine to render an image and write that image to a file. It then computes an isosurface on the
-input data set and renders this output data set in a separate image file:
-
-```cpp
-#include <viskores/cont/Initialize.h>
-#include <viskores/source/Tangle.h>
-
-#include <viskores/rendering/Actor.h>
-#include <viskores/rendering/CanvasRayTracer.h>
-#include <viskores/rendering/MapperRayTracer.h>
-#include <viskores/rendering/MapperVolume.h>
-#include <viskores/rendering/MapperWireframer.h>
-#include <viskores/rendering/Scene.h>
-#include <viskores/rendering/View3D.h>
-
-#include <viskores/filter/contour/Contour.h>
-
-using viskores::rendering::CanvasRayTracer;
-using viskores::rendering::MapperRayTracer;
-using viskores::rendering::MapperVolume;
-using viskores::rendering::MapperWireframer;
-
-int main(int argc, char* argv[])
-{
-  viskores::cont::Initialize(argc, argv, viskores::cont::InitializeOptions::Strict);
-
-  auto tangle = viskores::source::Tangle(viskores::Id3{ 50, 50, 50 });
-  viskores::cont::DataSet tangleData = tangle.Execute();
-  std::string fieldName = "tangle";
-
-  // Set up a camera for rendering the input data
-  viskores::rendering::Camera camera;
-  camera.SetLookAt(viskores::Vec3f_32(0.5, 0.5, 0.5));
-  camera.SetViewUp(viskores::make_Vec(0.f, 1.f, 0.f));
-  camera.SetClippingRange(1.f, 10.f);
-  camera.SetFieldOfView(60.f);
-  camera.SetPosition(viskores::Vec3f_32(1.5, 1.5, 1.5));
-  viskores::cont::ColorTable colorTable("inferno");
-
-  // Background color:
-  viskores::rendering::Color bg(0.2f, 0.2f, 0.2f, 1.0f);
-  viskores::rendering::Actor actor(tangleData.GetCellSet(),
-                               tangleData.GetCoordinateSystem(),
-                               tangleData.GetField(fieldName),
-                               colorTable);
-  viskores::rendering::Scene scene;
-  scene.AddActor(actor);
-  // 2048x2048 pixels in the canvas:
-  CanvasRayTracer canvas(2048, 2048);
-  // Create a view and use it to render the input data using OS Mesa
-
-  viskores::rendering::View3D view(scene, MapperVolume(), canvas, camera, bg);
-  view.Paint();
-  view.SaveAs("volume.png");
-
-  // Compute an isosurface:
-  viskores::filter::contour::Contour filter;
-  // [min, max] of the tangle field is [-0.887, 24.46]:
-  filter.SetIsoValue(3.0);
-  filter.SetActiveField(fieldName);
-  viskores::cont::DataSet isoData = filter.Execute(tangleData);
-  // Render a separate image with the output isosurface
-  viskores::rendering::Actor isoActor(
-    isoData.GetCellSet(), isoData.GetCoordinateSystem(), isoData.GetField(fieldName), colorTable);
-  // By default, the actor will automatically scale the scalar range of the color table to match
-  // that of the data. However, we are coloring by the scalar that we just extracted a contour
-  // from, so we want the scalar range to match that of the previous image.
-  isoActor.SetScalarRange(actor.GetScalarRange());
-  viskores::rendering::Scene isoScene;
-  isoScene.AddActor(isoActor);
-
-  // Wireframe surface:
-  viskores::rendering::View3D isoView(isoScene, MapperWireframer(), canvas, camera, bg);
-  isoView.Paint();
-  isoView.SaveAs("isosurface_wireframer.png");
-
-  // Smooth surface:
-  viskores::rendering::View3D solidView(isoScene, MapperRayTracer(), canvas, camera, bg);
-  solidView.Paint();
-  solidView.SaveAs("isosurface_raytracer.png");
-
-  return 0;
-}
-```
-
-A minimal CMakeLists.txt such as the following one can be used to build this
-example.
-
-```CMake
-cmake_minimum_required(VERSION 3.12...3.15 FATAL_ERROR)
-project(ViskoresDemo CXX)
-
-#Find the Viskores package
-find_package(Viskores REQUIRED QUIET)
-
-if(TARGET viskores::rendering)
-  add_executable(Demo Demo.cxx)
-  target_link_libraries(Demo PRIVATE viskores::filter viskores::rendering viskores::source)
-endif()
-```
+A simple starting example is [Demo.cxx](examples/demo/Demo.cxx), which can be
+found in the [examples/demo](examples/demo) directory. It also comes with a
+sample [CMakeLists.txt](examples/demo/CMakeLists.txt) for configuring such a
+project. When learning to create your own code, both the [Viskores Tutorial] and
+[Viskores Users Guide] have many examples to get you started.
 
 ## License ##
 


### PR DESCRIPTION
Previously, the README.md file listed a simple example to demonstrate what Viskores code looks like. However, it was pointed out that the code was out of date (using deprecated features).

To prevent the example getting out of date, change the listing to a reference to the code in the examples directory. When viewing the README on GitHub, users will be able to simply click the link and view this file directly. Because the code is compiled as part of the CI, we don't have to worry about it being out of date.

Fixes: #94