### PR TITLE
Add ArrayHandleSOAStride

### DIFF
--- a/docs/changelog/array-soa-stride.md
+++ b/docs/changelog/array-soa-stride.md
@@ -1,0 +1,18 @@
+## Added ArrayHandleSOAStride
+
+Added a new array type named `ArrayHandleSOAStride`. This new array type holds
+each of its components in a separate array. Unlike `ArrayHandleSOA`,
+`ArrayHandleSOAStride` represents each component as an `ArrayHandleStride`
+rather than a basic array. This allows `ArrayHandleSOAStride` to represent
+most arrays with values of a fixed vector length.
+
+`ArrayHandleSOAStride` can be used in similar situations as
+`ArrayHandleRecombineVec`. The difference is that `ArrayHandleSOAStride`
+requires the Vec length to be determined at compile time. This has both good and
+bad consequences. The bad part is that if the number of components can vary,
+`ArrayHandleSOAStride` cannot represent the data well. However, if the number of
+components is fixed, then each value in the array is represented with a simple
+`Vec`, which means it can be used as a drop-in replacement for basic arrays.
+
+`ArrayHandleSOAStride` is created as a backup array when trying to do a cast and
+call when the size and type of values can be determined.

--- a/viskores/cont/ArrayHandleSOAStride.cxx
+++ b/viskores/cont/ArrayHandleSOAStride.cxx
@@ -1,0 +1,48 @@
+//============================================================================
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//============================================================================
+
+//============================================================================
+//  Copyright (c) Kitware, Inc.
+//  All rights reserved.
+//  See LICENSE.txt for details.
+//
+//  This software is distributed WITHOUT ANY WARRANTY; without even
+//  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+//  PURPOSE.  See the above copyright notice for more information.
+//============================================================================
+
+#define viskores_cont_ArrayHandleSOAStride_cxx
+#include <viskores/cont/ArrayHandleSOAStride.h>
+
+#include <viskores/cont/UnknownArrayHandle.h>
+
+namespace viskores
+{
+namespace cont
+{
+
+#define VISKORES_ARRAYHANDLE_SOA_STRIDE_INSTANTIATE(Type)                                       \
+  template class VISKORES_CONT_EXPORT ArrayHandle<viskores::Vec<Type, 2>, StorageTagSOAStride>; \
+  template class VISKORES_CONT_EXPORT ArrayHandle<viskores::Vec<Type, 3>, StorageTagSOAStride>; \
+  template class VISKORES_CONT_EXPORT ArrayHandle<viskores::Vec<Type, 4>, StorageTagSOAStride>;
+
+VISKORES_ARRAYHANDLE_SOA_STRIDE_INSTANTIATE(char)
+VISKORES_ARRAYHANDLE_SOA_STRIDE_INSTANTIATE(viskores::Int8)
+VISKORES_ARRAYHANDLE_SOA_STRIDE_INSTANTIATE(viskores::UInt8)
+VISKORES_ARRAYHANDLE_SOA_STRIDE_INSTANTIATE(viskores::Int16)
+VISKORES_ARRAYHANDLE_SOA_STRIDE_INSTANTIATE(viskores::UInt16)
+VISKORES_ARRAYHANDLE_SOA_STRIDE_INSTANTIATE(viskores::Int32)
+VISKORES_ARRAYHANDLE_SOA_STRIDE_INSTANTIATE(viskores::UInt32)
+VISKORES_ARRAYHANDLE_SOA_STRIDE_INSTANTIATE(viskores::Int64)
+VISKORES_ARRAYHANDLE_SOA_STRIDE_INSTANTIATE(viskores::UInt64)
+VISKORES_ARRAYHANDLE_SOA_STRIDE_INSTANTIATE(viskores::Float32)
+VISKORES_ARRAYHANDLE_SOA_STRIDE_INSTANTIATE(viskores::Float64)
+
+#undef VISKORES_ARRAYHANDLE_SOA_STRIDE_INSTANTIATE
+}
+} // end viskores::cont

--- a/viskores/cont/ArrayHandleSOAStride.h
+++ b/viskores/cont/ArrayHandleSOAStride.h
@@ -1,0 +1,559 @@
+//============================================================================
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//============================================================================
+
+#ifndef viskores_cont_ArrayHandleSOAStride_h
+#define viskores_cont_ArrayHandleSOAStride_h
+
+#include <viskores/cont/ArrayExtractComponent.h>
+#include <viskores/cont/ArrayHandle.h>
+#include <viskores/cont/ArrayHandleSOA.h>
+#include <viskores/cont/ArrayHandleStride.h>
+
+#include <viskores/Math.h>
+#include <viskores/VecTraits.h>
+
+#include <viskores/internal/ArrayPortalBasic.h>
+#include <viskores/internal/ArrayPortalHelpers.h>
+
+#include <viskoresstd/integer_sequence.h>
+
+#include <array>
+#include <limits>
+#include <type_traits>
+
+namespace viskores
+{
+
+namespace cont
+{
+
+struct VISKORES_ALWAYS_EXPORT StorageTagSOAStride
+{
+};
+
+namespace internal
+{
+
+template <typename ValueType>
+class VISKORES_ALWAYS_EXPORT Storage<ValueType, viskores::cont::StorageTagSOAStride>
+{
+  using VTraits = viskores::VecTraits<ValueType>;
+  using ComponentType = typename VTraits::ComponentType;
+  static constexpr viskores::IdComponent NUM_COMPONENTS = VTraits::NUM_COMPONENTS;
+  VISKORES_STATIC_ASSERT_MSG(
+    (std::is_same<ComponentType, typename VTraits::BaseComponentType>::value),
+    "ArrayHandleSOAStride currently only supports flat Vec types.");
+
+  static constexpr viskores::IdComponent NUM_BUFFERS_PER_COMPONENT = 2;
+
+  using ComponentStorage =
+    viskores::cont::internal::Storage<ComponentType, viskores::cont::StorageTagStride>;
+
+public:
+  using ReadPortalType =
+    viskores::internal::ArrayPortalSOA<ValueType,
+                                       viskores::internal::ArrayPortalStrideRead<ComponentType>>;
+  using WritePortalType =
+    viskores::internal::ArrayPortalSOA<ValueType,
+                                       viskores::internal::ArrayPortalStrideWrite<ComponentType>>;
+
+  using ComponentArrayType = viskores::cont::ArrayHandleStride<ComponentType>;
+
+  VISKORES_CONT static std::vector<viskores::cont::internal::Buffer> CreateBuffers()
+  {
+    std::vector<viskores::cont::internal::Buffer> buffers;
+    buffers.reserve(static_cast<std::size_t>(NUM_COMPONENTS * NUM_BUFFERS_PER_COMPONENT));
+    for (viskores::IdComponent i = 0; i < NUM_COMPONENTS; ++i)
+    {
+      ComponentArrayType newArray;
+      std::vector<viskores::cont::internal::Buffer> newBuffers = newArray.GetBuffers();
+      VISKORES_ASSERT(newBuffers.size() == static_cast<std::size_t>(NUM_BUFFERS_PER_COMPONENT));
+      buffers.insert(buffers.end(), newBuffers.begin(), newBuffers.end());
+    }
+    return buffers;
+  }
+
+  VISKORES_CONT static std::vector<viskores::cont::internal::Buffer> GetComponentBuffers(
+    const std::vector<viskores::cont::internal::Buffer>& buffers,
+    viskores::IdComponent componentIndex)
+  {
+    VISKORES_ASSERT(buffers.size() ==
+                    static_cast<std::size_t>(NUM_COMPONENTS * NUM_BUFFERS_PER_COMPONENT));
+    VISKORES_ASSERT(componentIndex >= 0);
+    VISKORES_ASSERT(componentIndex < NUM_COMPONENTS);
+
+    return { buffers.begin() + (NUM_BUFFERS_PER_COMPONENT * componentIndex),
+             buffers.begin() + (NUM_BUFFERS_PER_COMPONENT * (componentIndex + 1)) };
+  }
+
+  VISKORES_CONT static ComponentArrayType GetComponentArray(
+    const std::vector<viskores::cont::internal::Buffer>& buffers,
+    viskores::IdComponent componentIndex)
+  {
+    return ComponentArrayType(GetComponentBuffers(buffers, componentIndex));
+  }
+
+  VISKORES_CONT static void SetComponentArray(
+    std::vector<viskores::cont::internal::Buffer>& buffers,
+    viskores::IdComponent componentIndex,
+    const ComponentArrayType& componentArray)
+  {
+    VISKORES_ASSERT(buffers.size() ==
+                    static_cast<std::size_t>(NUM_COMPONENTS * NUM_BUFFERS_PER_COMPONENT));
+    VISKORES_ASSERT(componentIndex >= 0);
+    VISKORES_ASSERT(componentIndex < NUM_COMPONENTS);
+
+    const std::vector<viskores::cont::internal::Buffer>& componentBuffers =
+      componentArray.GetBuffers();
+    VISKORES_ASSERT(componentBuffers.size() == static_cast<std::size_t>(NUM_BUFFERS_PER_COMPONENT));
+
+    for (viskores::IdComponent sourceIndex = 0; sourceIndex < NUM_BUFFERS_PER_COMPONENT;
+         ++sourceIndex)
+    {
+      buffers[static_cast<std::size_t>(componentIndex * NUM_BUFFERS_PER_COMPONENT + sourceIndex)] =
+        componentBuffers[static_cast<std::size_t>(sourceIndex)];
+    }
+  }
+
+  VISKORES_CONT static viskores::IdComponent GetNumberOfComponentsFlat(
+    const std::vector<viskores::cont::internal::Buffer>&)
+  {
+    return NUM_COMPONENTS;
+  }
+
+  VISKORES_CONT static void ResizeBuffers(
+    viskores::Id numValues,
+    const std::vector<viskores::cont::internal::Buffer>& buffers,
+    viskores::CopyFlag preserve,
+    viskores::cont::Token& token)
+  {
+    for (viskores::IdComponent componentIndex = 0; componentIndex < NUM_COMPONENTS;
+         ++componentIndex)
+    {
+      ComponentStorage::ResizeBuffers(
+        numValues, GetComponentBuffers(buffers, componentIndex), preserve, token);
+    }
+  }
+
+  VISKORES_CONT static viskores::Id GetNumberOfValues(
+    const std::vector<viskores::cont::internal::Buffer>& buffers)
+  {
+    // Assume all buffers are the same size.
+    return ComponentStorage::GetNumberOfValues(GetComponentBuffers(buffers, 0));
+  }
+
+  VISKORES_CONT static void Fill(const std::vector<viskores::cont::internal::Buffer>& buffers,
+                                 const ValueType& fillValue,
+                                 viskores::Id startIndex,
+                                 viskores::Id endIndex,
+                                 viskores::cont::Token& token)
+  {
+    for (viskores::IdComponent componentIndex = 0; componentIndex < NUM_COMPONENTS;
+         ++componentIndex)
+    {
+      ComponentStorage::Fill(GetComponentBuffers(buffers, componentIndex),
+                             VTraits::GetComponent(fillValue, componentIndex),
+                             startIndex,
+                             endIndex,
+                             token);
+    }
+  }
+
+  VISKORES_CONT static ReadPortalType CreateReadPortal(
+    const std::vector<viskores::cont::internal::Buffer>& buffers,
+    viskores::cont::DeviceAdapterId device,
+    viskores::cont::Token& token)
+  {
+    viskores::Id numValues = GetNumberOfValues(buffers);
+    ReadPortalType portal(numValues);
+    for (viskores::IdComponent componentIndex = 0; componentIndex < NUM_COMPONENTS;
+         ++componentIndex)
+    {
+      auto componentPortal = ComponentStorage::CreateReadPortal(
+        GetComponentBuffers(buffers, componentIndex), device, token);
+      VISKORES_ASSERT(componentPortal.GetNumberOfValues() == numValues);
+      portal.SetPortal(componentIndex, componentPortal);
+    }
+    return portal;
+  }
+
+  VISKORES_CONT static WritePortalType CreateWritePortal(
+    const std::vector<viskores::cont::internal::Buffer>& buffers,
+    viskores::cont::DeviceAdapterId device,
+    viskores::cont::Token& token)
+  {
+    viskores::Id numValues = GetNumberOfValues(buffers);
+    WritePortalType portal(numValues);
+    for (viskores::IdComponent componentIndex = 0; componentIndex < NUM_COMPONENTS;
+         ++componentIndex)
+    {
+      auto componentPortal = ComponentStorage::CreateWritePortal(
+        GetComponentBuffers(buffers, componentIndex), device, token);
+      VISKORES_ASSERT(componentPortal.GetNumberOfValues() == numValues);
+      portal.SetPortal(componentIndex, componentPortal);
+    }
+    return portal;
+  }
+};
+
+} // namespace internal
+
+/// @brief An `ArrayHandle` that stores each component in a separate physical array with striding.
+///
+/// `ArrayHandleSOAStride` behaves much like an `ArrayHandleSOA` in that each component is
+/// (potentially) stored in a separate array. However, whereas `ArrayHandleSOA` specifically
+/// stores each component in a basic array, `ArrayHandleSOAStride` represents each component
+/// as an `ArrayHandleStride`. This gives flexibility in the representation because the values
+/// do not have to be tightly packed. The spacing between values can be determined at runtime.
+/// This allows `ArrayHandleSOAStride` to represent most memory array layouts. For example,
+/// although it behaves like an SOA array, it can point to an AOS array by having each component
+/// point to the same physical array with different offsets.
+///
+/// `ArrayHandleSOAStride` is also similar to `ArrayHandleRecombineVec`. It can be used to
+/// represent unknown arrays by extracting each component. The difference is that
+/// `ArrayHandleSOAStride` requires a fix sized value where the number of components is known
+/// at compile time. In contrast, `ArrayHandleRecombineVec` can work with any size vector
+/// defined at runtime. However, `ArrayHandleRecombineVec` requires a dynamically sized `Vec`-like
+/// object that has limited use. When `ArrayHandleSOAStride` can be used, it uses the same value
+/// type as the array it is mimicking.
+template <typename T>
+class ArrayHandleSOAStride : public ArrayHandle<T, viskores::cont::StorageTagSOAStride>
+{
+  using ComponentType = typename viskores::VecTraits<T>::ComponentType;
+  static constexpr viskores::IdComponent NUM_COMPONENTS = viskores::VecTraits<T>::NUM_COMPONENTS;
+
+public:
+  /// @brief The type of each component array.
+  using ComponentArrayType =
+    viskores::cont::ArrayHandle<ComponentType, viskores::cont::StorageTagStride>;
+
+  VISKORES_ARRAY_HANDLE_SUBCLASS(ArrayHandleSOAStride,
+                                 (ArrayHandleSOAStride<T>),
+                                 (ArrayHandle<T, viskores::cont::StorageTagSOAStride>));
+
+  /// @brief Construct an `ArrayHandleSOAStride` from a collection of component arrays.
+  ///
+  /// @code{.cpp}
+  /// viskores::cont::ArrayHandleStride<T> components1;
+  /// viskores::cont::ArrayHandleStride<T> components2;
+  /// viskores::cont::ArrayHandleStride<T> components3;
+  /// // Fill arrays...
+  ///
+  /// std::array<viskores::cont::ArrayHandleStride<T>, 3>
+  ///   allComponents{ components1, components2, components3 };
+  /// viskores::cont::ArrayHandleSOAStride<viskores::Vec<T, 3>> vecarray(allComponents);
+  /// @endcode
+  ArrayHandleSOAStride(const std::array<ComponentArrayType, NUM_COMPONENTS>& componentArrays)
+  {
+    for (viskores::IdComponent componentIndex = 0; componentIndex < NUM_COMPONENTS;
+         ++componentIndex)
+    {
+      this->SetArray(componentIndex, componentArrays[componentIndex]);
+    }
+  }
+
+  /// @brief Construct an `ArrayHandleSOAStride` from a collection of component arrays.
+  ///
+  /// @code{.cpp}
+  /// viskores::cont::ArrayHandleStride<T> components1;
+  /// viskores::cont::ArrayHandleStride<T> components2;
+  /// viskores::cont::ArrayHandleStride<T> components3;
+  /// // Fill arrays...
+  ///
+  /// std::vector<viskores::cont::ArrayHandleStride<T>>
+  ///   allComponents{ components1, components2, components3 };
+  /// viskores::cont::ArrayHandleSOAStride<viskores::Vec<T, 3>> vecarray(allComponents);
+  /// @endcode
+  ArrayHandleSOAStride(const std::vector<ComponentArrayType>& componentArrays)
+  {
+    VISKORES_ASSERT(componentArrays.size() == NUM_COMPONENTS);
+    for (viskores::IdComponent componentIndex = 0; componentIndex < NUM_COMPONENTS;
+         ++componentIndex)
+    {
+      this->SetArray(componentIndex, componentArrays[componentIndex]);
+    }
+  }
+
+  /// @brief Construct an `ArrayHandleSOAStride` from a collection of component arrays.
+  ///
+  /// @code{.cpp}
+  /// viskores::cont::ArrayHandle<T> components1;
+  /// viskores::cont::ArrayHandle<T> components2;
+  /// viskores::cont::ArrayHandle<T> components3;
+  /// // Fill arrays...
+  ///
+  /// viskores::cont::ArrayHandleSOAStride<viskores::Vec<T, 3> vecarray(
+  ///   { components1, components2, components3 });
+  /// @endcode
+  ArrayHandleSOAStride(std::initializer_list<ComponentArrayType>&& componentArrays)
+  {
+    VISKORES_ASSERT(componentArrays.size() == NUM_COMPONENTS);
+    viskores::IdComponent componentIndex = 0;
+    for (auto&& array : componentArrays)
+    {
+      this->SetArray(componentIndex, array);
+      ++componentIndex;
+    }
+  }
+
+  /// @brief Construct an `ArrayHandleSOAStride` from a collection of component arrays.
+  ///
+  /// The data is copied from the `std::vector`s to the array handle.
+  ///
+  /// @code{.cpp}
+  /// std::vector<T> components1;
+  /// std::vector<T> components2;
+  /// std::vector<T> components3;
+  /// // Fill arrays...
+  ///
+  /// viskores::cont::ArrayHandleSOAStride<viskores::Vec<T, 3>> vecarray(
+  ///   { components1, components2, components3 });
+  /// @endcode
+  ArrayHandleSOAStride(std::initializer_list<std::vector<ComponentType>>&& componentVectors)
+  {
+    VISKORES_ASSERT(componentVectors.size() == NUM_COMPONENTS);
+    viskores::IdComponent componentIndex = 0;
+    for (auto&& vector : componentVectors)
+    {
+      // Note, std::vectors that come from std::initializer_list must be copied because the scope
+      // of the objects in the initializer list disappears.
+      this->SetArray(componentIndex,
+                     viskores::cont::make_ArrayHandle(vector, viskores::CopyFlag::On));
+      ++componentIndex;
+    }
+  }
+
+  /// @brief Get a basic array representing the component for the given index.
+  VISKORES_CONT ComponentArrayType GetArray(viskores::IdComponent index) const
+  {
+    return StorageType::GetComponentArray(this->GetBuffers(), index);
+  }
+
+  /// @brief Replace a component array.
+  VISKORES_CONT void SetArray(viskores::IdComponent index, const ComponentArrayType& array)
+  {
+    StorageType::SetComponentArray(this->GetBuffers(), index, array);
+  }
+};
+
+/// @brief Create a `viskores::cont::ArrayHandleSOAStride` with an initializer list of array handles.
+///
+/// @code{.cpp}
+/// viskores::cont::ArrayHandle<T> components1;
+/// viskores::cont::ArrayHandle<T> components2;
+/// viskores::cont::ArrayHandle<T> components3;
+/// // Fill arrays...
+///
+/// auto vecarray = viskores::cont::make_ArrayHandleSOAStride<viskores::Vec<T, 3>>(
+///   { components1, components2, components3 });
+/// @endcode
+template <typename ValueType>
+VISKORES_CONT ArrayHandleSOAStride<ValueType> make_ArrayHandleSOAStride(
+  std::initializer_list<
+    viskores::cont::ArrayHandle<typename viskores::VecTraits<ValueType>::ComponentType,
+                                viskores::cont::StorageTagBasic>>&& componentArrays)
+{
+  return ArrayHandleSOAStride<ValueType>(std::move(componentArrays));
+}
+
+/// @brief Create a `viskores::cont::ArrayHandleSOAStride` with a number of array handles.
+///
+/// This only works if all the templated arguments are of type
+/// `viskores::cont::ArrayHandle<ComponentType>`.
+///
+/// @code{.cpp}
+/// viskores::cont::ArrayHandle<T> components1;
+/// viskores::cont::ArrayHandle<T> components2;
+/// viskores::cont::ArrayHandle<T> components3;
+/// // Fill arrays...
+///
+/// auto vecarray =
+///   viskores::cont::make_ArrayHandleSOAStride(components1, components2, components3);
+/// @endcode
+template <typename ComponentType, typename... RemainingArrays>
+VISKORES_CONT ArrayHandleSOAStride<
+  viskores::Vec<ComponentType, internal::VecSizeFromRemaining<RemainingArrays...>::value>>
+make_ArrayHandleSOAStride(
+  const viskores::cont::ArrayHandle<ComponentType, viskores::cont::StorageTagBasic>&
+    componentArray0,
+  const RemainingArrays&... componentArrays)
+{
+  return { componentArray0, componentArrays... };
+}
+
+/// @brief Create a `viskores::cont::ArrayHandleSOAStride` with a `std::vector` of component arrays.
+///
+/// The data is copied from the `std::vector`s to the array handle.
+///
+/// @code{.cpp}
+/// std::vector<T> components1;
+/// std::vector<T> components2;
+/// std::vector<T> components3;
+/// // Fill arrays...
+///
+/// auto vecarray = viskores::cont::make_ArrayHandleSOAStride<viskores::Vec<T, 3>>(
+///   { components1, components2, components3 });
+/// @endcode
+template <typename ValueType>
+VISKORES_CONT ArrayHandleSOAStride<ValueType> make_ArrayHandleSOAStride(
+  std::initializer_list<std::vector<typename viskores::VecTraits<ValueType>::ComponentType>>&&
+    componentVectors)
+{
+  return ArrayHandleSOAStride<ValueType>(std::move(componentVectors));
+}
+
+namespace internal
+{
+
+/// @cond
+
+template <>
+struct ArrayExtractComponentImpl<viskores::cont::StorageTagSOAStride>
+{
+  template <typename T>
+  auto operator()(const viskores::cont::ArrayHandle<T, viskores::cont::StorageTagSOAStride>& src,
+                  viskores::IdComponent componentIndex,
+                  viskores::CopyFlag allowCopy) const
+    -> decltype(ArrayExtractComponentImpl<viskores::cont::StorageTagStride>{}(
+      viskores::cont::ArrayHandleBasic<T>{},
+      componentIndex,
+      allowCopy))
+  {
+    using FirstLevelComponentType = typename viskores::VecTraits<T>::ComponentType;
+    viskores::cont::ArrayHandleSOAStride<T> array(src);
+    constexpr viskores::IdComponent NUM_SUB_COMPONENTS =
+      viskores::VecFlat<FirstLevelComponentType>::NUM_COMPONENTS;
+    return ArrayExtractComponentImpl<viskores::cont::StorageTagStride>{}(
+      array.GetArray(componentIndex / NUM_SUB_COMPONENTS),
+      componentIndex % NUM_SUB_COMPONENTS,
+      allowCopy);
+  }
+};
+
+/// @endcond
+
+} // namespace internal
+
+}
+} // namespace viskores::cont
+
+//=============================================================================
+// Specializations of serialization related classes
+/// @cond SERIALIZATION
+
+namespace viskores
+{
+namespace cont
+{
+
+template <typename ValueType>
+struct SerializableTypeString<viskores::cont::ArrayHandleSOAStride<ValueType>>
+{
+  static VISKORES_CONT const std::string& Get()
+  {
+    static std::string name = "AH_SOAStride<" + SerializableTypeString<ValueType>::Get() + ">";
+    return name;
+  }
+};
+
+template <typename ValueType>
+struct SerializableTypeString<
+  viskores::cont::ArrayHandle<ValueType, viskores::cont::StorageTagSOAStride>>
+  : SerializableTypeString<viskores::cont::ArrayHandleSOAStride<ValueType>>
+{
+};
+}
+} // namespace viskores::cont
+
+namespace mangled_diy_namespace
+{
+
+template <typename ValueType>
+struct Serialization<viskores::cont::ArrayHandleSOAStride<ValueType>>
+{
+  using BaseType = viskores::cont::ArrayHandle<ValueType, viskores::cont::StorageTagSOAStride>;
+  static constexpr viskores::IdComponent NUM_COMPONENTS =
+    viskores::VecTraits<ValueType>::NUM_COMPONENTS;
+  using ComponentType = typename viskores::VecTraits<ValueType>::ComponentType;
+
+  using SubSerialization = Serialization<viskores::cont::ArrayHandleStride<ComponentType>>;
+
+  static VISKORES_CONT void save(BinaryBuffer& bb, const BaseType& obj_)
+  {
+    viskores::cont::ArrayHandleSOAStride<ValueType> obj = obj_;
+    for (viskores::IdComponent componentIndex = 0; componentIndex < NUM_COMPONENTS;
+         ++componentIndex)
+    {
+      SubSerialization::save(bb, obj.GetArray(componentIndex));
+    }
+  }
+
+  static VISKORES_CONT void load(BinaryBuffer& bb, BaseType& obj_)
+  {
+    viskores::cont::ArrayHandleSOAStride<ValueType> obj;
+    std::vector<viskores::cont::internal::Buffer> buffers(NUM_COMPONENTS);
+    for (std::size_t componentIndex = 0; componentIndex < NUM_COMPONENTS; ++componentIndex)
+    {
+      viskores::cont::ArrayHandleStride<ComponentType> subobj;
+      SubSerialization::load(bb, subobj);
+      obj.SetArray(index, subobj);
+    }
+    obj_ = obj;
+  }
+};
+
+template <typename ValueType>
+struct Serialization<viskores::cont::ArrayHandle<ValueType, viskores::cont::StorageTagSOAStride>>
+  : Serialization<viskores::cont::ArrayHandleSOAStride<ValueType>>
+{
+};
+
+} // namespace mangled_diy_namespace
+// @endcond SERIALIZATION
+
+//=============================================================================
+// Precompiled instances
+
+#ifndef viskores_cont_ArrayHandleSOAStride_cxx
+
+/// @cond
+
+namespace viskores
+{
+namespace cont
+{
+
+#define VISKORES_ARRAYHANDLE_SOA_STRIDE_EXPORT(Type)          \
+  extern template class VISKORES_CONT_TEMPLATE_EXPORT         \
+    ArrayHandle<viskores::Vec<Type, 2>, StorageTagSOAStride>; \
+  extern template class VISKORES_CONT_TEMPLATE_EXPORT         \
+    ArrayHandle<viskores::Vec<Type, 3>, StorageTagSOAStride>; \
+  extern template class VISKORES_CONT_TEMPLATE_EXPORT         \
+    ArrayHandle<viskores::Vec<Type, 4>, StorageTagSOAStride>;
+
+VISKORES_ARRAYHANDLE_SOA_STRIDE_EXPORT(char)
+VISKORES_ARRAYHANDLE_SOA_STRIDE_EXPORT(viskores::Int8)
+VISKORES_ARRAYHANDLE_SOA_STRIDE_EXPORT(viskores::UInt8)
+VISKORES_ARRAYHANDLE_SOA_STRIDE_EXPORT(viskores::Int16)
+VISKORES_ARRAYHANDLE_SOA_STRIDE_EXPORT(viskores::UInt16)
+VISKORES_ARRAYHANDLE_SOA_STRIDE_EXPORT(viskores::Int32)
+VISKORES_ARRAYHANDLE_SOA_STRIDE_EXPORT(viskores::UInt32)
+VISKORES_ARRAYHANDLE_SOA_STRIDE_EXPORT(viskores::Int64)
+VISKORES_ARRAYHANDLE_SOA_STRIDE_EXPORT(viskores::UInt64)
+VISKORES_ARRAYHANDLE_SOA_STRIDE_EXPORT(viskores::Float32)
+VISKORES_ARRAYHANDLE_SOA_STRIDE_EXPORT(viskores::Float64)
+
+#undef VISKORES_ARRAYHANDLE_SOA_STRIDE_EXPORT
+}
+} // namespace viskores::cont
+
+/// @endcond
+
+#endif // !viskores_cont_ArrayHandleSOAStride_cxx
+
+#endif //viskores_cont_ArrayHandleSOAStride_h

--- a/viskores/cont/CMakeLists.txt
+++ b/viskores/cont/CMakeLists.txt
@@ -48,6 +48,7 @@ set(headers
   ArrayHandleRandomUniformReal.h
   ArrayHandleRuntimeVec.h
   ArrayHandleSOA.h
+  ArrayHandleSOAStride.h
   ArrayHandleStride.h
   ArrayHandleSwizzle.h
   ArrayHandleTransform.h
@@ -146,6 +147,7 @@ set(sources
   ArrayHandle.cxx
   ArrayHandleBasic.cxx
   ArrayHandleSOA.cxx
+  ArrayHandleSOAStride.cxx
   ArrayHandleStride.cxx
   AssignerPartitionedDataSet.cxx
   BitField.cxx

--- a/viskores/cont/testing/CMakeLists.txt
+++ b/viskores/cont/testing/CMakeLists.txt
@@ -96,6 +96,7 @@ set(unit_tests_device
   UnitTestArrayHandleRecombineVec.cxx
   UnitTestArrayHandleRuntimeVec.cxx
   UnitTestArrayHandleSOA.cxx
+  UnitTestArrayHandleSOAStride.cxx
   UnitTestArrayHandleSwizzle.cxx
   UnitTestArrayHandleTransform.cxx
   UnitTestArrayHandleView.cxx

--- a/viskores/cont/testing/UnitTestArrayHandleSOAStride.cxx
+++ b/viskores/cont/testing/UnitTestArrayHandleSOAStride.cxx
@@ -1,0 +1,155 @@
+//============================================================================
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//============================================================================
+
+//============================================================================
+//  Copyright (c) Kitware, Inc.
+//  All rights reserved.
+//  See LICENSE.txt for details.
+//
+//  This software is distributed WITHOUT ANY WARRANTY; without even
+//  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+//  PURPOSE.  See the above copyright notice for more information.
+//============================================================================
+
+#include <viskores/cont/ArrayHandleSOAStride.h>
+
+#include <viskores/cont/ArrayCopyDevice.h>
+#include <viskores/cont/ArrayHandleGroupVec.h>
+#include <viskores/cont/Invoker.h>
+
+#include <viskores/worklet/WorkletMapField.h>
+
+#include <viskores/cont/testing/Testing.h>
+
+namespace
+{
+
+constexpr viskores::Id ARRAY_SIZE = 10;
+
+using ScalarTypesToTest = viskores::List<viskores::UInt8, viskores::FloatDefault>;
+using VectorTypesToTest = viskores::List<viskores::Vec2i_8, viskores::Vec3f_32>;
+
+struct PassThrough : public viskores::worklet::WorkletMapField
+{
+  using ControlSignature = void(FieldIn, FieldOut);
+  using ExecutionSignature = void(_1, _2);
+
+  template <typename InValue, typename OutValue>
+  VISKORES_EXEC void operator()(const InValue& inValue, OutValue& outValue) const
+  {
+    outValue = inValue;
+  }
+};
+
+struct TestSOASAsInput
+{
+  template <typename ValueType>
+  VISKORES_CONT void operator()(const ValueType viskoresNotUsed(v)) const
+  {
+    using VTraits = viskores::VecTraits<ValueType>;
+    using ComponentType = typename VTraits::ComponentType;
+    constexpr viskores::IdComponent NUM_COMPONENTS = VTraits::NUM_COMPONENTS;
+
+    viskores::cont::ArrayHandleSOAStride<ValueType> soaStrideArray;
+    {
+      viskores::cont::ArrayHandle<ComponentType> dataArray;
+      auto groupVec = viskores::cont::make_ArrayHandleGroupVec<NUM_COMPONENTS>(dataArray);
+      groupVec.Allocate(ARRAY_SIZE);
+      SetPortal(groupVec.WritePortal());
+      for (viskores::IdComponent componentIndex = 0; componentIndex < NUM_COMPONENTS;
+           ++componentIndex)
+      {
+        viskores::cont::ArrayHandleStride<ComponentType> componentArray =
+          viskores::cont::make_ArrayHandleStride(
+            dataArray, ARRAY_SIZE, NUM_COMPONENTS, componentIndex);
+        soaStrideArray.SetArray(componentIndex, componentArray);
+      }
+    }
+
+    VISKORES_TEST_ASSERT(soaStrideArray.GetNumberOfComponentsFlat() ==
+                         viskores::VecFlat<ValueType>::NUM_COMPONENTS);
+    VISKORES_TEST_ASSERT(soaStrideArray.GetNumberOfValues() == ARRAY_SIZE);
+    VISKORES_TEST_ASSERT(soaStrideArray.ReadPortal().GetNumberOfValues() == ARRAY_SIZE);
+    CheckPortal(soaStrideArray.ReadPortal());
+
+    viskores::cont::ArrayHandle<ValueType> basicArray;
+    viskores::cont::ArrayCopyDevice(soaStrideArray, basicArray);
+    VISKORES_TEST_ASSERT(basicArray.GetNumberOfValues() == ARRAY_SIZE);
+    CheckPortal(basicArray.ReadPortal());
+  }
+};
+
+struct TestSOASAsOutput
+{
+  template <typename ValueType>
+  VISKORES_CONT void operator()(const ValueType viskoresNotUsed(v)) const
+  {
+    using VTraits = viskores::VecTraits<ValueType>;
+    using ComponentType = typename VTraits::ComponentType;
+    constexpr viskores::IdComponent NUM_COMPONENTS = VTraits::NUM_COMPONENTS;
+
+    viskores::cont::ArrayHandle<ValueType> basicArray;
+    basicArray.Allocate(ARRAY_SIZE);
+    SetPortal(basicArray.WritePortal());
+
+    viskores::cont::ArrayHandleSOAStride<ValueType> soaStrideArray;
+    viskores::cont::ArrayHandle<ComponentType> dataArray;
+    {
+      auto groupVec = viskores::cont::make_ArrayHandleGroupVec<NUM_COMPONENTS>(dataArray);
+      for (viskores::IdComponent componentIndex = 0; componentIndex < NUM_COMPONENTS;
+           ++componentIndex)
+      {
+        viskores::cont::ArrayHandleStride<ComponentType> componentArray =
+          viskores::cont::make_ArrayHandleStride(dataArray, 0, NUM_COMPONENTS, componentIndex);
+        soaStrideArray.SetArray(componentIndex, componentArray);
+      }
+    }
+
+    soaStrideArray.Allocate(ARRAY_SIZE);
+    auto portal = soaStrideArray.WritePortal();
+    portal.Set(0, ValueType{});
+    viskores::cont::Invoker{}(PassThrough{}, basicArray, soaStrideArray);
+
+    VISKORES_TEST_ASSERT(soaStrideArray.GetNumberOfValues() == ARRAY_SIZE);
+    for (viskores::IdComponent componentIndex = 0; componentIndex < NUM_COMPONENTS;
+         ++componentIndex)
+    {
+      viskores::cont::ArrayHandleStride<ComponentType> componentArray =
+        soaStrideArray.GetArray(componentIndex);
+      auto componentPortal = componentArray.ReadPortal();
+      for (viskores::Id valueIndex = 0; valueIndex < ARRAY_SIZE; ++valueIndex)
+      {
+        ComponentType expected =
+          VTraits::GetComponent(TestValue(valueIndex, ValueType{}), componentIndex);
+        ComponentType got = componentPortal.Get(valueIndex);
+        VISKORES_TEST_ASSERT(test_equal(expected, got));
+      }
+    }
+    CheckPortal(dataArray.ReadPortal());
+  }
+};
+
+static void Run()
+{
+  std::cout << "-------------------------------------------" << std::endl;
+  std::cout << "Testing ArrayHandleSOAStride as Input" << std::endl;
+  viskores::testing::Testing::TryTypes(TestSOASAsInput(), ScalarTypesToTest());
+  viskores::testing::Testing::TryTypes(TestSOASAsInput(), VectorTypesToTest());
+
+  std::cout << "-------------------------------------------" << std::endl;
+  std::cout << "Testing ArrayHandleSOAStride as Output" << std::endl;
+  viskores::testing::Testing::TryTypes(TestSOASAsOutput(), ScalarTypesToTest());
+  viskores::testing::Testing::TryTypes(TestSOASAsOutput(), VectorTypesToTest());
+}
+
+} // anonymous namespace
+
+int UnitTestArrayHandleSOAStride(int argc, char* argv[])
+{
+  return viskores::cont::testing::Testing::Run(Run, argc, argv);
+}


### PR DESCRIPTION
Added a new array type named `ArrayHandleSOAStride`. This new array type holds each of its components in a separate array. Unlike `ArrayHandleSOA`, `ArrayHandleSOAStride` represents each component as an `ArrayHandleStride` rather than a basic array. This allows `ArrayHandleSOAStride` to represent most arrays with values of a fixed vector length.

`ArrayHandleSOAStride` can be used in similar situations as `ArrayHandleRecombineVec`. The difference is that `ArrayHandleSOAStride` requires the Vec length to be determined at compile time. This has both good and bad consequences. The bad part is that if the number of components can vary, `ArrayHandleSOAStride` cannot represent the data well. However, if the number of components is fixed, then each value in the array is represented with a simple `Vec`, which means it can be used as a drop-in replacement for basic arrays.

`ArrayHandleSOAStride` is created as a backup array when trying to do a cast and call when the size and type of values can be determined.