### PR TITLE
Clip: Fix cellOffset increment

### DIFF
--- a/docs/changelog/clip-fix-cell-offset-increment.md
+++ b/docs/changelog/clip-fix-cell-offset-increment.md
@@ -1,0 +1,9 @@
+## Clip: Fix cellOffset increment
+
+There was bug in the newly redesigned Clip filter that caused the cellOffset to not be incremented,
+cause output cells to be incorrectly placed in the output. This has now been fixed, and the output.
+
+Additionally, all resources are released as soon as possible.
+
+Finally, the ScanExclusive usages within the Clip filter have been improved to operate
+only on the batches of points/cells that are actually needed, rather than the entire batch data.

--- a/viskores/filter/contour/worklet/Clip.h
+++ b/viskores/filter/contour/worklet/Clip.h
@@ -234,7 +234,7 @@ public:
         {
           pointsInputToOutput.Set(pointId, pointOffset);
           pointsOutputToInput.Set(pointOffset, pointId);
-          pointOffset++;
+          ++pointOffset; // increment point offset
         }
       }
     }
@@ -309,7 +309,7 @@ public:
             const viskores::UInt8 numberOfCellIndices = CT::ValueAt(index++);
 
             for (viskores::IdComponent pointId = 0; pointId < numberOfCellIndices;
-                 pointId++, index++)
+                 ++pointId, ++index)
             {
               // Find how many points need to be calculated using edge interpolation.
               const viskores::UInt8 pointIndex = CT::ValueAt(index);
@@ -387,13 +387,13 @@ public:
           viskores::Id index = CT::GetCaseIndex(shape.Id, caseIndex);
           const viskores::UInt8 numberOfShapes = CT::ValueAt(index++);
 
-          for (viskores::IdComponent shapeId = 0; shapeId < numberOfShapes; shapeId++)
+          for (viskores::IdComponent shapeId = 0; shapeId < numberOfShapes; ++shapeId)
           {
             /*viskores::UInt8 cellShape = */ CT::ValueAt(index++);
             const viskores::UInt8 numberOfCellIndices = CT::ValueAt(index++);
 
             for (viskores::IdComponent pointId = 0; pointId < numberOfCellIndices;
-                 pointId++, index++)
+                 ++pointId, ++index)
             {
               // Find how many points need to be calculated using edge interpolation.
               const viskores::UInt8 pointIndex = CT::ValueAt(index);
@@ -412,7 +412,8 @@ public:
                   (static_cast<viskores::Float64>(scalars.Get(ei.Vertex1)) - this->IsoValue) /
                   static_cast<viskores::Float64>(scalars.Get(ei.Vertex2) - scalars.Get(ei.Vertex1));
                 // Add edge to the list of edges.
-                edges.Set(edgeOffset++, ei);
+                edges.Set(edgeOffset, ei);
+                ++edgeOffset; // increment edge offset
               }
             }
           }
@@ -478,7 +479,7 @@ public:
                                   Connectivity& connectivity) const
     {
       namespace CTI = viskores::worklet::internal::ClipTablesInformation;
-      viskores::Id cellsOffset = cellBatchDataOffsets.NumberOfCells;
+      viskores::Id cellOffset = cellBatchDataOffsets.NumberOfCells;
       viskores::Id cellIndicesOffset = cellBatchDataOffsets.NumberOfCellIndices;
       viskores::Id edgeOffset = cellBatchDataOffsets.NumberOfEdges;
       viskores::Id centroidOffset = cellBatchDataOffsets.NumberOfCentroids;
@@ -494,13 +495,15 @@ public:
           const auto points = cellSet.GetIndices(cellId);
           if (caseIndex == CT::GetKeptCellCase()) // kept cell
           {
-            cellMapOutputToInput.Set(cellsOffset, cellId);
-            shapes.Set(cellsOffset, static_cast<viskores::UInt8>(shape.Id));
-            offsets.Set(cellsOffset, cellIndicesOffset);
+            cellMapOutputToInput.Set(cellOffset, cellId);
+            shapes.Set(cellOffset, static_cast<viskores::UInt8>(shape.Id));
+            offsets.Set(cellOffset, cellIndicesOffset);
+            ++cellOffset; // increment cell offset
             for (viskores::IdComponent pointId = 0; pointId < points.GetNumberOfComponents();
                  ++pointId)
             {
-              connectivity.Set(cellIndicesOffset++, pointMapInputToOutput.Get(points[pointId]));
+              connectivity.Set(cellIndicesOffset, pointMapInputToOutput.Get(points[pointId]));
+              ++cellIndicesOffset; // increment cell indices offset
             }
           }
           else // clipped cell
@@ -510,7 +513,7 @@ public:
             viskores::Id index = CT::GetCaseIndex(shape.Id, caseIndex);
             const viskores::UInt8 numberOfShapes = CT::ValueAt(index++);
 
-            for (viskores::IdComponent shapeId = 0; shapeId < numberOfShapes; shapeId++)
+            for (viskores::IdComponent shapeId = 0; shapeId < numberOfShapes; ++shapeId)
             {
               const viskores::UInt8 cellShape = CT::ValueAt(index++);
               const viskores::UInt8 numberOfCellIndices = CT::ValueAt(index++);
@@ -518,12 +521,12 @@ public:
               if (cellShape != CTI::ST_PNT) // normal cell
               {
                 // Store the cell data
-                cellMapOutputToInput.Set(cellsOffset, cellId);
-                shapes.Set(cellsOffset, cellShape);
-                offsets.Set(cellsOffset++, cellIndicesOffset);
-
+                cellMapOutputToInput.Set(cellOffset, cellId);
+                shapes.Set(cellOffset, cellShape);
+                offsets.Set(cellOffset, cellIndicesOffset);
+                ++cellOffset; // increment cell offset
                 for (viskores::IdComponent pointId = 0; pointId < numberOfCellIndices;
-                     pointId++, index++)
+                     ++pointId, ++index)
                 {
                   // Find how many points need to be calculated using edge interpolation.
                   const viskores::UInt8 pointIndex = CT::ValueAt(index);
@@ -532,28 +535,30 @@ public:
                     // We know pt P0 must be > P0 since we already
                     // assume P0 == 0.  This is why we do not
                     // bother subtracting P0 from pt here.
-                    connectivity.Set(cellIndicesOffset++,
+                    connectivity.Set(cellIndicesOffset,
                                      pointMapInputToOutput.Get(points[pointIndex]));
                   }
                   else if (/*pointIndex >= CTI::E00 &&*/ pointIndex <= CTI::E11) // Mid-Edge Point
                   {
-                    connectivity.Set(cellIndicesOffset++,
-                                     this->EdgePointsOffset + edgeIndexToUnique.Get(edgeOffset++));
+                    connectivity.Set(cellIndicesOffset,
+                                     this->EdgePointsOffset + edgeIndexToUnique.Get(edgeOffset));
+                    ++edgeOffset; // increment edge offset
                   }
                   else // pointIndex == CTI::N0 // Centroid Point
                   {
-                    connectivity.Set(cellIndicesOffset++, centroidIndex);
+                    connectivity.Set(cellIndicesOffset, centroidIndex);
                   }
+                  ++cellIndicesOffset; // increment cell indices offset
                 }
               }
               else // cellShape == CTI::ST_PNT
               {
                 // Store the centroid data
                 centroidIndex = this->CentroidPointsOffset + centroidOffset;
-                centroidOffsets.Set(centroidOffset++, centroidIndicesOffset);
-
+                centroidOffsets.Set(centroidOffset, centroidIndicesOffset);
+                ++centroidOffset; // increment centroid offset
                 for (viskores::IdComponent pointId = 0; pointId < numberOfCellIndices;
-                     pointId++, index++)
+                     ++pointId, ++index)
                 {
                   // Find how many points need to be calculated using edge interpolation.
                   const viskores::UInt8 pointIndex = CT::ValueAt(index);
@@ -562,15 +567,17 @@ public:
                     // We know pt P0 must be > P0 since we already
                     // assume P0 == 0.  This is why we do not
                     // bother subtracting P0 from pt here.
-                    centroidConnectivity.Set(centroidIndicesOffset++,
+                    centroidConnectivity.Set(centroidIndicesOffset,
                                              pointMapInputToOutput.Get(points[pointIndex]));
                   }
                   else /*pointIndex >= CTI::E00 && pointIndex <= CTI::E11*/ // Mid-Edge Point
                   {
-                    centroidConnectivity.Set(centroidIndicesOffset++,
+                    centroidConnectivity.Set(centroidIndicesOffset,
                                              this->EdgePointsOffset +
-                                               edgeIndexToUnique.Get(edgeOffset++));
+                                               edgeIndexToUnique.Get(edgeOffset));
+                    ++edgeOffset; // increment edge offset
                   }
+                  ++centroidIndicesOffset; // increment centroid indices offset
                 }
               }
             }


### PR DESCRIPTION
There was bug in the newly redesigned Clip filter that caused the cellOffset to not be incremented,
cause output cells to be incorrectly placed in the output. This has now been fixed, and the output.

Additionally, all resources are released as soon as possible.

Finally, the ScanExclusive usages within the Clip filter have been improved to operate
only on the batches of points/cells that are actually needed, rather than the entire batch data.
