### PR TITLE
Disable threaded flow algorithm

### DIFF
--- a/viskores/filter/flow/internal/ParticleAdvector.h
+++ b/viskores/filter/flow/internal/ParticleAdvector.h
@@ -58,7 +58,12 @@ public:
     }
     else
     {
-      using AlgorithmType = viskores::filter::flow::internal::AdvectAlgorithmThreaded<DSIType>;
+      // There appears to be a race condition in AdvectAlgorithmThreaded, so it is
+      //  currently disabled.
+      // using AlgorithmType = viskores::filter::flow::internal::AdvectAlgorithmThreaded<DSIType>;
+      VISKORES_LOG_S(viskores::cont::LogLevel::Info,
+                     "Threaded flow management currently disabled.");
+      using AlgorithmType = viskores::filter::flow::internal::AdvectAlgorithm<DSIType>;
       return this->RunAlgo<AlgorithmType>(seeds, stepSize);
     }
   }


### PR DESCRIPTION
There appears to be a race condition. I suspect it is in the handling of the `ParticleBlockIDsMap` structure in `viskores::flow::internal::AdvectAlgorithm`. Both the worker and manager threads may be editing this, and I'm not certain they are all blocked by a mutex.