### PR TITLE
Update use of Actor rendering class

### DIFF
--- a/benchmarking/BenchmarkInSitu.cxx
+++ b/benchmarking/BenchmarkInSitu.cxx
@@ -214,10 +214,7 @@ viskores::rendering::Canvas* RenderDataSets(const std::vector<viskores::cont::Da
 
   for (auto& dataSet : dataSets)
   {
-    scene.AddActor(viskores::rendering::Actor(dataSet.GetCellSet(),
-                                              dataSet.GetCoordinateSystem(),
-                                              dataSet.GetField(fieldName),
-                                              colorTable));
+    scene.AddActor(viskores::rendering::Actor(dataSet, fieldName, colorTable));
   }
 
   auto bounds =

--- a/docs/users-guide/examples/GuideExampleRendering.cxx
+++ b/docs/users-guide/examples/GuideExampleRendering.cxx
@@ -59,9 +59,7 @@ void DoBasicRender()
   ////
   //// BEGIN-EXAMPLE ActorScene
   ////
-  viskores::rendering::Actor actor(surfaceData.GetCellSet(),
-                                   surfaceData.GetCoordinateSystem(),
-                                   surfaceData.GetField("RandomPointScalars"));
+  viskores::rendering::Actor actor(surfaceData, "RandomPointScalars");
 
   viskores::rendering::Scene scene;
   scene.AddActor(actor);
@@ -130,9 +128,7 @@ void DoPointRender()
   }
 
   // Initialize Viskores rendering classes
-  viskores::rendering::Actor actor(surfaceData.GetCellSet(),
-                                   surfaceData.GetCoordinateSystem(),
-                                   surfaceData.GetField("RandomPointScalars"));
+  viskores::rendering::Actor actor(surfaceData, "RandomPointScalars");
 
   viskores::rendering::Scene scene;
   scene.AddActor(actor);
@@ -181,9 +177,7 @@ void DoEdgeRender()
   }
 
   // Initialize Viskores rendering classes
-  viskores::rendering::Actor actor(surfaceData.GetCellSet(),
-                                   surfaceData.GetCoordinateSystem(),
-                                   surfaceData.GetField("RandomPointScalars"));
+  viskores::rendering::Actor actor(surfaceData, "RandomPointScalars");
 
   viskores::rendering::Scene scene;
   scene.AddActor(actor);

--- a/docs/users-guide/examples/GuideExampleRenderingInteractive.cxx
+++ b/docs/users-guide/examples/GuideExampleRenderingInteractive.cxx
@@ -346,10 +346,8 @@ int go()
   ////
   //// BEGIN-EXAMPLE SpecifyColorTable
   ////
-  viskores::rendering::Actor actor(surfaceData.GetCellSet(),
-                                   surfaceData.GetCoordinateSystem(),
-                                   surfaceData.GetField("RandomPointScalars"),
-                                   viskores::cont::ColorTable("inferno"));
+  viskores::rendering::Actor actor(
+    surfaceData, "RandomPointScalars", viskores::cont::ColorTable("inferno"));
   ////
   //// END-EXAMPLE SpecifyColorTable
   ////

--- a/docs/users-guide/examples/ViskoresQuickStart.cxx
+++ b/docs/users-guide/examples/ViskoresQuickStart.cxx
@@ -78,8 +78,7 @@ int main(int argc, char* argv[])
   //// BEGIN-EXAMPLE ViskoresQuickStartRender
   ////
   //// LABEL scene-start
-  viskores::rendering::Actor actor(
-    outData.GetCellSet(), outData.GetCoordinateSystem(), outData.GetField("area"));
+  viskores::rendering::Actor actor(outData, "area");
 
   viskores::rendering::Scene scene;
   //// LABEL scene-end

--- a/docs/users-guide/rendering.rst
+++ b/docs/users-guide/rendering.rst
@@ -33,11 +33,8 @@ The primary intent of the rendering package in |Viskores| is to visually display
 Data are represented in |Viskores| by :class:`viskores::cont::DataSet` objects, which are described in :chapref:`dataset:Data Sets`.
 They are also the object created from :chapref:`io:File I/O` and :chapref:`running-filters:Running Filters`.
 
-To render a :class:`viskores::cont::DataSet`, the data are wrapped in a
-:class:`viskores::rendering::Actor` class. The :class:`viskores::rendering::Actor` holds the
-components of the :class:`viskores::cont::DataSet` to render (a cell set, a
-coordinate system, and a field). A color table can also be optionally be
-specified, but a default color table will be specified otherwise.
+To render a :class:`viskores::cont::DataSet`, the data are wrapped in a :class:`viskores::rendering::Actor` class.
+A color table can also be optionally be specified, but a default color table will be specified otherwise.
 
 .. load-example:: ActorScene
    :file: GuideExampleRendering.cxx
@@ -50,7 +47,7 @@ specified, but a default color table will be specified otherwise.
    double: rendering; scene
 
 :class:`viskores::rendering::Actor` objects are collected together in an object called :class:`viskores::rendering::Scene`.
-       An :class:`viskores::rendering::Actor` is added to a :class:`viskores::rendering::Scene` with the :func:`viskores::rendering::Scene::AddActor` method.
+       A :class:`viskores::rendering::Actor` is added to a :class:`viskores::rendering::Scene` with the :func:`viskores::rendering::Scene::AddActor` method.
 
 .. doxygenclass:: viskores::rendering::Scene
    :members:

--- a/examples/demo/Demo.cxx
+++ b/examples/demo/Demo.cxx
@@ -58,10 +58,7 @@ int main(int argc, char* argv[])
 
   // Background color:
   viskores::rendering::Color bg(0.2f, 0.2f, 0.2f, 1.0f);
-  viskores::rendering::Actor actor(tangleData.GetCellSet(),
-                                   tangleData.GetCoordinateSystem(),
-                                   tangleData.GetField(fieldName),
-                                   colorTable);
+  viskores::rendering::Actor actor(tangleData, fieldName, colorTable);
   viskores::rendering::Scene scene;
   scene.AddActor(actor);
   // 2048x2048 pixels in the canvas:
@@ -79,11 +76,11 @@ int main(int argc, char* argv[])
   filter.SetActiveField(fieldName);
   viskores::cont::DataSet isoData = filter.Execute(tangleData);
   // Render a separate image with the output isosurface
-  viskores::rendering::Actor isoActor(
-    isoData.GetCellSet(), isoData.GetCoordinateSystem(), isoData.GetField(fieldName), colorTable);
-  // By default, the actor will automatically scale the scalar range of the color table to match
-  // that of the data. However, we are coloring by the scalar that we just extracted a contour
-  // from, so we want the scalar range to match that of the previous image.
+  viskores::rendering::Actor isoActor(isoData, fieldName, colorTable);
+  // By default, the actor will automatically scale the scalar range of the
+  // color table to match that of the data. However, we are coloring by the
+  // scalar that we just extracted a contour from, so we want the scalar range
+  // to match that of the previous image.
   isoActor.SetScalarRange(actor.GetScalarRange());
   viskores::rendering::Scene isoScene;
   isoScene.AddActor(std::move(isoActor));

--- a/examples/ising/Ising.cxx
+++ b/examples/ising/Ising.cxx
@@ -112,10 +112,7 @@ int main(int argc, char** argv)
   dataSet.GetCellField("spins").GetData().AsArrayHandle(spins);
 
   viskores::rendering::Scene scene;
-  viskores::rendering::Actor actor(dataSet.GetCellSet(),
-                                   dataSet.GetCoordinateSystem(),
-                                   dataSet.GetCellField("spins"),
-                                   viskores::cont::ColorTable("Cool To Warm"));
+  viskores::rendering::Actor actor(dataSet, "spins", viskores::cont::ColorTable("Cool To Warm"));
   scene.AddActor(actor);
   viskores::rendering::CanvasRayTracer canvas(1024, 1024);
   viskores::rendering::MapperRayTracer mapper;

--- a/examples/polyline_archimedean_helix/PolyLineArchimedeanHelix.cxx
+++ b/examples/polyline_archimedean_helix/PolyLineArchimedeanHelix.cxx
@@ -126,10 +126,7 @@ void TubeThatSpiral(viskores::FloatDefault radius,
   v[v.size() - 1] = v[v.size() - 2];
 
   tubeDataset.AddPointField("Spiral Radius", v);
-  scene.AddActor(viskores::rendering::Actor(tubeDataset.GetCellSet(),
-                                            tubeDataset.GetCoordinateSystem(),
-                                            tubeDataset.GetField("Spiral Radius"),
-                                            colorTable));
+  scene.AddActor(viskores::rendering::Actor(tubeDataset, "Spiral Radius", colorTable));
   viskores::rendering::View3D view(scene, mapper, canvas, camera, bg);
   view.Paint();
   // We can save the file as a .NetBPM:

--- a/tutorial/rendering.cxx
+++ b/tutorial/rendering.cxx
@@ -36,10 +36,7 @@ int main(int argc, char** argv)
 
   //Creating Actor
   viskores::cont::ColorTable colorTable("viridis");
-  viskores::rendering::Actor actor(ds_from_file.GetCellSet(),
-                               ds_from_file.GetCoordinateSystem(),
-                               ds_from_file.GetField("c1"),
-                               colorTable);
+  viskores::rendering::Actor actor(ds_from_file, "c1", colorTable);
 
   //Creating Scene and adding Actor
   viskores::rendering::Scene scene;

--- a/viskores/rendering/Actor.cxx
+++ b/viskores/rendering/Actor.cxx
@@ -26,6 +26,8 @@
 
 #include <utility>
 
+static std::string gDefaultCoordName = "_viskores_default_coords";
+
 namespace viskores
 {
 namespace rendering
@@ -78,6 +80,14 @@ Actor::Actor(const viskores::cont::DataSet dataSet,
   this->Init();
 }
 
+Actor::Actor(const viskores::cont::DataSet dataSet, const std::string fieldName)
+{
+  viskores::cont::PartitionedDataSet partitionedDataSet(dataSet);
+  this->Internals =
+    std::make_unique<InternalsType>(partitionedDataSet, gDefaultCoordName, fieldName);
+  this->Init();
+}
+
 Actor::Actor(const viskores::cont::DataSet dataSet,
              const std::string coordinateName,
              const std::string fieldName,
@@ -86,6 +96,16 @@ Actor::Actor(const viskores::cont::DataSet dataSet,
   viskores::cont::PartitionedDataSet partitionedDataSet(dataSet);
   this->Internals =
     std::make_unique<InternalsType>(partitionedDataSet, coordinateName, fieldName, color);
+  this->Init();
+}
+
+Actor::Actor(const viskores::cont::DataSet dataSet,
+             const std::string fieldName,
+             const viskores::rendering::Color& color)
+{
+  viskores::cont::PartitionedDataSet partitionedDataSet(dataSet);
+  this->Internals =
+    std::make_unique<InternalsType>(partitionedDataSet, gDefaultCoordName, fieldName, color);
   this->Init();
 }
 
@@ -100,10 +120,26 @@ Actor::Actor(const viskores::cont::DataSet dataSet,
   this->Init();
 }
 
+Actor::Actor(const viskores::cont::DataSet dataSet,
+             const std::string fieldName,
+             const viskores::cont::ColorTable& colorTable)
+{
+  viskores::cont::PartitionedDataSet partitionedDataSet(dataSet);
+  this->Internals =
+    std::make_unique<InternalsType>(partitionedDataSet, gDefaultCoordName, fieldName, colorTable);
+  this->Init();
+}
+
 Actor::Actor(const viskores::cont::PartitionedDataSet dataSet,
              const std::string coordinateName,
              const std::string fieldName)
   : Internals(new InternalsType(dataSet, coordinateName, fieldName))
+{
+  this->Init();
+}
+
+Actor::Actor(const viskores::cont::PartitionedDataSet dataSet, const std::string fieldName)
+  : Internals(new InternalsType(dataSet, gDefaultCoordName, fieldName))
 {
   this->Init();
 }
@@ -118,10 +154,26 @@ Actor::Actor(const viskores::cont::PartitionedDataSet dataSet,
 }
 
 Actor::Actor(const viskores::cont::PartitionedDataSet dataSet,
+             const std::string fieldName,
+             const viskores::rendering::Color& color)
+  : Internals(new InternalsType(dataSet, gDefaultCoordName, fieldName, color))
+{
+  this->Init();
+}
+
+Actor::Actor(const viskores::cont::PartitionedDataSet dataSet,
              const std::string coordinateName,
              const std::string fieldName,
              const viskores::cont::ColorTable& colorTable)
   : Internals(new InternalsType(dataSet, coordinateName, fieldName, colorTable))
+{
+  this->Init();
+}
+
+Actor::Actor(const viskores::cont::PartitionedDataSet dataSet,
+             const std::string fieldName,
+             const viskores::cont::ColorTable& colorTable)
+  : Internals(new InternalsType(dataSet, gDefaultCoordName, fieldName, colorTable))
 {
   this->Init();
 }
@@ -228,7 +280,15 @@ const viskores::cont::UnknownCellSet& Actor::GetCells() const
 
 viskores::cont::CoordinateSystem Actor::GetCoordinates() const
 {
-  return this->Internals->Data.GetPartition(0).GetCoordinateSystem(this->Internals->CoordinateName);
+  if (this->Internals->CoordinateName == gDefaultCoordName)
+  {
+    return this->Internals->Data.GetPartition(0).GetCoordinateSystem();
+  }
+  else
+  {
+    return this->Internals->Data.GetPartition(0).GetCoordinateSystem(
+      this->Internals->CoordinateName);
+  }
 }
 
 const viskores::cont::Field& Actor::GetScalarField() const

--- a/viskores/rendering/Actor.h
+++ b/viskores/rendering/Actor.h
@@ -38,31 +38,99 @@ namespace rendering
 class VISKORES_RENDERING_EXPORT Actor
 {
 public:
+  /// Create an `Actor` object that renders a given `viskores::cont::DataSet`.
+  /// The name of the coordinate system and a field to apply psudocoloring is
+  /// also provided. The default colormap is applied.
   Actor(const viskores::cont::DataSet dataSet,
         const std::string coordinateName,
         const std::string fieldName);
 
+  /// Create an `Actor` object that renders a given `viskores::cont::DataSet`. A
+  /// field to apply psudocoloring is also provided. The default colormap is
+  /// applied. This constructor assumes the `DataSet` has one coordinate system.
+  Actor(const viskores::cont::DataSet dataSet, const std::string fieldName);
+
+  /// Create an `Actor` object that renders a given `viskores::cont::DataSet`.
+  /// The name of the coordinate system and a field to apply psudocoloring is
+  /// also provided. A color table providing the map from scalar values to colors
+  /// is also provided.
   Actor(const viskores::cont::DataSet dataSet,
         const std::string coordinateName,
         const std::string fieldName,
         const viskores::cont::ColorTable& colorTable);
 
+  /// Create an `Actor` object that renders a given `viskores::cont::DataSet`. A
+  /// field to apply psudocoloring is also provided. A color table providing the
+  /// map from scalar values to colors is also provided. This constructor assumes
+  /// the `DataSet` has one coordinate system.
+  Actor(const viskores::cont::DataSet dataSet,
+        const std::string fieldName,
+        const viskores::cont::ColorTable& colorTable);
+
+  /// Create an `Actor` object that renders a given `viskores::cont::DataSet`.
+  /// The name of the coordinate system and a field to apply psudocoloring is
+  /// also provided. A constant color to apply to the object is also provided.
+  // Why do you have to provide a `Field` if a constant color is provided?
   Actor(const viskores::cont::DataSet dataSet,
         const std::string coordinateName,
         const std::string fieldName,
         const viskores::rendering::Color& color);
 
+  /// Create an `Actor` object that renders a given `viskores::cont::DataSet`. A
+  /// field to apply psudocoloring is also provided. A constant color to apply to
+  /// the object is also provided. This constructor assumes the `DataSet` has one
+  /// coordinate system.
+  // Why do you have to provide a `Field` if a constant color is provided?
+  Actor(const viskores::cont::DataSet dataSet,
+        const std::string fieldName,
+        const viskores::rendering::Color& color);
+
+  /// Create an `Actor` object that renders a given `viskores::cont::PartitionedDataSet`.
+  /// The name of the coordinate system and a field to apply psudocoloring is
+  /// also provided. The default colormap is applied.
   Actor(const viskores::cont::PartitionedDataSet dataSet,
         const std::string coordinateName,
         const std::string fieldName);
 
+  /// Create an `Actor` object that renders a given
+  /// `viskores::cont::PartitionedDataSet`. A field to apply psudocoloring is
+  /// also provided. The default colormap is applied. This constructor assumes
+  /// that each partition in the `PartitionedDataSet` has one coordinate system.
+  Actor(const viskores::cont::PartitionedDataSet dataSet, const std::string fieldName);
+
+  /// Create an `Actor` object that renders a given `viskores::cont::PartitionedDataSet`.
+  /// The name of the coordinate system and a field to apply psudocoloring is
+  /// also provided. A color table providing the map from scalar values to colors
+  /// is also provided.
   Actor(const viskores::cont::PartitionedDataSet dataSet,
         const std::string coordinateName,
         const std::string fieldName,
         const viskores::cont::ColorTable& colorTable);
 
+  /// Create an `Actor` object that renders a given
+  /// `viskores::cont::PartitionedDataSet`. A field to apply psudocoloring is
+  /// also provided. A color table providing the map from scalar values to colors
+  /// is also provided. This constructor assumes that each partition in the
+  /// `PartitionedDataSet` has one coordinate system.
+  Actor(const viskores::cont::PartitionedDataSet dataSet,
+        const std::string fieldName,
+        const viskores::cont::ColorTable& colorTable);
+
+  /// Create an `Actor` object that renders a given `viskores::cont::PartitionedDataSet`.
+  /// The name of the coordinate system and a field to apply psudocoloring is
+  /// also provided. A constant color to apply to the object is also provided.
+  // Why do you have to provide a `Field` if a constant color is provided?
   Actor(const viskores::cont::PartitionedDataSet dataSet,
         const std::string coordinateName,
+        const std::string fieldName,
+        const viskores::rendering::Color& color);
+
+  /// Create an `Actor` object that renders a given `viskores::cont::PartitionedDataSet`.
+  /// A field to apply psudocoloring is also provided. A constant color to apply
+  /// to the object is also provided. This constructor assumes that each
+  /// partition in the `PartitionedDataSet` has one coordinate system.
+  // Why do you have to provide a `Field` if a constant color is provided?
+  Actor(const viskores::cont::PartitionedDataSet dataSet,
         const std::string fieldName,
         const viskores::rendering::Color& color);
 

--- a/viskores/rendering/testlib/RenderTest.cxx
+++ b/viskores/rendering/testlib/RenderTest.cxx
@@ -185,18 +185,12 @@ void DoRenderTest(viskores::rendering::Canvas& canvas,
     std::string fieldName = dataSetsFields[dataFieldId].second;
     if (options.Colors.empty())
     {
-      scene.AddActor(viskores::rendering::Actor(dataSet.GetCellSet(),
-                                                dataSet.GetCoordinateSystem(),
-                                                dataSet.GetField(fieldName),
-                                                options.ColorTable));
+      scene.AddActor(viskores::rendering::Actor(dataSet, fieldName, options.ColorTable));
     }
     else
     {
-      scene.AddActor(
-        viskores::rendering::Actor(dataSet.GetCellSet(),
-                                   dataSet.GetCoordinateSystem(),
-                                   dataSet.GetField(fieldName),
-                                   options.Colors[dataFieldId % options.Colors.size()]));
+      scene.AddActor(viskores::rendering::Actor(
+        dataSet, fieldName, options.Colors[dataFieldId % options.Colors.size()]));
     }
     bounds.Include(dataSet.GetCoordinateSystem().GetBounds());
     fieldRange.Include(dataSet.GetField(fieldName).GetRange().ReadPortal().Get(0));


### PR DESCRIPTION
When the rendering classes were originally created, `Actor` accepted the cell set, coordinate system, and field independently. More recently (but not that recently), new constructors were made that accept a `DataSet` object and pulls these out for you. This is generally a better way to construct actors, so update the documentation and testing code to follow this convention.