### PR TITLE
Fixed bug with `MapperVolume` blending

### DIFF
--- a/docs/changelog/mapper-volume-blend.md
+++ b/docs/changelog/mapper-volume-blend.md
@@ -1,0 +1,12 @@
+## Fixed bug with `MapperVolume` blending
+
+When writing cast rays back to a frame buffer, the canvas records both the color
+and the depth. The depth is computed from where the ray intersected the data.
+However, `MapperVolume` does not record this intersection depth because it
+traces through the whole transparent volume. This was causing bogus depth to be
+written to the buffer, and that was interfering when rendering multiple
+partitions.
+
+This problem is fixed by adding an option to the `Canvas::WriteToCanvas` method
+that prevents the depth buffer from being updated. The `MapperVolume` uses this
+option to prevent writing bad depth values.

--- a/viskores/rendering/CanvasRayTracer.h
+++ b/viskores/rendering/CanvasRayTracer.h
@@ -42,11 +42,13 @@ public:
 
   void WriteToCanvas(const viskores::rendering::raytracing::Ray<viskores::Float32>& rays,
                      const viskores::cont::ArrayHandle<viskores::Float32>& colors,
-                     const viskores::rendering::Camera& camera);
+                     const viskores::rendering::Camera& camera,
+                     bool writeDepth = true);
 
   void WriteToCanvas(const viskores::rendering::raytracing::Ray<viskores::Float64>& rays,
                      const viskores::cont::ArrayHandle<viskores::Float64>& colors,
-                     const viskores::rendering::Camera& camera);
+                     const viskores::rendering::Camera& camera,
+                     bool writeDepth = true);
 }; // class CanvasRayTracer
 }
 } // namespace viskores::rendering

--- a/viskores/rendering/MapperVolume.cxx
+++ b/viskores/rendering/MapperVolume.cxx
@@ -129,7 +129,7 @@ void MapperVolume::RenderCellsImpl(const viskores::cont::UnknownCellSet& cellset
     tracer.Render(rays);
 
     timer.Start();
-    this->Internals->Canvas->WriteToCanvas(rays, rays.Buffers.at(0).Buffer, camera);
+    this->Internals->Canvas->WriteToCanvas(rays, rays.Buffers.at(0).Buffer, camera, false);
 
     if (this->Internals->CompositeBackground)
     {


### PR DESCRIPTION
When writing cast rays back to a frame buffer, the canvas records both the color and the depth. The depth is computed from where the ray intersected the data. However, `MapperVolume` does not record this intersection depth because it traces through the whole transparent volume. This was causing bogus depth to be written to the buffer, and that was interfering when rendering multiple partitions.

This problem is fixed by adding an option to the `Canvas::WriteToCanvas` method that prevents the depth buffer from being updated. The `MapperVolume` uses this option to prevent writing bad depth values.