### PR TITLE
Fix more compiler warnings about constructor templates

### DIFF
--- a/viskores/cont/cuda/internal/RuntimeDeviceConfigurationCuda.h
+++ b/viskores/cont/cuda/internal/RuntimeDeviceConfigurationCuda.h
@@ -43,7 +43,7 @@ class RuntimeDeviceConfiguration<viskores::cont::DeviceAdapterTagCuda>
   : public viskores::cont::internal::RuntimeDeviceConfigurationBase
 {
 public:
-  RuntimeDeviceConfiguration<viskores::cont::DeviceAdapterTagCuda>()
+  RuntimeDeviceConfiguration()
   {
     this->CudaDeviceCount = 0;
     this->CudaProp.clear();

--- a/viskores/cont/tbb/internal/RuntimeDeviceConfigurationTBB.h
+++ b/viskores/cont/tbb/internal/RuntimeDeviceConfigurationTBB.h
@@ -46,7 +46,7 @@ class RuntimeDeviceConfiguration<viskores::cont::DeviceAdapterTagTBB>
 {
 public:
   VISKORES_CONT
-  RuntimeDeviceConfiguration<viskores::cont::DeviceAdapterTagTBB>()
+  RuntimeDeviceConfiguration()
     :
 #if TBB_VERSION_MAJOR >= 2020
     HardwareMaxThreads(::tbb::task_arena{}.max_concurrency())


### PR DESCRIPTION
f48c0ddde4e5666f89e8df5bd7c325f45cce698b fixed this for RuntimeDeviceConfigurationOpenMP, this does the same for TBB and CUDA.

This is applying #175 to the main branch.