### PR TITLE
Added a template constructor to MaskSelect

### DIFF
--- a/docs/changelog/mask-select-template.md
+++ b/docs/changelog/mask-select-template.md
@@ -1,0 +1,11 @@
+## Added a template constructor to MaskSelect
+
+The `viskores::worklet::MaskSelect` constructor takes a mask array and
+constructs a lookup array for the mask operation. To speed up compilation and
+reduce executable sizes, the building on the mask array is pre-compiled for
+expected array types. However, it might be that you would like to construct a
+mask from a selection array with other types such as
+`viskores::cont::ArrayHandleTransform`. To do this efficiently, you need to
+compile a special version of the mask build function. To allow this, a
+`MaskSelectTemplate` class is added that has a templated version of the
+constructor.

--- a/viskores/worklet/CMakeLists.txt
+++ b/viskores/worklet/CMakeLists.txt
@@ -33,6 +33,7 @@ set(headers
   MaskIndices.h
   MaskNone.h
   MaskSelect.h
+  MaskSelectTemplate.h
   NDimsHistMarginalization.h
   Normalize.h
   ScalarsToColors.h

--- a/viskores/worklet/MaskSelect.cxx
+++ b/viskores/worklet/MaskSelect.cxx
@@ -16,40 +16,10 @@
 //  PURPOSE.  See the above copyright notice for more information.
 //============================================================================
 
-#include <viskores/worklet/MaskSelect.h>
+#include <viskores/worklet/MaskSelectTemplate.h>
 
-#include <viskores/worklet/DispatcherMapField.h>
-#include <viskores/worklet/WorkletMapField.h>
-
-#include <viskores/cont/Algorithm.h>
-#include <viskores/cont/ArrayHandleCast.h>
-#include <viskores/cont/ArrayHandleView.h>
-
-namespace
-{
-
-struct ReverseOutputToThreadMap : viskores::worklet::WorkletMapField
-{
-  using ControlSignature = void(FieldIn outputToThreadMap,
-                                FieldIn maskArray,
-                                WholeArrayOut threadToOutputMap);
-  using ExecutionSignature = void(_1, InputIndex, _2, _3);
-
-  template <typename MaskType, typename ThreadToOutputPortal>
-  VISKORES_EXEC void operator()(viskores::Id threadIndex,
-                                viskores::Id outputIndex,
-                                MaskType mask,
-                                ThreadToOutputPortal threadToOutput) const
-  {
-    if (mask)
-    {
-      threadToOutput.Set(threadIndex, outputIndex);
-    }
-  }
-};
-
-VISKORES_CONT static viskores::worklet::MaskSelect::ThreadToOutputMapType
-BuildThreadToOutputMapWithFind(viskores::Id numThreads,
+VISKORES_CONT viskores::worklet::MaskSelect::ThreadToOutputMapType
+viskores::worklet::internal::BuildThreadToOutputMapWithFind(viskores::Id numThreads,
                                viskores::cont::ArrayHandle<viskores::Id> outputToThreadMap,
                                viskores::cont::DeviceAdapterId device)
 {
@@ -67,25 +37,8 @@ BuildThreadToOutputMapWithFind(viskores::Id numThreads,
   return threadToOutputMap;
 }
 
-template <typename MaskArrayType>
-VISKORES_CONT static viskores::worklet::MaskSelect::ThreadToOutputMapType
-BuildThreadToOutputMapWithCopy(viskores::Id numThreads,
-                               const viskores::cont::ArrayHandle<viskores::Id>& outputToThreadMap,
-                               const MaskArrayType& maskArray,
-                               viskores::cont::DeviceAdapterId device)
-{
-  viskores::worklet::MaskSelect::ThreadToOutputMapType threadToOutputMap;
-  threadToOutputMap.Allocate(numThreads);
-
-  viskores::worklet::DispatcherMapField<ReverseOutputToThreadMap> dispatcher;
-  dispatcher.SetDevice(device);
-  dispatcher.Invoke(outputToThreadMap, maskArray, threadToOutputMap);
-
-  return threadToOutputMap;
-}
-
-VISKORES_CONT static viskores::worklet::MaskSelect::ThreadToOutputMapType
-BuildThreadToOutputMapAllOn(viskores::Id numThreads, viskores::cont::DeviceAdapterId device)
+VISKORES_CONT viskores::worklet::MaskSelect::ThreadToOutputMapType
+viskores::worklet::internal::BuildThreadToOutputMapAllOn(viskores::Id numThreads, viskores::cont::DeviceAdapterId device)
 {
   viskores::worklet::MaskSelect::ThreadToOutputMapType threadToOutputMap;
   threadToOutputMap.Allocate(numThreads);
@@ -96,6 +49,9 @@ BuildThreadToOutputMapAllOn(viskores::Id numThreads, viskores::cont::DeviceAdapt
   return threadToOutputMap;
 }
 
+namespace
+{
+
 struct MaskBuilder
 {
   template <typename ArrayHandleType>
@@ -103,33 +59,10 @@ struct MaskBuilder
                   viskores::worklet::MaskSelect::ThreadToOutputMapType& threadToOutputMap,
                   viskores::cont::DeviceAdapterId device)
   {
-    viskores::cont::ArrayHandle<viskores::Id> outputToThreadMap;
-    viskores::Id numThreads = viskores::cont::Algorithm::ScanExclusive(
-      device, viskores::cont::make_ArrayHandleCast<viskores::Id>(maskArray), outputToThreadMap);
-    VISKORES_ASSERT(numThreads <= maskArray.GetNumberOfValues());
-
-    // We have implemented two different ways to compute the thread to output map. The first way is
-    // to use a binary search on each thread index into the output map. The second way is to
-    // schedule on each output and copy the the index to the thread map. The first way is faster
-    // for output sizes that are small relative to the input and also tends to be well load
-    // balanced. The second way is faster for larger outputs.
-    //
-    // The former is obviously faster for one thread and the latter is obviously faster when all
-    // outputs have a thread. We have to guess for values in the middle. I'm using if the square of
-    // the number of threads is less than the number of outputs because it is easy to compute.
-    if (numThreads == maskArray.GetNumberOfValues())
-    { //fast path when everything is on
-      threadToOutputMap = BuildThreadToOutputMapAllOn(numThreads, device);
-    }
-    else if ((numThreads * numThreads) < maskArray.GetNumberOfValues())
-    {
-      threadToOutputMap = BuildThreadToOutputMapWithFind(numThreads, outputToThreadMap, device);
-    }
-    else
-    {
-      threadToOutputMap =
-        BuildThreadToOutputMapWithCopy(numThreads, outputToThreadMap, maskArray, device);
-    }
+    // We could call MaskSelectBuild directly, but this ensures that the MaskSelectTemplate
+    // constructor is working correctly.
+    viskores::worklet::MaskSelectTemplate maskSelect{ maskArray, device };
+    threadToOutputMap = maskSelect.GetThreadToOutputMap(viskores::Id{});
   }
 };
 

--- a/viskores/worklet/MaskSelect.h
+++ b/viskores/worklet/MaskSelect.h
@@ -69,6 +69,18 @@ public:
     return this->ThreadToOutputMap;
   }
 
+protected:
+  // Allows to differentiate between MaskSelect and ThreadToOutputMap arrays in constructors.
+  struct ThreadToOutputMapWrapper
+  {
+    ThreadToOutputMapType ThreadToOutputMap;
+  };
+
+  MaskSelect(const ThreadToOutputMapWrapper& threadToOutputMap)
+    : ThreadToOutputMap(threadToOutputMap.ThreadToOutputMap)
+  {
+  }
+
 private:
   ThreadToOutputMapType ThreadToOutputMap;
 

--- a/viskores/worklet/MaskSelectTemplate.h
+++ b/viskores/worklet/MaskSelectTemplate.h
@@ -1,0 +1,133 @@
+//============================================================================
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//============================================================================
+
+#ifndef viskores_worklet_MaskSelectTemplate_h
+#define viskores_worklet_MaskSelectTemplate_h
+
+#include <viskores/worklet/MaskSelect.h>
+#include <viskores/worklet/WorkletMapField.h>
+
+#include <viskores/cont/Algorithm.h>
+#include <viskores/cont/ArrayHandleCast.h>
+#include <viskores/cont/ArrayHandleView.h>
+
+namespace viskores
+{
+namespace worklet
+{
+
+namespace internal
+{
+
+struct MaskSelectReverseOutputToThreadMap : viskores::worklet::WorkletMapField
+{
+  using ControlSignature = void(FieldIn outputToThreadMap,
+                                FieldIn maskArray,
+                                WholeArrayOut threadToOutputMap);
+  using ExecutionSignature = void(_1, InputIndex, _2, _3);
+
+  template <typename MaskType, typename ThreadToOutputPortal>
+  VISKORES_EXEC void operator()(viskores::Id threadIndex,
+                                viskores::Id outputIndex,
+                                MaskType mask,
+                                ThreadToOutputPortal threadToOutput) const
+  {
+    if (mask)
+    {
+      threadToOutput.Set(threadIndex, outputIndex);
+    }
+  }
+};
+
+VISKORES_WORKLET_EXPORT VISKORES_CONT viskores::worklet::MaskSelect::ThreadToOutputMapType
+BuildThreadToOutputMapWithFind(viskores::Id numThreads,
+                               viskores::cont::ArrayHandle<viskores::Id> outputToThreadMap,
+                               viskores::cont::DeviceAdapterId device);
+
+template <typename MaskArrayType>
+VISKORES_CONT viskores::worklet::MaskSelect::ThreadToOutputMapType
+BuildThreadToOutputMapWithCopy(viskores::Id numThreads,
+                               const viskores::cont::ArrayHandle<viskores::Id>& outputToThreadMap,
+                               const MaskArrayType& maskArray,
+                               viskores::cont::DeviceAdapterId device)
+{
+  viskores::worklet::MaskSelect::ThreadToOutputMapType threadToOutputMap;
+  threadToOutputMap.Allocate(numThreads);
+
+  viskores::worklet::DispatcherMapField<MaskSelectReverseOutputToThreadMap> dispatcher;
+  dispatcher.SetDevice(device);
+  dispatcher.Invoke(outputToThreadMap, maskArray, threadToOutputMap);
+
+  return threadToOutputMap;
+}
+
+VISKORES_WORKLET_EXPORT VISKORES_CONT viskores::worklet::MaskSelect::ThreadToOutputMapType
+BuildThreadToOutputMapAllOn(viskores::Id numThreads, viskores::cont::DeviceAdapterId device);
+
+template <typename ArrayHandleType>
+viskores::worklet::MaskSelect::ThreadToOutputMapType MaskSelectBuild(
+  const ArrayHandleType& maskArray,
+  viskores::cont::DeviceAdapterId device)
+{
+  viskores::cont::ArrayHandle<viskores::Id> outputToThreadMap;
+  viskores::Id numThreads = viskores::cont::Algorithm::ScanExclusive(
+    device, viskores::cont::make_ArrayHandleCast<viskores::Id>(maskArray), outputToThreadMap);
+  VISKORES_ASSERT(numThreads <= maskArray.GetNumberOfValues());
+
+  // We have implemented two different ways to compute the thread to output map. The first way is
+  // to use a binary search on each thread index into the output map. The second way is to
+  // schedule on each output and copy the the index to the thread map. The first way is faster
+  // for output sizes that are small relative to the input and also tends to be well load
+  // balanced. The second way is faster for larger outputs.
+  //
+  // The former is obviously faster for one thread and the latter is obviously faster when all
+  // outputs have a thread. We have to guess for values in the middle. I'm using if the square of
+  // the number of threads is less than the number of outputs because it is easy to compute.
+  if (numThreads == maskArray.GetNumberOfValues())
+  { //fast path when everything is on
+    return BuildThreadToOutputMapAllOn(numThreads, device);
+  }
+  else if ((numThreads * numThreads) < maskArray.GetNumberOfValues())
+  {
+    return BuildThreadToOutputMapWithFind(numThreads, outputToThreadMap, device);
+  }
+  else
+  {
+    return BuildThreadToOutputMapWithCopy(numThreads, outputToThreadMap, maskArray, device);
+  }
+}
+
+} // namespace internal
+
+/// @brief A templated version `MaskSelect`.
+///
+/// To construct a `MaskSelect`, you provide a mask array, which gets processed
+/// to construct a lookup array. To prevent multiple recompiles, this is compiled
+/// into a library. However, if your mask array is of an atypical type, such as a
+/// `viskores::cont::ArrayHandleTransform`, the underlying code will have to copy
+/// the array into a form it is familiar with. In this case where you have such
+/// an array (and Viskores is warning you about an inefficient array copy), you
+/// can use the constructor of this subclass to compile a version of `MaskSelect`
+/// directly for your array type.
+///
+/// Once constructed, this object can (and probably should) be cast to a `MaskSelect`.
+class VISKORES_ALWAYS_EXPORT MaskSelectTemplate : public viskores::worklet::MaskSelect
+{
+public:
+  template <typename ArrayHandleType>
+  MaskSelectTemplate(const ArrayHandleType& maskArray,
+                     viskores::cont::DeviceAdapterId device = viskores::cont::DeviceAdapterTagAny())
+  : MaskSelect(ThreadToOutputMapWrapper{ internal::MaskSelectBuild(maskArray, device)} )
+  {
+  }
+};
+
+}
+} // namespace viskores::worklet
+
+#endif // viskores_worklet_MaskSelectTemplate_h


### PR DESCRIPTION
The `viskores::worklet::MaskSelect` constructor takes a mask array and constructs a lookup array for the mask operation. To speed up compilation and reduce executable sizes, the building on the mask array is pre-compiled for expected array types. However, it might be that you would like to construct a mask from a selection array with other types such as `viskores::cont::ArrayHandleTransform`. To do this efficiently, you need to compile a special version of the mask build function. To allow this, a `MaskSelectTemplate` class is added that has a templated version of the constructor.