### PR TITLE
ci: only use voltar for a100 jobs (backport)

### DIFF
--- a/.gitlab/ci/ubuntu2004.yml
+++ b/.gitlab/ci/ubuntu2004.yml
@@ -49,6 +49,7 @@ ubuntu2004_gcc9_cuda:
     - nvidia-a100
     - uo-gpu
     - x86_64-nvidiagpu
+    - voltar
   extends:
     - .ubuntu2004_cuda
     - .cmake_build_linux

--- a/.gitlab/ci/ubuntu2204.yml
+++ b/.gitlab/ci/ubuntu2204.yml
@@ -80,6 +80,7 @@ ubuntu2204_clang11_cuda:
     - nvidia-a100
     - uo-gpu
     - x86_64-nvidiagpu
+    - voltar
   extends:
     - .ubuntu2204_cuda
     - .cmake_build_linux
@@ -124,6 +125,7 @@ ubuntu2204_kokkos37_cuda:
     - nvidia-a100
     - uo-gpu
     - x86_64-nvidiagpu
+    - voltar
   extends:
     - .ubuntu2204_cuda_kokkos
     - .cmake_build_linux


### PR DESCRIPTION
Backport of #82 to release branch.