### PR TITLE
Extract to SOA Stride

### DIFF
--- a/docs/changelog/extract-to-soastride.md
+++ b/docs/changelog/extract-to-soastride.md
@@ -1,0 +1,19 @@
+## Extract Arrays to ArrayHandleSOAStride
+
+`UnknownArrayHandle` has a new method named `ExtractArrayWithValueType` that
+extracts an array with a given `ValueType` regardless of the storage. The method
+extracts the data to an `ArrayHandleSOAStride` by extracting each component and
+collecting them in that array type. This provides similar behavior to
+`ExtractArrayFromComponents` except that it extracts to a `Vec` (or scalar) of
+known type and size. This means that the array can later be used as a normal
+array without the restrictions that an `ArrayHandleRecombineVec` that comes from
+`ExtractArrayFromComponents` has.
+
+Additionally, you can pull most arrays from an `UnknownArrayHandle` using
+`AsArrayHandle` with an `ArrayHandleSOAStride` as long as the value types match.
+A consequence of this is that if `StorageTagSOAStride` is added to the storage
+types to check when doing a `CastAndCall`, then the cast and call will
+automatically put the data into an array of that type. This makes for a
+convenient backup for unexpected storage or a way to not worry about storage. As
+such, `StorageTagSOAStride` has been added to the list default storage types to
+check.

--- a/docs/users-guide/examples/GuideExampleUnknownArrayHandle.cxx
+++ b/docs/users-guide/examples/GuideExampleUnknownArrayHandle.cxx
@@ -474,6 +474,49 @@ void ExtractUnknownComponent()
   viskores::cont::ArrayHandle<viskores::Vec3f> outArray;
 
   ////
+  //// BEGIN-EXAMPLE UnknownArrayExtractArrayWithValueType
+  ////
+  invoke(
+    MyWorklet{}, unknownArray.ExtractArrayWithValueType<viskores::Vec3f>(), outArray);
+  ////
+  //// END-EXAMPLE UnknownArrayExtractArrayWithValueType
+  ////
+  VISKORES_TEST_ASSERT(test_equal_ArrayHandles(outArray, concreteArray));
+
+  outArray.ReleaseResources();
+  {
+    ////
+    //// BEGIN-EXAMPLE UnknownArrayAsSOAStride
+    ////
+    viskores::cont::ArrayHandleSOAStride<viskores::Vec3f> extractedArray;
+    unknownArray.AsArrayHandle(extractedArray);
+    invoke(MyWorklet{}, extractedArray, outArray);
+    ////
+    //// END-EXAMPLE UnknownArrayAsSOAStride
+    ////
+  }
+  VISKORES_TEST_ASSERT(test_equal_ArrayHandles(outArray, concreteArray));
+
+  outArray.ReleaseResources();
+  {
+    ////
+    //// BEGIN-EXAMPLE UnknownArrayCastAndCallExtract
+    ////
+    auto resolveType = [&](auto extractedArray)
+    { invoke(MyWorklet{}, extractedArray, outArray); };
+
+    unknownArray
+      .CastAndCallForTypes<viskores::TypeListFieldVec3,
+                           viskores::List<viskores::cont::StorageTagSOAStride>>(
+        resolveType);
+    ////
+    //// END-EXAMPLE UnknownArrayCastAndCallExtract
+    ////
+  }
+  VISKORES_TEST_ASSERT(test_equal_ArrayHandles(outArray, concreteArray));
+
+  outArray.ReleaseResources();
+  ////
   //// BEGIN-EXAMPLE UnknownArrayExtractArrayFromComponents
   ////
   invoke(MyWorklet{},

--- a/docs/users-guide/memory-layout.rst
+++ b/docs/users-guide/memory-layout.rst
@@ -167,8 +167,18 @@ This is convenient for operations that want to operate on arrays with an unknown
 Recombined Vec Arrays of Strided Components
 ---------------------------------------------
 
-|Viskores| contains a special array, :class:`viskores::cont::ArrayHandleRecombineVec`, to combine component arrays represented in :class:`viskores::cont::ArrayHandleStride` together to form `Vec` values.
-:class:`viskores::cont::ArrayHandleRecombineVec` is similar to :class:`viskores::cont::ArrayHandleSOA` (see :secref:`memory-layout:Structure of Arrays`) except that (1) it holds stride arrays for its components instead of basic arrays and that (2) the number of components can be specified at runtime.
-:class:`viskores::cont::ArrayHandleRecombineVec` is mainly provided for the implementation of extracting arrays out of a :class:`viskores::cont::UnknownArrayHandle` (see :secref:`unknown-array-handle:Extracting All Components`).
+|Viskores| contains a special array, :class:`viskores::cont::ArrayHandleSOAStride`, to combine component arrays represented in :class:`viskores::cont::ArrayHandleStride` together to form `Vec` values.
+:class:`viskores::cont::ArrayHandleSOAStride` is similar to :class:`viskores::cont::ArrayHandleSOA` (see :secref:`memory-layout:Structure of Arrays`) except that it holds stride arrays for its components instead of basic arrays.
+:class:`viskores::cont::ArrayHandleSOAStride` is mainly provided for the implementation of extracting arrays out of a :class:`viskores::cont::UnknownArrayHandle` (see :secref:`unknown-array-handle:Extracting a Known Value Type from Unknown Storage`).
+
+.. doxygenclass:: viskores::cont::ArrayHandleSOAStride
+   :members:
+
+|Viskores| also contains a similar special array names :class:`viskores::cont::ArrayHandleRecombineVec`.
+This array is similar to :class:`viskores::cont::ArrayHandleSOAStride` except that
+the number of components can be specified at runtime.
+This is useful when you know little or nothing about the value type and storage type but comes with limitations in its use.
+This class is likewise provided for extracting arrays out of a :class:`viskores::cont::UnknownArrayHandle` (see :secref:`unknown-array-handle:Extracting An Unknown Amount of Components`).
 
 .. doxygenclass:: viskores::cont::ArrayHandleRecombineVec
+   :members:

--- a/viskores/cont/ArrayHandleStride.h
+++ b/viskores/cont/ArrayHandleStride.h
@@ -559,8 +559,14 @@ public:
     viskoresdiy::load(bb, divisor);
     viskoresdiy::load(bb, buffer);
 
-    obj = viskores::cont::ArrayHandleStride<T>(buffer, stride, offset, modulo, divisor);
+    obj = viskores::cont::ArrayHandleStride<T>(buffer, numValues, stride, offset, modulo, divisor);
   }
+};
+
+template <typename ValueType>
+struct Serialization<viskores::cont::ArrayHandle<ValueType, viskores::cont::StorageTagStride>>
+  : Serialization<viskores::cont::ArrayHandleStride<ValueType>>
+{
 };
 
 } // namespace diy

--- a/viskores/cont/StorageList.h
+++ b/viskores/cont/StorageList.h
@@ -22,7 +22,7 @@
 
 #include <viskores/cont/ArrayHandleBasic.h>
 #include <viskores/cont/ArrayHandleCartesianProduct.h>
-#include <viskores/cont/ArrayHandleSOA.h>
+#include <viskores/cont/ArrayHandleSOAStride.h>
 #include <viskores/cont/ArrayHandleUniformPointCoordinates.h>
 
 namespace viskores
@@ -34,11 +34,11 @@ using StorageListBasic = viskores::List<viskores::cont::StorageTagBasic>;
 
 using StorageListCommon =
   viskores::List<viskores::cont::StorageTagBasic,
-                 viskores::cont::StorageTagSOA,
                  viskores::cont::StorageTagUniformPoints,
                  viskores::cont::StorageTagCartesianProduct<viskores::cont::StorageTagBasic,
                                                             viskores::cont::StorageTagBasic,
-                                                            viskores::cont::StorageTagBasic>>;
+                                                            viskores::cont::StorageTagBasic>,
+                 viskores::cont::StorageTagSOAStride>;
 
 }
 } // namespace viskores::cont

--- a/viskores/cont/UnknownArrayHandle.cxx
+++ b/viskores/cont/UnknownArrayHandle.cxx
@@ -62,7 +62,6 @@ using RemoveBasicStorage = viskores::ListRemoveIf<List, IsBasicStorage>;
 using UnknownSerializationTypes =
   viskores::ListAppend<viskores::TypeListBaseC, AllVec<2>, AllVec<3>, AllVec<4>>;
 using UnknownSerializationSpecializedStorage = viskores::ListAppend<
-  RemoveBasicStorage<VISKORES_DEFAULT_STORAGE_LIST>,
   viskores::List<viskores::cont::StorageTagCartesianProduct<viskores::cont::StorageTagBasic,
                                                             viskores::cont::StorageTagBasic,
                                                             viskores::cont::StorageTagBasic>,
@@ -76,7 +75,8 @@ using UnknownSerializationSpecializedStorage = viskores::ListAppend<
                                                        viskores::cont::StorageTagBasic>,
                  viskores::cont::StorageTagReverse<viskores::cont::StorageTagBasic>,
                  viskores::cont::StorageTagSOA,
-                 viskores::cont::StorageTagUniformPoints>>;
+                 viskores::cont::StorageTagUniformPoints>,
+  RemoveBasicStorage<VISKORES_DEFAULT_STORAGE_LIST>>;
 
 } // anonymous namespace
 

--- a/viskores/cont/UnknownArrayHandle.h
+++ b/viskores/cont/UnknownArrayHandle.h
@@ -26,6 +26,7 @@
 #include <viskores/cont/ArrayHandleMultiplexer.h>
 #include <viskores/cont/ArrayHandleRecombineVec.h>
 #include <viskores/cont/ArrayHandleRuntimeVec.h>
+#include <viskores/cont/ArrayHandleSOAStride.h>
 #include <viskores/cont/ArrayHandleStride.h>
 #include <viskores/cont/StorageList.h>
 
@@ -160,6 +161,13 @@ std::vector<viskores::cont::internal::Buffer> UnknownAHExtractComponent(
 }
 
 template <typename T, typename S>
+bool UnknownAHExtractIsInefficient()
+{
+  return viskores::cont::internal::ArrayExtractComponentIsInefficient<
+    viskores::cont::ArrayHandle<T, S>>::value;
+}
+
+template <typename T, typename S>
 void UnknownAHReleaseResources(void* mem)
 {
   using AH = viskores::cont::ArrayHandle<T, S>;
@@ -270,6 +278,9 @@ struct VISKORES_CONT_EXPORT UnknownAHContainer
                                                                              viskores::IdComponent,
                                                                              viskores::CopyFlag);
   ExtractComponentType* ExtractComponent;
+
+  using ExtractIsInefficientType = bool();
+  ExtractIsInefficientType* ExtractIsInefficient;
 
   using ReleaseResourcesType = void(void*);
   ReleaseResourcesType* ReleaseResources;
@@ -399,6 +410,7 @@ inline UnknownAHContainer::UnknownAHContainer(const viskores::cont::ArrayHandle<
   , ShallowCopy(detail::UnknownAHShallowCopy<T, S>)
   , DeepCopy(detail::UnknownAHDeepCopy<T, S>)
   , ExtractComponent(detail::UnknownAHExtractComponent<T, S>)
+  , ExtractIsInefficient(detail::UnknownAHExtractIsInefficient<T, S>)
   , ReleaseResources(detail::UnknownAHReleaseResources<T, S>)
   , ReleaseResourcesExecution(detail::UnknownAHReleaseResourcesExecution<T, S>)
   , PrintSummary(detail::UnknownAHPrintSummary<T, S>)
@@ -719,6 +731,18 @@ public:
     }
   }
   /// @copydoc AsArrayHandle
+  template <typename T>
+  VISKORES_CONT void AsArrayHandle(
+    viskores::cont::ArrayHandle<T, viskores::cont::StorageTagSOAStride>& array) const
+  {
+    if (!this->CanConvert<viskores::cont::ArrayHandle<T, viskores::cont::StorageTagSOAStride>>())
+    {
+      VISKORES_LOG_CAST_FAIL(*this, decltype(array));
+      throwFailedDynamicCast(this->GetArrayTypeName(), viskores::cont::TypeToString(array));
+    }
+    array = this->ExtractArrayWithValueType<T>();
+  }
+  /// @copydoc AsArrayHandle
   template <typename ArrayType>
   VISKORES_CONT ArrayType AsArrayHandle() const
   {
@@ -826,6 +850,16 @@ public:
     return ComponentArrayType(buffers);
   }
 
+  /// @brief Returns true if a call to `ExtractComponent` or a related method is inefficient.
+  ///
+  /// It is usually efficient to extract components from array handles. However,
+  /// some array handle types are inefficient. If the `UnknownArrayHandle` holds
+  /// an array with this type of storage, this method will return true. Note that
+  /// if the array returns false, an array extract may still require a copy. The
+  /// main consequence of the copy is that the extracted array will not point to
+  /// the same space as the original array.
+  bool ExtractIsInefficient() const { return this->Container->ExtractIsInefficient(); }
+
   /// @brief Extract the array knowing only the component type of the array.
   ///
   /// This method returns an `ArrayHandle` that points to the data in the array. This method
@@ -868,6 +902,23 @@ public:
   /// for each component. This array adds a slight overhead for each lookup as it performs the
   /// arithmetic for finding the index of each component.
   ///
+  /// This method is similar to `ExtractArrayWithValueType()` except that the
+  /// number of components need not be specified at compile time. However,
+  /// because the components cannot be specified, you get many of the
+  /// aforementioned limitations of the returned array.
+  ///
+  /// Note that the template argument between this method and
+  /// `ExtractArrayWithValueType()` is different. For this method, provide the type
+  /// of the base component.
+  /// ```cpp
+  /// auto extractedArray = unknownArray.ExtractArrayFromComponents<viskores::FloatDefault>();
+  /// ```
+  /// However, to extract the same array with `ExtractArrayWithValueType()`,
+  /// you would use this full `Vec` type.
+  /// ```cpp
+  /// auto extractedArray = unknownArray.ExtractArrayWithValue<viskores::Vec3f>();
+  /// ```
+  ///
   template <typename BaseComponentType>
   VISKORES_CONT viskores::cont::ArrayHandleRecombineVec<BaseComponentType>
   ExtractArrayFromComponents(viskores::CopyFlag allowCopy = viskores::CopyFlag::On) const
@@ -879,6 +930,39 @@ public:
       result.AppendComponentArray(this->ExtractComponent<BaseComponentType>(cIndex, allowCopy));
     }
     return result;
+  }
+
+  /// @brief Extract an array with any storage for a given value type.
+  ///
+  /// If you can determine the type of each value in the array, which can be
+  /// verified with the `IsValueType()` method, then this method can extract that
+  /// array into a flexible `ArrayHandleSOAStride`. Most arrays can do so
+  /// efficiently. You can check the `ExtractionIsInefficient()` method to check
+  /// to see if a very inefficient copy would be required (and hence should not
+  /// be used). Regardless, some arrays may be efficiently extracted but require
+  /// a some amount of copying to match the `ArrayHandleSOAStride` structure.
+  /// This would mean that writing to the extracted array will not be reflected
+  /// in the array held by this `UnknownArrayHandle`. To prevent such problems,
+  /// you can use the `allowCopy` parameter.
+  ///
+  /// @tparam ValueType The type of each value in the array. This must match `IsValueType()`.
+  /// @param allowCopy Determines whether the data is allowed to be copied or it must reference
+  ///   the data from the original array.
+  /// @return A `viskores::cont::ArrayHandleSOSStride` containing the array.
+  template <typename ValueType>
+  VISKORES_CONT viskores::cont::ArrayHandleSOAStride<ValueType> ExtractArrayWithValueType(
+    viskores::CopyFlag allowCopy = viskores::CopyFlag::On) const
+  {
+    using VTraits = viskores::VecTraits<ValueType>;
+    using ComponentType = typename VTraits::ComponentType;
+    viskores::cont::ArrayHandleSOAStride<ValueType> strideArray;
+    for (viskores::IdComponent componentIndex = 0; componentIndex < VTraits::NUM_COMPONENTS;
+         ++componentIndex)
+    {
+      strideArray.SetArray(componentIndex,
+                           this->ExtractComponent<ComponentType>(componentIndex, allowCopy));
+    }
+    return strideArray;
   }
 
   /// @brief Call a functor using the underlying array type.
@@ -1016,6 +1100,19 @@ struct UnknownArrayHandleCanConvert<T, viskores::cont::StorageTagRuntimeVec>
     return (array.IsType<viskores::cont::ArrayHandle<T, viskores::cont::StorageTagRuntimeVec>>() ||
             (array.IsStorageType<viskores::cont::StorageTagBasic>() &&
              array.IsBaseComponentType<BaseComponentType>()));
+  }
+};
+
+template <typename T>
+struct UnknownArrayHandleCanConvert<T, viskores::cont::StorageTagSOAStride>
+{
+  VISKORES_CONT bool operator()(const viskores::cont::UnknownArrayHandle& array) const
+  {
+    using VTraits = viskores::VecTraits<T>;
+    using BaseComponentType = typename VTraits::BaseComponentType;
+    return (!array.ExtractIsInefficient() && array.IsBaseComponentType<BaseComponentType>() &&
+            (array.GetNumberOfComponentsFlat() == VTraits::NUM_COMPONENTS) &&
+            std::is_same<BaseComponentType, typename VTraits::ComponentType>::value);
   }
 };
 

--- a/viskores/cont/internal/DefaultTypesAscent.h.in
+++ b/viskores/cont/internal/DefaultTypesAscent.h.in
@@ -23,6 +23,7 @@
 
 #include <viskores/cont/ArrayHandleCartesianProduct.h>
 #include <viskores/cont/ArrayHandleSOA.h>
+#include <viskores/cont/ArrayHandleSOAStride.h>
 #include <viskores/cont/ArrayHandleUniformPointCoordinates.h>
 #include <viskores/cont/StorageList.h>
 
@@ -40,13 +41,14 @@ namespace internal
 {
 
 // Default value types for fields in Ascent.
-using TypeListAscent = viskores::List<viskores::FloatDefault,
-                                  viskores::Vec3f,
-                                  // We should not need Float32 types, but currently the tests need
-                                  // them. We should remove these types once we are able to "fix"
-                                  // the tests by converting to supported default types.
-                                  viskores::Float32,
-                                  viskores::Vec3f_32>;
+using TypeListAscent =
+  viskores::List<viskores::FloatDefault,
+                 viskores::Vec3f,
+                 // We should not need Float32 types, but currently the tests need
+                 // them. We should remove these types once we are able to "fix"
+                 // the tests by converting to supported default types.
+                 viskores::Float32,
+                 viskores::Vec3f_32>;
 
 }
 } // namespace viskores::internal
@@ -61,12 +63,18 @@ namespace internal
 {
 
 using StorageListAscent = viskores::List<
-  viskores::cont::StorageTagBasic,         // Basic storage should always be included
-  viskores::cont::StorageTagSOA,           // Support separate arrays for each component
-  viskores::cont::StorageTagUniformPoints, // Support uniform structured grids
-  viskores::cont::StorageTagCartesianProduct<viskores::cont::StorageTagBasic, // Support rectilinear grids
-                                         viskores::cont::StorageTagBasic,
-                                         viskores::cont::StorageTagBasic>>;
+  // Basic storage should always be included
+  viskores::cont::StorageTagBasic,
+  // Support separate arrays for each component
+  viskores::cont::StorageTagSOA,
+  // Support uniform structured grids
+  viskores::cont::StorageTagUniformPoints,
+  // Support rectilinear grids
+  viskores::cont::StorageTagCartesianProduct<viskores::cont::StorageTagBasic,
+                                             viskores::cont::StorageTagBasic,
+                                             viskores::cont::StorageTagBasic>,
+  // Catchall for other storage
+  viskores::cont::StorageTagSOAStride>;
 
 }
 }

--- a/viskores/cont/internal/DefaultTypesVTK.h.in
+++ b/viskores/cont/internal/DefaultTypesVTK.h.in
@@ -119,8 +119,8 @@ using CellListAllOutVTK = viskores::ListAppend<CellListStructuredOutVTK, CellLis
 
 #ifdef VISKORES_ADD_XGC_DEFAULT_TYPES
 using StorageListField = viskores::ListAppend<
-  viskores::cont::StorageListCommon,
-  viskores::List<viskores::cont::StorageTagXGCCoordinates>>;
+  viskores::List<viskores::cont::StorageTagXGCCoordinates>,
+  viskores::cont::StorageListCommon>;
 #endif
 
 } // end namespace toviskores

--- a/viskores/cont/testing/UnitTestArrayExtractComponent.cxx
+++ b/viskores/cont/testing/UnitTestArrayExtractComponent.cxx
@@ -200,6 +200,23 @@ void DoTest()
 
     std::cout << "ArrayHandleMultiplexer" << std::endl;
     CheckInputArray(ArrayMultiplexerType(array));
+
+    std::cout << "ArrayHandleSOAStride" << std::endl;
+    {
+      array.Allocate(ARRAY_SIZE);
+      SetPortal(array.WritePortal());
+      viskores::cont::ArrayHandleSOAStride<viskores::Vec3f> soaStrideInput;
+      soaStrideInput.SetArray(1, viskores::cont::ArrayExtractComponent(array, 1));
+      soaStrideInput.SetArray(2, viskores::cont::ArrayExtractComponent(array, 2));
+      viskores::cont::ArrayHandle<viskores::Vec3f> outBuffer;
+      viskores::cont::ArrayHandleSOAStride<viskores::Vec3f> soaStrideOutput;
+      for (viskores::IdComponent i = 0; i < 3; ++i)
+      {
+        soaStrideInput.SetArray(i, viskores::cont::ArrayExtractComponent(array, i));
+        soaStrideOutput.SetArray(i, viskores::cont::ArrayExtractComponent(outBuffer, i));
+      }
+      CheckOutputArray(soaStrideInput, soaStrideOutput);
+    }
   }
 
   {

--- a/viskores/cont/testing/UnitTestDataSetConvertToExpected.cxx
+++ b/viskores/cont/testing/UnitTestDataSetConvertToExpected.cxx
@@ -32,8 +32,8 @@ namespace
 {
 
 // Likely to contain both supported and unsupported types.
-using TypesToTry = viskores::
-  List<viskores::FloatDefault, viskores::UInt32, VISKORES_UNUSED_INT_TYPE, viskores::Int8>;
+using TypesToTry =
+  viskores::List<viskores::FloatDefault, viskores::UInt32, viskores::Int16, viskores::Int8>;
 
 constexpr viskores::Id DIM_SIZE = 4;
 constexpr viskores::Id ARRAY_SIZE = DIM_SIZE * DIM_SIZE * DIM_SIZE;

--- a/viskores/cont/testing/UnitTestUnknownArrayHandle.cxx
+++ b/viskores/cont/testing/UnitTestUnknownArrayHandle.cxx
@@ -176,6 +176,11 @@ void CheckAsArrayHandle(const ArrayHandleType& array)
 
     ArrayHandleType retreivedArray2 = arrayUnknown.AsArrayHandle<ArrayHandleType>();
     VISKORES_TEST_ASSERT(array == retreivedArray2, "Did not get back same array.");
+
+    viskores::cont::ArrayHandleSOAStride<T> strideArray;
+    arrayUnknown.AsArrayHandle(strideArray);
+    VISKORES_TEST_ASSERT(test_equal_ArrayHandles(array, strideArray),
+                         "Could not retrieve basic array in ArrayHandleSOAStride.");
   }
 
   {
@@ -583,16 +588,37 @@ void TryExtractComponent()
   unknownArray.CastAndCallWithExtractedArray(CheckExtractedArray{}, originalArray);
 }
 
+// Currently separated from TryExtractComponent because ExtractArrayWithValueType does not
+// work with nested Vecs.
+template <typename ArrayHandleType>
+void TryExtractArrayWithValueType()
+{
+  using ValueType = typename ArrayHandleType::ValueType;
+
+  ArrayHandleType originalArray;
+  originalArray.Allocate(ARRAY_SIZE);
+  SetPortal(originalArray.WritePortal());
+
+  viskores::cont::UnknownArrayHandle unknownArray(originalArray);
+
+  viskores::cont::ArrayHandleSOAStride<ValueType> extractedArray =
+    unknownArray.ExtractArrayWithValueType<ValueType>();
+  VISKORES_TEST_ASSERT(test_equal_ArrayHandles(originalArray, extractedArray));
+}
+
 void TryExtractComponent()
 {
   std::cout << "  Scalar array." << std::endl;
   TryExtractComponent<viskores::cont::ArrayHandle<viskores::FloatDefault>>();
+  TryExtractArrayWithValueType<viskores::cont::ArrayHandle<viskores::FloatDefault>>();
 
   std::cout << "  Equivalent scalar." << std::endl;
   TryExtractComponent<viskores::cont::ArrayHandle<VISKORES_UNUSED_INT_TYPE>>();
+  TryExtractArrayWithValueType<viskores::cont::ArrayHandle<VISKORES_UNUSED_INT_TYPE>>();
 
   std::cout << "  Basic Vec." << std::endl;
   TryExtractComponent<viskores::cont::ArrayHandle<viskores::Id3>>();
+  TryExtractArrayWithValueType<viskores::cont::ArrayHandle<viskores::Id3>>();
 
   std::cout << "  Vec of Vecs." << std::endl;
   TryExtractComponent<viskores::cont::ArrayHandle<viskores::Vec<viskores::Vec2f, 3>>>();

--- a/viskores/filter/density_estimate/ContinuousScatterPlot.cxx
+++ b/viskores/filter/density_estimate/ContinuousScatterPlot.cxx
@@ -63,7 +63,7 @@ VISKORES_CONT viskores::cont::DataSet ContinuousScatterPlot::DoExecute(
     viskores::cont::ArrayHandle<viskores::Vec<FieldType, 3>> newCoords;
 
     // Both fields need to resolve to the same type in order to perform calculations
-    viskores::cont::ArrayHandle<FieldType> resolvedScalar2;
+    std::decay_t<decltype(resolvedScalar)> resolvedScalar2;
     viskores::cont::ArrayCopyShallowIfPossible(scalarField2.GetData(), resolvedScalar2);
 
     worklet.Run(tetraCellSet,

--- a/viskores/filter/density_estimate/worklet/ContinuousScatterPlot.h
+++ b/viskores/filter/density_estimate/worklet/ContinuousScatterPlot.h
@@ -420,15 +420,16 @@ public:
             typename CoordsInStorageType,
             typename OutputCellSetType,
             typename CoordsOutStorageType,
-            typename FieldType>
+            typename FieldType,
+            typename FieldStorageType>
   void Run(
     const viskores::cont::CellSetSingleType<>& inputCellSet,
     const viskores::cont::ArrayHandle<viskores::Vec<CoordsComType, 3>, CoordsInStorageType>& coords,
     viskores::cont::ArrayHandle<viskores::Vec<CoordsComTypeOut, 3>, CoordsOutStorageType>&
       newCoords,
     viskores::cont::ArrayHandle<FieldType>& density,
-    const viskores::cont::ArrayHandle<FieldType>& field1,
-    const viskores::cont::ArrayHandle<FieldType>& field2,
+    const viskores::cont::ArrayHandle<FieldType, FieldStorageType>& field1,
+    const viskores::cont::ArrayHandle<FieldType, FieldStorageType>& field2,
     OutputCellSetType& outputCellset)
   {
     viskores::cont::Invoker invoke;

--- a/viskores/io/testing/UnitTestVTKDataSetWriter.cxx
+++ b/viskores/io/testing/UnitTestVTKDataSetWriter.cxx
@@ -63,6 +63,14 @@ struct CheckSameCoordinateSystem
     CheckSameField{}(originalArray, fileCoords);
   }
 
+  template <typename T>
+  void operator()(
+    const viskores::cont::ArrayHandle<T, viskores::cont::StorageTagSOAStride>& originalArray,
+    const viskores::cont::CoordinateSystem& fileCoords) const
+  {
+    CheckSameField{}(originalArray, fileCoords);
+  }
+
   void operator()(const viskores::cont::ArrayHandleUniformPointCoordinates& originalArray,
                   const viskores::cont::CoordinateSystem& fileCoords) const
   {


### PR DESCRIPTION
`UnknownArrayHandle` has a new method named `ExtractArrayWithValueType` that
extracts an array with a given `ValueType` regardless of the storage. The method
extracts the data to an `ArrayHandleSOAStride` by extracting each component and
collecting them in that array type. This provides similar behavior to
`ExtractArrayFromComponents` except that it extracts to a `Vec` (or scalar) of
known type and size. This means that the array can later be used as a normal
array without the restrictions that an `ArrayHandleRecombineVec` that comes from
`ExtractArrayFromComponents` has.

Additionally, you can pull most arrays from an `UnknownArrayHandle` using
`AsArrayHandle` with an `ArrayHandleSOAStride` as long as the value types match.
A consequence of this is that if `StorageTagSOAStride` is added to the storage
types to check when doing a `CastAndCall`, then the cast and call will
automatically put the data into an array of that type. This makes for a
convenient backup for unexpected storage or a way to not worry about storage. As
such, `StorageTagSOAStride` has been added to the list default storage types to
check.