### PR TITLE
Enable more types for Clamp function

### DIFF
--- a/docs/changelog/more-clamp-types.md
+++ b/docs/changelog/more-clamp-types.md
@@ -1,0 +1,10 @@
+## Enable more types for Clamp function
+
+The Viskores `Clamp` function now works with any numeric type. Previously it
+only worked with basic floating point types (i.e., `viskores::Float32` and
+`viskores::Float64`). It is now templated to work with any numeric type. It can
+now also operate on `Vec` and `Vec`-like types. Furthermore, it is possible to
+mix the types of the arguments without ambiguous overloading.
+
+Documentation for `Clamp` is now in the user's guide whereas previously it was
+missing.

--- a/docs/users-guide/math.rst
+++ b/docs/users-guide/math.rst
@@ -20,6 +20,17 @@ The :file:`viskores/Math.h` header file contains several math functions that rep
    When writing worklets, you should favor using these math functions provided by |Viskores| over the standard math functions in :file:`viskores/Math.h`.
    |Viskores|'s implementation manages several compiling and efficiency issues when porting.
 
+Comparison and Distance
+==============================
+
+.. doxygenfunction:: Clamp
+
+.. doxygenfunction:: FloatDistance(viskores::Float64, viskores::Float64)
+.. doxygenfunction:: FloatDistance(viskores::Float32, viskores::Float32)
+
+.. doxygenfunction:: Max(const T&, const T&)
+.. doxygenfunction:: Min(const T&, const T&)
+
 Exponentials
 ==============================
 
@@ -239,15 +250,6 @@ Trigonometry
 .. doxygenfunction:: viskores::TanH(const viskores::Vec<T, N>&)
 
 .. doxygenfunction:: TwoPi
-
-Miscellaneous
-==============================
-
-.. doxygenfunction:: FloatDistance(viskores::Float64, viskores::Float64)
-.. doxygenfunction:: FloatDistance(viskores::Float32, viskores::Float32)
-
-.. doxygenfunction:: Max(const T&, const T&)
-.. doxygenfunction:: Min(const T&, const T&)
 
 
 ------------------------------

--- a/viskores/Math.h
+++ b/viskores/Math.h
@@ -40,7 +40,7 @@
 #endif
 
 #ifdef VISKORES_MSVC
-#include <intrin.h>                // For bitwise intrinsics (__popcnt, etc)
+#include <intrin.h>                    // For bitwise intrinsics (__popcnt, etc)
 #include <viskores/internal/Windows.h> // for types used by MSVC intrinsics.
 #ifndef VISKORES_CUDA
 #include <math.h>
@@ -117,7 +117,8 @@ static constexpr inline VISKORES_EXEC_CONT typename detail::FloatingPointReturnT
 /// Returns the constant Pi one hundred and eightieth.
 ///
 template <typename T = viskores::Float64>
-static constexpr inline VISKORES_EXEC_CONT typename detail::FloatingPointReturnType<T>::Type Pi_180()
+static constexpr inline VISKORES_EXEC_CONT typename detail::FloatingPointReturnType<T>::Type
+Pi_180()
 {
   using FT = typename detail::FloatingPointReturnType<T>::Type;
   return static_cast<FT>(0.01745329251994329547437168059786927);
@@ -1829,19 +1830,73 @@ static inline VISKORES_EXEC_CONT T Min(const T& x, const T& y)
   return detail::Min(x, y, typename viskores::TypeTraits<T>::DimensionalityTag());
 }
 
-///@{
-/// Clamp \p x to the given range.
-///
-inline VISKORES_EXEC_CONT viskores::Float32 Clamp(viskores::Float32 x, viskores::Float32 lo, viskores::Float32 hi)
+// clang-format on
+namespace detail
 {
-  return x > lo ? (x < hi ? x : hi) : lo;
+
+// Forward declarations
+template <typename Tx, typename Tlo, typename Thi>
+static inline VISKORES_EXEC_CONT Tx Clamp(Tx x, Tlo lo, Thi hi, viskores::TypeTraitsScalarTag);
+template <typename Tx, typename Tlo, typename Thi>
+static inline VISKORES_EXEC_CONT Tx Clamp(Tx x, Tlo lo, Thi hi, viskores::TypeTraitsVectorTag);
+
+} // namespace detail
+
+/// @brief Clamp `x` to the given range.
+///
+/// Given a value `x` and a range of valid range of values, provides the value within the range.
+/// If `x` is already within the range, that value is just returned. If `x` is outside that range,
+/// the low or high value (whichever is closer) is returned.
+///
+/// For convenience, the `low` and `high` and high values will be typecast to the type of `x`.
+/// `Clamp` may be called for `Vec` and `Vec`-like objects to do a component-wise clamp.
+/// It is an error if the number of components does not match.
+///
+/// @param x The value to clamp to a specific range.
+/// @param low The minimum value of the valid range.
+/// @param high The maximum value of the valid range.
+/// @returns `x` adjusted to be in the range from `low` to `high`.
+template <typename Tx, typename Tlow, typename Thigh>
+inline VISKORES_EXEC_CONT Tx Clamp(Tx&& x, Tlow&& low, Thigh&& high)
+{
+  return detail::Clamp(std::forward<Tx>(x),
+                       std::forward<Tlow>(low),
+                       std::forward<Thigh>(high),
+                       typename viskores::TypeTraits<Tx>::DimensionalityTag());
 }
 
-inline VISKORES_EXEC_CONT viskores::Float64 Clamp(viskores::Float64 x, viskores::Float64 lo, viskores::Float64 hi)
+namespace detail
 {
-  return x > lo ? (x < hi ? x : hi) : lo;
+
+template <typename Tx, typename Tlo, typename Thi>
+static inline VISKORES_EXEC_CONT Tx Clamp(Tx x, Tlo lo, Thi hi, viskores::TypeTraitsScalarTag)
+{
+  return x > static_cast<Tx>(lo) ? (x < static_cast<Tx>(hi) ? x : static_cast<Tx>(hi))
+                                 : static_cast<Tx>(lo);
 }
-///@}
+
+template <typename Tx, typename Tlo, typename Thi>
+static inline VISKORES_EXEC_CONT Tx Clamp(Tx x, Tlo lo, Thi hi, viskores::TypeTraitsVectorTag)
+{
+  using TraitsX = viskores::VecTraits<Tx>;
+  using TraitsLo = viskores::VecTraits<Tlo>;
+  using TraitsHi = viskores::VecTraits<Thi>;
+  VISKORES_ASSERT(TraitsX::GetNumberOfComponents(x) == TraitsLo::GetNumberOfComponents(lo));
+  VISKORES_ASSERT(TraitsX::GetNumberOfComponents(x) == TraitsHi::GetNumberOfComponents(hi));
+  Tx result;
+  for (viskores::IdComponent index = 0; index < TraitsX::GetNumberOfComponents(x); ++index)
+  {
+    TraitsX::SetComponent(result,
+                          index,
+                          viskores::Clamp(TraitsX::GetComponent(x, index),
+                                          TraitsLo::GetComponent(lo, index),
+                                          TraitsHi::GetComponent(hi, index)));
+  }
+}
+
+} // namespace detail
+
+// clang-format off
 
 //-----------------------------------------------------------------------------
 

--- a/viskores/Math.h.in
+++ b/viskores/Math.h.in
@@ -52,7 +52,7 @@ $# Ignore the following comment. It is meant for the generated file.
 #endif
 
 #ifdef VISKORES_MSVC
-#include <intrin.h>                // For bitwise intrinsics (__popcnt, etc)
+#include <intrin.h>                    // For bitwise intrinsics (__popcnt, etc)
 #include <viskores/internal/Windows.h> // for types used by MSVC intrinsics.
 #ifndef VISKORES_CUDA
 #include <math.h>
@@ -267,7 +267,8 @@ static constexpr inline VISKORES_EXEC_CONT typename detail::FloatingPointReturnT
 /// Returns the constant Pi one hundred and eightieth.
 ///
 template <typename T = viskores::Float64>
-static constexpr inline VISKORES_EXEC_CONT typename detail::FloatingPointReturnType<T>::Type Pi_180()
+static constexpr inline VISKORES_EXEC_CONT typename detail::FloatingPointReturnType<T>::Type
+Pi_180()
 {
   using FT = typename detail::FloatingPointReturnType<T>::Type;
   return static_cast<FT>(0.01745329251994329547437168059786927);
@@ -677,19 +678,73 @@ static inline VISKORES_EXEC_CONT T Min(const T& x, const T& y)
   return detail::Min(x, y, typename viskores::TypeTraits<T>::DimensionalityTag());
 }
 
-///@{
-/// Clamp \p x to the given range.
-///
-inline VISKORES_EXEC_CONT viskores::Float32 Clamp(viskores::Float32 x, viskores::Float32 lo, viskores::Float32 hi)
+// clang-format on
+namespace detail
 {
-  return x > lo ? (x < hi ? x : hi) : lo;
+
+// Forward declarations
+template <typename Tx, typename Tlo, typename Thi>
+static inline VISKORES_EXEC_CONT Tx Clamp(Tx x, Tlo lo, Thi hi, viskores::TypeTraitsScalarTag);
+template <typename Tx, typename Tlo, typename Thi>
+static inline VISKORES_EXEC_CONT Tx Clamp(Tx x, Tlo lo, Thi hi, viskores::TypeTraitsVectorTag);
+
+} // namespace detail
+
+/// @brief Clamp `x` to the given range.
+///
+/// Given a value `x` and a range of valid range of values, provides the value within the range.
+/// If `x` is already within the range, that value is just returned. If `x` is outside that range,
+/// the low or high value (whichever is closer) is returned.
+///
+/// For convenience, the `low` and `high` and high values will be typecast to the type of `x`.
+/// `Clamp` may be called for `Vec` and `Vec`-like objects to do a component-wise clamp.
+/// It is an error if the number of components does not match.
+///
+/// @param x The value to clamp to a specific range.
+/// @param low The minimum value of the valid range.
+/// @param high The maximum value of the valid range.
+/// @returns `x` adjusted to be in the range from `low` to `high`.
+template <typename Tx, typename Tlow, typename Thigh>
+inline VISKORES_EXEC_CONT Tx Clamp(Tx&& x, Tlow&& low, Thigh&& high)
+{
+  return detail::Clamp(std::forward<Tx>(x),
+                       std::forward<Tlow>(low),
+                       std::forward<Thigh>(high),
+                       typename viskores::TypeTraits<Tx>::DimensionalityTag());
 }
 
-inline VISKORES_EXEC_CONT viskores::Float64 Clamp(viskores::Float64 x, viskores::Float64 lo, viskores::Float64 hi)
+namespace detail
 {
-  return x > lo ? (x < hi ? x : hi) : lo;
+
+template <typename Tx, typename Tlo, typename Thi>
+static inline VISKORES_EXEC_CONT Tx Clamp(Tx x, Tlo lo, Thi hi, viskores::TypeTraitsScalarTag)
+{
+  return x > static_cast<Tx>(lo) ? (x < static_cast<Tx>(hi) ? x : static_cast<Tx>(hi))
+                                 : static_cast<Tx>(lo);
 }
-///@}
+
+template <typename Tx, typename Tlo, typename Thi>
+static inline VISKORES_EXEC_CONT Tx Clamp(Tx x, Tlo lo, Thi hi, viskores::TypeTraitsVectorTag)
+{
+  using TraitsX = viskores::VecTraits<Tx>;
+  using TraitsLo = viskores::VecTraits<Tlo>;
+  using TraitsHi = viskores::VecTraits<Thi>;
+  VISKORES_ASSERT(TraitsX::GetNumberOfComponents(x) == TraitsLo::GetNumberOfComponents(lo));
+  VISKORES_ASSERT(TraitsX::GetNumberOfComponents(x) == TraitsHi::GetNumberOfComponents(hi));
+  Tx result;
+  for (viskores::IdComponent index = 0; index < TraitsX::GetNumberOfComponents(x); ++index)
+  {
+    TraitsX::SetComponent(result,
+                          index,
+                          viskores::Clamp(TraitsX::GetComponent(x, index),
+                                          TraitsLo::GetComponent(lo, index),
+                                          TraitsHi::GetComponent(hi, index)));
+  }
+}
+
+} // namespace detail
+
+// clang-format off
 
 //-----------------------------------------------------------------------------
 

--- a/viskores/testing/UnitTestMath.cxx
+++ b/viskores/testing/UnitTestMath.cxx
@@ -993,6 +993,35 @@ struct AllTypesTests : public viskores::exec::FunctorBase
     VISKORES_MATH_ASSERT(test_equal(viskores::Max(mixed2, mixed1), high), "Wrong max.");
   }
 
+  VISKORES_EXEC void TestClamp() const
+  {
+    T low = TestValue(2, T());
+    T high = TestValue(7, T());
+
+    using FloatType =
+      typename viskores::TypeTraits<T>::template ReplaceComponentType<viskores::FloatDefault>;
+    FloatType lowf = static_cast<FloatType>(low);
+    FloatType highf = static_cast<FloatType>(high);
+
+    for (viskores::Id index = 0; index < 5; ++index)
+    {
+      T x = TestValue(index, T());
+      VISKORES_MATH_ASSERT(test_equal(viskores::Clamp(x, low, high), viskores::Max(x, low)),
+                           "Bad clamp.");
+      VISKORES_MATH_ASSERT(test_equal(viskores::Clamp(x, lowf, highf), viskores::Max(x, low)),
+                           "Bad clamp.");
+    }
+
+    for (viskores::Id index = 5; index < 10; ++index)
+    {
+      T x = TestValue(index, T());
+      VISKORES_MATH_ASSERT(test_equal(viskores::Clamp(x, low, high), viskores::Min(x, high)),
+                           "Bad clamp.");
+      VISKORES_MATH_ASSERT(test_equal(viskores::Clamp(x, lowf, highf), viskores::Min(x, high)),
+                           "Bad clamp.");
+    }
+  }
+
   VISKORES_EXEC
   void operator()(viskores::Id) const { this->TestMinMax(); }
 };


### PR DESCRIPTION
The Viskores `Clamp` function now works with any numeric type. Previously it only worked with basic floating point types (i.e., `viskores::Float32` and `viskores::Float64`). It is now templated to work with any numeric type. It can now also operate on `Vec` and `Vec`-like types. Furthermore, it is possible to mix the types of the arguments without ambiguous overloading.

Documentation for `Clamp` is now in the user's guide whereas previously it was missing.