### PR TITLE
Support TypeTraits for reference types

### DIFF
--- a/docs/changelog/typetraits-ref.md
+++ b/docs/changelog/typetraits-ref.md
@@ -1,0 +1,23 @@
+## Support TypeTraits for reference types
+
+Viskores now supports passing reference types to `viskores::TypeTraits`.
+Previously, if you used `viskores::TypeTraits` with a reference type (such as
+`viskores::TypeTraits<viskores::Id&>`) you would get the "default"
+implementation, which would state that the type was unknown.
+
+Now when you use `viskores::TypeTraits` with a reference type, you get the
+traits for the type without the reference. For example, if you use
+
+```cpp
+viskores::TypeTraits<T&>
+```
+
+you will get the same traits as
+
+```cpp
+viskores::TypeTraits<T>
+```
+
+This feature is important when implementing templated methods where a templated
+type can be a reference. This avoids having to remove references from templated
+types.

--- a/viskores/TypeTraits.h
+++ b/viskores/TypeTraits.h
@@ -92,6 +92,12 @@ struct TypeTraits<const T> : TypeTraits<T>
 {
 };
 
+// Reference types should have the same traits as their value counterparts.
+template <typename T>
+struct TypeTraits<T&> : TypeTraits<T>
+{
+};
+
 #define VISKORES_BASIC_REAL_TYPE(T)                  \
   template <>                                        \
   struct TypeTraits<T>                               \

--- a/viskores/testing/UnitTestTypeTraits.cxx
+++ b/viskores/testing/UnitTestTypeTraits.cxx
@@ -33,7 +33,13 @@ struct TypeTraitTest
     // If you get compiler errors here, it could be a TypeTraits instance
     // has missing or malformed tags.
     this->TestDimensionality(t, typename viskores::TypeTraits<T>::DimensionalityTag());
+    this->TestDimensionality(t, typename viskores::TypeTraits<const T>::DimensionalityTag());
+    this->TestDimensionality(t, typename viskores::TypeTraits<T&>::DimensionalityTag());
+    this->TestDimensionality(t, typename viskores::TypeTraits<const T&>::DimensionalityTag());
     this->TestNumeric(t, typename viskores::TypeTraits<T>::NumericTag());
+    this->TestNumeric(t, typename viskores::TypeTraits<const T>::NumericTag());
+    this->TestNumeric(t, typename viskores::TypeTraits<T&>::NumericTag());
+    this->TestNumeric(t, typename viskores::TypeTraits<const T&>::NumericTag());
   }
 
 private:

--- a/viskores/testing/VecTraitsTests.h
+++ b/viskores/testing/VecTraitsTests.h
@@ -151,6 +151,16 @@ static void TestVecTypeImpl(const typename std::remove_const<T>::type& inVector,
   using ComponentType = typename Traits::ComponentType;
   using NonConstT = typename std::remove_const<T>::type;
 
+  VISKORES_STATIC_ASSERT_MSG(
+    (std::is_base_of<viskores::VecTraits<NonConstT>, viskores::VecTraits<T&>>::value),
+    "Reference should have same implementation as base type.");
+  VISKORES_STATIC_ASSERT_MSG(
+    (std::is_base_of<viskores::VecTraits<NonConstT>, viskores::VecTraits<const T&>>::value),
+    "Const reference should have same implementation as base type.");
+  VISKORES_STATIC_ASSERT_MSG(
+    (std::is_base_of<viskores::VecTraits<NonConstT>, viskores::VecTraits<const NonConstT>>::value),
+    "Const should have same implementation as base type.");
+
   CheckIsStatic<NUM_COMPONENTS>(inVector, typename Traits::IsSizeStatic());
 
   VISKORES_TEST_ASSERT(Traits::GetNumberOfComponents(inVector) == NUM_COMPONENTS,


### PR DESCRIPTION
Viskores now supports passing reference types to `viskores::TypeTraits`. Previously, if you used `viskores::TypeTraits` with a reference type (such as `viskores::TypeTraits<viskores::Id&>`) you would get the "default" implementation, which would state that the type was unknown.

Now when you use `viskores::TypeTraits` with a reference type, you get the traits for the type without the reference. For example, if you use

```cpp
viskores::TypeTraits<T&>
```

you will get the same traits as

```cpp
viskores::TypeTraits<T>
```

This feature is important when implementing templated methods where a templated type can be a reference. This avoids having to remove references from templated types.

Fixes #150 