### PR TITLE
Correct issue with CI config

### DIFF
--- a/.gitlab/ci/config/initial_config.cmake
+++ b/.gitlab/ci/config/initial_config.cmake
@@ -141,7 +141,6 @@ foreach(option IN LISTS options)
     execute_process(
       COMMAND ${CCACHE_COMMAND} "--version"
       OUTPUT_VARIABLE CCACHE_VERSION
-      ECHO_ERROR_VARIABLE
       )
 
     string(REGEX REPLACE "\n" " " CCACHE_VERSION ${CCACHE_VERSION})


### PR DESCRIPTION
The CI configuration used the option `ECHO_ERROR_VARIABLE` for `execute_process`. However, this option is only available for CMake 3.18 and greater, and some of the CI runs as early as 3.13.5.