### PR TITLE
ci: add no_testing cuda13 job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -46,7 +46,7 @@
   extends:
     - .docker_image
 
-.ubuntu2004_cuda: &ubuntu2004_cuda
+.ubuntu2004_cuda118: &ubuntu2004_cuda118
   image:
     name: "ghcr.io/viskores/viskores:ci-ubuntu2004_cuda11.8-20250320"
   extends:
@@ -64,13 +64,13 @@
   extends:
     - .docker_image
 
-.ubuntu2204_cuda: &ubuntu2204_cuda
+.ubuntu2204_cuda122: &ubuntu2204_cuda122
   image:
     name: "ghcr.io/viskores/viskores:ci-ubuntu2204_cuda12.2-20250320"
   extends:
     - .docker_image
 
-.ubuntu2204_cuda_kokkos: &ubuntu2204_cuda_kokkos
+.ubuntu2204_cuda122_kokkos: &ubuntu2204_cuda122_kokkos
   image:
     name: "ghcr.io/viskores/viskores:ci-ubuntu2204_kokkos_cuda-20250320"
   extends:
@@ -85,6 +85,12 @@
 .ubuntu2404: &ubuntu2404
   image:
     name: "ghcr.io/viskores/viskores:ci-ubuntu2404-20250320"
+  extends:
+    - .docker_image
+
+.ubuntu2404_cuda130: &ubuntu2404_cuda130
+  image:
+    name: "ghcr.io/viskores/viskores:ci-ubuntu2404_cuda13.0-20250820"
   extends:
     - .docker_image
 

--- a/.gitlab/ci/docker/build_images.bash
+++ b/.gitlab/ci/docker/build_images.bash
@@ -48,6 +48,7 @@ function build_all_images() {
   build_image ubuntu2204_kokkos_cuda.dockerfile
   build_image ubuntu2204_kokkos_hip.dockerfile
   build_image ubuntu2404.dockerfile
+  build_image ubuntu2404_cuda13.0.dockerfile
 }
 
 if [ "$#" -eq 0 ]; then

--- a/.gitlab/ci/docker/ubuntu2404_cuda13.0.dockerfile
+++ b/.gitlab/ci/docker/ubuntu2404_cuda13.0.dockerfile
@@ -1,0 +1,42 @@
+##============================================================================
+##  The contents of this file are covered by the Viskores license. See
+##  LICENSE.txt for details.
+##
+##  By contributing to this file, all contributors agree to the Developer
+##  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+##============================================================================
+
+##=============================================================================
+##
+##  Copyright (c) Kitware, Inc.
+##  All rights reserved.
+##  See LICENSE.txt for details.
+##
+##  This software is distributed WITHOUT ANY WARRANTY; without even
+##  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+##  PURPOSE.  See the above copyright notice for more information.
+##
+##=============================================================================
+
+FROM docker.io/nvidia/cuda:13.0.0-devel-ubuntu24.04
+LABEL maintainer "Vicente Adolfo Bolea Sanchez<vicente.bolea@gmail.com>"
+
+# Base dependencies for building VTK-m projects
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      cmake \
+      curl \
+      g++ \
+      g++-14 \
+      git \
+      libhdf5-dev \
+      libmpich-dev \
+      libomp-dev \
+      libtbb-dev \
+      make \
+      mpich \
+      ninja-build \
+      pkg-config \
+      python3 \
+      python3-scipy \
+      && \
+    rm -rf /var/lib/apt/lists/*

--- a/.gitlab/ci/ubuntu2004.yml
+++ b/.gitlab/ci/ubuntu2004.yml
@@ -44,14 +44,14 @@ ubuntu2004_gcc9:
     OMP_NUM_THREADS: 4
     VISKORES_SETTINGS: "benchmarks+tbb+openmp+mpi+shared+hdf5+ccache"
 
-ubuntu2004_gcc9_cuda:
+ubuntu2004_gcc9_cuda118:
   tags:
     - nvidia-a100
     - uo-gpu
     - x86_64-nvidiagpu
     - voltar
   extends:
-    - .ubuntu2004_cuda
+    - .ubuntu2004_cuda118
     - .cmake_build_linux
     - .run_automatically
   variables:

--- a/.gitlab/ci/ubuntu2204.yml
+++ b/.gitlab/ci/ubuntu2204.yml
@@ -75,14 +75,14 @@ ubuntu2204_hip_kokkos43:
     - ccache -v -s
     - ccache -z
 
-ubuntu2204_clang11_cuda:
+ubuntu2204_clang11_cuda122:
   tags:
     - nvidia-a100
     - uo-gpu
     - x86_64-nvidiagpu
     - voltar
   extends:
-    - .ubuntu2204_cuda
+    - .ubuntu2204_cuda122
     - .cmake_build_linux
     - .run_automatically
   variables:
@@ -92,13 +92,13 @@ ubuntu2204_clang11_cuda:
     VISKORES_SETTINGS: "cuda+ampere+tbb+examples+shared+ccache"
     CTEST_EXCLUSIONS: "UnitTestTimer"
 
-#ubuntu2204_gcc10_cuda:
+#ubuntu2204_gcc10_cuda122:
 #  tags:
 #    - nvidia-h100
 #    - uo-gpu
 #    - x86_64-nvidiagpu
 #  extends:
-#    - .ubuntu2204_cuda
+#    - .ubuntu2204_cuda122
 #    - .cmake_build_linux
 #    - .run_automatically
 #  variables:
@@ -120,14 +120,14 @@ ubuntu2204_clang12:
     CMAKE_BUILD_TYPE: Debug
     VISKORES_SETTINGS: "tbb+shared+examples+ccache"
 
-ubuntu2204_kokkos37_cuda:
+ubuntu2204_kokkos37_cuda122:
   tags:
     - nvidia-a100
     - uo-gpu
     - x86_64-nvidiagpu
     - voltar
   extends:
-    - .ubuntu2204_cuda_kokkos
+    - .ubuntu2204_cuda122_kokkos
     - .cmake_build_linux
     - .run_automatically
   variables:

--- a/.gitlab/ci/ubuntu2404.yml
+++ b/.gitlab/ci/ubuntu2404.yml
@@ -47,3 +47,16 @@ ubuntu2404_gcc14:
     # execute on the same hardware concurrently
     OMP_NUM_THREADS: 3
     CTEST_EXCLUSIONS: "UnitTestArrayPortalValueReference"
+
+ubuntu2404_gcc14_cuda130:
+  extends:
+    - .ubuntu2404_cuda130
+    - .cmake_build_linux
+    - .run_automatically
+    - .uo_cpu_tags
+  variables:
+    CC: "gcc-14"
+    CXX: "g++-14"
+    CUDAHOSTCXX: "g++-14"
+    VISKORES_SETTINGS: "no_testing+cuda+turing+tbb+examples+shared+ccache"
+    NO_TESTING: "ON"

--- a/docs/CI-README.md
+++ b/docs/CI-README.md
@@ -225,7 +225,7 @@ test:ubuntu2004_$<compiler>:
     - docker
     - linux
   extends:
-    - .ubuntu2004_cuda
+    - .ubuntu2004_cuda118
     - .cmake_test_linux
     - .only-default
   needs:

--- a/viskores/Swap.h
+++ b/viskores/Swap.h
@@ -42,8 +42,18 @@ namespace viskores
 // `Swap`, it results in ADL being used, causing the templated functions `cub::Swap` and
 // `viskores::Swap` to conflict.
 #if defined(VISKORES_CUDA_VERSION_MAJOR) && (VISKORES_CUDA_VERSION_MAJOR >= 12)
+#if VISKORES_CUDA_VERSION_MAJOR == 12
 using cub::Swap;
+#elif VISKORES_CUDA_VERSION_MAJOR >= 13
+template <typename T>
+VISKORES_EXEC_CONT inline void Swap(T& a, T& b)
+{
+  using ::cuda::std::swap;
+  swap(a, b);
+}
+#endif
 #else
+
 template <typename T>
 VISKORES_EXEC_CONT inline void Swap(T& a, T& b)
 {

--- a/viskores/cont/cuda/internal/CudaAllocator.cu
+++ b/viskores/cont/cuda/internal/CudaAllocator.cu
@@ -284,10 +284,26 @@ void CudaAllocator::PrepareForControl(const void* ptr, std::size_t numBytes)
 {
   if (IsManagedPointer(ptr) && numBytes >= Threshold)
   {
+    viskores::Id deviceId;
+    viskores::cont::RuntimeDeviceInformation()
+      .GetRuntimeConfiguration(viskores::cont::DeviceAdapterTagCuda())
+      .GetDeviceInstance(deviceId);
+#if defined(VISKORES_CUDA_VERSION_MAJOR) && (VISKORES_CUDA_VERSION_MAJOR >= 13)
+    cudaMemLocation dev;
+    dev.id = cudaCpuDeviceId;
+    dev.type = cudaMemLocationTypeHost;
+#else
+    viskores::Id dev = cudaCpuDeviceId;
+#endif
     // TODO these hints need to be benchmarked and adjusted once we start
     // sharing the pointers between cont/exec
-    VISKORES_CUDA_CALL(cudaMemAdvise(ptr, numBytes, cudaMemAdviseSetAccessedBy, cudaCpuDeviceId));
-    VISKORES_CUDA_CALL(cudaMemPrefetchAsync(ptr, numBytes, cudaCpuDeviceId, cudaStreamPerThread));
+    VISKORES_CUDA_CALL(cudaMemAdvise(ptr, numBytes, cudaMemAdviseSetAccessedBy, dev));
+
+#if defined(VISKORES_CUDA_VERSION_MAJOR) && (VISKORES_CUDA_VERSION_MAJOR >= 13)
+    VISKORES_CUDA_CALL(cudaMemPrefetchAsync(ptr, numBytes, dev, 0, cudaStreamPerThread));
+#else
+    VISKORES_CUDA_CALL(cudaMemPrefetchAsync(ptr, numBytes, dev, cudaStreamPerThread));
+#endif
   }
 }
 
@@ -295,14 +311,23 @@ void CudaAllocator::PrepareForInput(const void* ptr, std::size_t numBytes)
 {
   if (IsManagedPointer(ptr) && numBytes >= Threshold)
   {
-    viskores::Id dev;
+    viskores::Id deviceId;
     viskores::cont::RuntimeDeviceInformation()
       .GetRuntimeConfiguration(viskores::cont::DeviceAdapterTagCuda())
-      .GetDeviceInstance(dev);
-    // VISKORES_CUDA_CALL(cudaMemAdvise(ptr, numBytes, cudaMemAdviseSetPreferredLocation, dev));
-    // VISKORES_CUDA_CALL(cudaMemAdvise(ptr, numBytes, cudaMemAdviseSetReadMostly, dev));
+      .GetDeviceInstance(deviceId);
+#if defined(VISKORES_CUDA_VERSION_MAJOR) && (VISKORES_CUDA_VERSION_MAJOR >= 13)
+    cudaMemLocation dev;
+    dev.id = deviceId;
+    dev.type = cudaMemLocationTypeDevice;
+#else
+    viskores::Id dev = deviceId;
+#endif
     VISKORES_CUDA_CALL(cudaMemAdvise(ptr, numBytes, cudaMemAdviseSetAccessedBy, dev));
+#if defined(VISKORES_CUDA_VERSION_MAJOR) && (VISKORES_CUDA_VERSION_MAJOR >= 13)
+    VISKORES_CUDA_CALL(cudaMemPrefetchAsync(ptr, numBytes, dev, 0, cudaStreamPerThread));
+#else
     VISKORES_CUDA_CALL(cudaMemPrefetchAsync(ptr, numBytes, dev, cudaStreamPerThread));
+#endif
   }
 }
 
@@ -310,14 +335,23 @@ void CudaAllocator::PrepareForOutput(const void* ptr, std::size_t numBytes)
 {
   if (IsManagedPointer(ptr) && numBytes >= Threshold)
   {
-    viskores::Id dev;
+    viskores::Id deviceId;
     viskores::cont::RuntimeDeviceInformation()
       .GetRuntimeConfiguration(viskores::cont::DeviceAdapterTagCuda())
-      .GetDeviceInstance(dev);
-    // VISKORES_CUDA_CALL(cudaMemAdvise(ptr, numBytes, cudaMemAdviseSetPreferredLocation, dev));
-    // VISKORES_CUDA_CALL(cudaMemAdvise(ptr, numBytes, cudaMemAdviseUnsetReadMostly, dev));
+      .GetDeviceInstance(deviceId);
+#if defined(VISKORES_CUDA_VERSION_MAJOR) && (VISKORES_CUDA_VERSION_MAJOR >= 13)
+    cudaMemLocation dev;
+    dev.id = deviceId;
+    dev.type = cudaMemLocationTypeDevice;
+#else
+    viskores::Id dev = deviceId;
+#endif
     VISKORES_CUDA_CALL(cudaMemAdvise(ptr, numBytes, cudaMemAdviseSetAccessedBy, dev));
+#if defined(VISKORES_CUDA_VERSION_MAJOR) && (VISKORES_CUDA_VERSION_MAJOR >= 13)
+    VISKORES_CUDA_CALL(cudaMemPrefetchAsync(ptr, numBytes, dev, 0, cudaStreamPerThread));
+#else
     VISKORES_CUDA_CALL(cudaMemPrefetchAsync(ptr, numBytes, dev, cudaStreamPerThread));
+#endif
   }
 }
 
@@ -325,14 +359,23 @@ void CudaAllocator::PrepareForInPlace(const void* ptr, std::size_t numBytes)
 {
   if (IsManagedPointer(ptr) && numBytes >= Threshold)
   {
-    viskores::Id dev;
+    viskores::Id deviceId;
     viskores::cont::RuntimeDeviceInformation()
       .GetRuntimeConfiguration(viskores::cont::DeviceAdapterTagCuda())
-      .GetDeviceInstance(dev);
-    // VISKORES_CUDA_CALL(cudaMemAdvise(ptr, numBytes, cudaMemAdviseSetPreferredLocation, dev));
-    // VISKORES_CUDA_CALL(cudaMemAdvise(ptr, numBytes, cudaMemAdviseUnsetReadMostly, dev));
+      .GetDeviceInstance(deviceId);
+#if defined(VISKORES_CUDA_VERSION_MAJOR) && (VISKORES_CUDA_VERSION_MAJOR >= 13)
+    cudaMemLocation dev;
+    dev.id = deviceId;
+    dev.type = cudaMemLocationTypeDevice;
+#else
+    viskores::Id dev = deviceId;
+#endif
     VISKORES_CUDA_CALL(cudaMemAdvise(ptr, numBytes, cudaMemAdviseSetAccessedBy, dev));
+#if defined(VISKORES_CUDA_VERSION_MAJOR) && (VISKORES_CUDA_VERSION_MAJOR >= 13)
+    VISKORES_CUDA_CALL(cudaMemPrefetchAsync(ptr, numBytes, dev, 0, cudaStreamPerThread));
+#else
     VISKORES_CUDA_CALL(cudaMemPrefetchAsync(ptr, numBytes, dev, cudaStreamPerThread));
+#endif
   }
 }
 


### PR DESCRIPTION
    We cannot add the testing phase yet since the UO Frank cluster does not
    have a recent enough nvidia driver.
    
    This commit also rename the Frank Cluster cuda builds to include
    in their name the cuda version.


cc @spyridon97 