### PR TITLE
Update user's guide document number

### DIFF
--- a/docs/users-guide/conf.py
+++ b/docs/users-guide/conf.py
@@ -85,7 +85,7 @@ rst_prolog = '''
 .. |Viskores| replace:: Viskores
 .. |Veclike| replace:: ``Vec``-like
 .. |report-year| replace:: 2025
-.. |report-number| replace:: ORNL/TM-2025/4019
+.. |report-number| replace:: ORNL/TM-2025/4175
 '''
 
 breathe_projects = { 'viskores': '@doxygen_xml_output_dir@' }

--- a/docs/users-guide/index.rst
+++ b/docs/users-guide/index.rst
@@ -5,7 +5,7 @@ The Viskores User's Guide
 ==============================
 
 | **The Viskores User's Guide**
-| Version |version|
+| Release |version|
 
 Kenneth Moreland
 
@@ -25,9 +25,9 @@ Allison Vacanti,
 Abhishek Yenpure,
 and the |Viskores| community.
 
-Moreland, K. (|report-year|). *The Viskores User's Guide*, version |release|, Tech report |report-number|, Oak Ridge National Laboratory.
+Moreland, K. (|report-year|). *The Viskores User's Guide*, Release |release|, Tech report |report-number|, Oak Ridge National Laboratory.
 
-.. centered:: Join the Viskores Community at http://m.vtk.org.
+.. centered:: Join the Viskores Community at https://github.com/Viskores/viskores.
 
 .. todo:: The centered directive is deprecated (https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-centered). Figure out how to add rst-class to center.
 


### PR DESCRIPTION
For the Release 1.1 version of the document.

Backport of #169 for the release branch.