### PR TITLE
Updated minimum CMake in configuration

### DIFF
--- a/.gitlab/ci/config/ccache.cmake
+++ b/.gitlab/ci/config/ccache.cmake
@@ -16,7 +16,7 @@
 ##  PURPOSE.  See the above copyright notice for more information.
 ##============================================================================
 
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 
 set(version 4.6.1)
 set(arch x86_64)

--- a/.gitlab/ci/config/ninja.cmake
+++ b/.gitlab/ci/config/ninja.cmake
@@ -16,7 +16,7 @@
 ##  PURPOSE.  See the above copyright notice for more information.
 ##============================================================================
 
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 
 set(version 1.11.0)
 

--- a/.gitlab/ci/ctest_test.cmake
+++ b/.gitlab/ci/ctest_test.cmake
@@ -19,7 +19,7 @@
 ##=============================================================================
 
 # We need this CMake versions for tests
-cmake_minimum_required(VERSION 3.12..3.15 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 
 # Read the files from the build directory that contain
 # host information ( name, parallel level, etc )

--- a/CMake/ViskoresCheckLicense.cmake
+++ b/CMake/ViskoresCheckLicense.cmake
@@ -23,7 +23,7 @@
 ## cmake -DViskores_SOURCE_DIR=<Viskores_SOURCE_DIR> -P <Viskores_SOURCE_DIR>/CMake/VISKORESCheckLicense.cmake
 ##
 
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.15)
 
 set(FILES_TO_CHECK
   *.txt

--- a/CMake/ViskoresDeviceAdapters.cmake
+++ b/CMake/ViskoresDeviceAdapters.cmake
@@ -77,7 +77,7 @@ if(Viskores_ENABLE_OPENMP AND NOT (TARGET viskores_openmp OR TARGET viskores::op
 endif()
 
 if(Viskores_ENABLE_CUDA)
-  cmake_minimum_required(VERSION 3.13...3.15 FATAL_ERROR)
+  cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
   enable_language(CUDA)
 
   if(CMAKE_CUDA_COMPILER_ID STREQUAL "NVIDIA" AND
@@ -320,7 +320,7 @@ function(kokkos_fix_compile_options)
 endfunction()
 
 if(Viskores_ENABLE_KOKKOS AND NOT TARGET viskores_kokkos)
-  cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+  cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 
   find_package(Kokkos 3.7 REQUIRED)
 

--- a/docs/users-guide/examples/ViskoresQuickStart.cmake
+++ b/docs/users-guide/examples/ViskoresQuickStart.cmake
@@ -21,7 +21,7 @@
 ####
 #### BEGIN-EXAMPLE QuickStartCMakeLists.txt
 ####
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.15)
 project(ViskoresQuickStart CXX)
 
 find_package(Viskores REQUIRED)

--- a/examples/clipping/CMakeLists.txt
+++ b/examples/clipping/CMakeLists.txt
@@ -15,7 +15,7 @@
 ##  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
 ##  PURPOSE.  See the above copyright notice for more information.
 ##============================================================================
-cmake_minimum_required(VERSION 3.12...3.15 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 project(Clipping CXX)
 
 #Find the Viskores package

--- a/examples/contour_tree/CMakeLists.txt
+++ b/examples/contour_tree/CMakeLists.txt
@@ -15,7 +15,7 @@
 ##  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
 ##  PURPOSE.  See the above copyright notice for more information.
 ##============================================================================
-cmake_minimum_required(VERSION 3.12...3.15 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 project(ContourTree CXX)
 
 #Find the Viskores package

--- a/examples/contour_tree_augmented/CMakeLists.txt
+++ b/examples/contour_tree_augmented/CMakeLists.txt
@@ -58,7 +58,7 @@
 ##  Hamish Carr (University of Leeds), Gunther H. Weber (LBNL), and
 ##  Oliver Ruebel (LBNL)
 ##==============================================================================
-cmake_minimum_required(VERSION 3.12...3.15 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 
 # Find the Viskores package
 find_package(Viskores REQUIRED QUIET)

--- a/examples/contour_tree_distributed/CMakeLists.txt
+++ b/examples/contour_tree_distributed/CMakeLists.txt
@@ -58,7 +58,7 @@
 ##  Hamish Carr (University of Leeds), Gunther H. Weber (LBNL), and
 ##  Oliver Ruebel (LBNL)
 ##==============================================================================
-cmake_minimum_required(VERSION 3.12...3.15 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 
 # Find the Viskores package
 find_package(Viskores REQUIRED QUIET)

--- a/examples/cosmotools/CMakeLists.txt
+++ b/examples/cosmotools/CMakeLists.txt
@@ -15,7 +15,7 @@
 ##  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
 ##  PURPOSE.  See the above copyright notice for more information.
 ##============================================================================
-cmake_minimum_required(VERSION 3.12...3.15 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 project(CosmoTools CXX)
 
 #Find the Viskores package

--- a/examples/demo/CMakeLists.txt
+++ b/examples/demo/CMakeLists.txt
@@ -15,7 +15,7 @@
 ##  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
 ##  PURPOSE.  See the above copyright notice for more information.
 ##============================================================================
-cmake_minimum_required(VERSION 3.12...3.15 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 project(ViskoresDemo CXX)
 
 #Find the Viskores package

--- a/examples/game_of_life/CMakeLists.txt
+++ b/examples/game_of_life/CMakeLists.txt
@@ -15,7 +15,7 @@
 ##  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
 ##  PURPOSE.  See the above copyright notice for more information.
 ##============================================================================
-cmake_minimum_required(VERSION 3.12...3.15 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 project(GameOfLife CXX)
 
 #Find the Viskores package

--- a/examples/hello_worklet/CMakeLists.txt
+++ b/examples/hello_worklet/CMakeLists.txt
@@ -15,7 +15,7 @@
 ##  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
 ##  PURPOSE.  See the above copyright notice for more information.
 ##============================================================================
-cmake_minimum_required(VERSION 3.12...3.15 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 project(HelloWorklet CXX)
 
 #Find the Viskores package

--- a/examples/histogram/CMakeLists.txt
+++ b/examples/histogram/CMakeLists.txt
@@ -15,7 +15,7 @@
 ##  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
 ##  PURPOSE.  See the above copyright notice for more information.
 ##============================================================================
-cmake_minimum_required(VERSION 3.12...3.15 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 project(Histogram CXX)
 
 #Find the Viskores package

--- a/examples/ising/CMakeLists.txt
+++ b/examples/ising/CMakeLists.txt
@@ -15,7 +15,7 @@
 ##  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
 ##  PURPOSE.  See the above copyright notice for more information.
 ##============================================================================
-cmake_minimum_required(VERSION 3.12...3.15 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 project(IsingModel CXX)
 
 #Find the Viskores package

--- a/examples/lagrangian/CMakeLists.txt
+++ b/examples/lagrangian/CMakeLists.txt
@@ -15,7 +15,7 @@
 ##  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
 ##  PURPOSE.  See the above copyright notice for more information.
 ##============================================================================
-cmake_minimum_required(VERSION 3.12...3.15 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 
 #Find the Viskores package
 find_package(Viskores REQUIRED QUIET)

--- a/examples/lagrangian_structures/CMakeLists.txt
+++ b/examples/lagrangian_structures/CMakeLists.txt
@@ -17,7 +17,7 @@
 ##  PURPOSE.  See the above copyright notice for more information.
 ##
 ##=============================================================================
-cmake_minimum_required(VERSION 3.12...3.15 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 project(ParticleAdvection CXX)
 
 #Find the Viskores package

--- a/examples/logistic_map/CMakeLists.txt
+++ b/examples/logistic_map/CMakeLists.txt
@@ -15,7 +15,7 @@
 ##  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
 ##  PURPOSE.  See the above copyright notice for more information.
 ##============================================================================
-cmake_minimum_required(VERSION 3.12...3.19 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15...3.19 FATAL_ERROR)
 project(LogisticMap CXX)
 
 find_package(Viskores REQUIRED QUIET)

--- a/examples/mesh_quality/CMakeLists.txt
+++ b/examples/mesh_quality/CMakeLists.txt
@@ -27,7 +27,7 @@
 ##  this software.
 ##
 ##=============================================================================
-cmake_minimum_required(VERSION 3.12...3.15 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 project(MeshQuality CXX)
 
 #Find the Viskores package

--- a/examples/multi_backend/CMakeLists.txt
+++ b/examples/multi_backend/CMakeLists.txt
@@ -15,7 +15,7 @@
 ##  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
 ##  PURPOSE.  See the above copyright notice for more information.
 ##============================================================================
-cmake_minimum_required(VERSION 3.12...3.15 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 project(MultiBackend CXX)
 
 #Find the Viskores package

--- a/examples/oscillator/CMakeLists.txt
+++ b/examples/oscillator/CMakeLists.txt
@@ -15,7 +15,7 @@
 ##  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
 ##  PURPOSE.  See the above copyright notice for more information.
 ##============================================================================
-cmake_minimum_required(VERSION 3.12...3.15 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 project(Oscillator CXX)
 
 #Find the Viskores package

--- a/examples/particle_advection/CMakeLists.txt
+++ b/examples/particle_advection/CMakeLists.txt
@@ -15,7 +15,7 @@
 ##  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
 ##  PURPOSE.  See the above copyright notice for more information.
 ##============================================================================
-cmake_minimum_required(VERSION 3.12...3.15 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 project(ParticleAdvection CXX)
 
 #Find the Viskores package

--- a/examples/polyline_archimedean_helix/CMakeLists.txt
+++ b/examples/polyline_archimedean_helix/CMakeLists.txt
@@ -15,7 +15,7 @@
 ##  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
 ##  PURPOSE.  See the above copyright notice for more information.
 ##============================================================================
-cmake_minimum_required(VERSION 3.12...3.15 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 project(PolyLineArchimedeanHelix CXX)
 
 find_package(Viskores REQUIRED QUIET)

--- a/examples/redistribute_points/CMakeLists.txt
+++ b/examples/redistribute_points/CMakeLists.txt
@@ -15,7 +15,7 @@
 ##  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
 ##  PURPOSE.  See the above copyright notice for more information.
 ##============================================================================
-cmake_minimum_required(VERSION 3.12...3.15 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 project(RedistributePoints CXX)
 
 #Find the Viskores package

--- a/examples/smoke_test/CMakeLists.txt
+++ b/examples/smoke_test/CMakeLists.txt
@@ -16,7 +16,7 @@
 ##  PURPOSE.  See the above copyright notice for more information.
 ##============================================================================
 
-cmake_minimum_required(VERSION 3.12...3.15 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 project(ViskoresSmokeTest CXX)
 include(CTest)
 

--- a/examples/streamline_mpi/CMakeLists.txt
+++ b/examples/streamline_mpi/CMakeLists.txt
@@ -15,7 +15,7 @@
 ##  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
 ##  PURPOSE.  See the above copyright notice for more information.
 ##============================================================================
-cmake_minimum_required(VERSION 3.12...3.15 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 project(StreamlineMPI CXX)
 
 #Find the Viskores package

--- a/examples/temporal_advection/CMakeLists.txt
+++ b/examples/temporal_advection/CMakeLists.txt
@@ -17,7 +17,7 @@
 ##============================================================================
 
 #Find the Viskores package
-cmake_minimum_required(VERSION 3.12...3.15 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 project(TemporalAdvection CXX)
 
 #Find the Viskores package

--- a/examples/tetrahedra/CMakeLists.txt
+++ b/examples/tetrahedra/CMakeLists.txt
@@ -15,7 +15,7 @@
 ##  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
 ##  PURPOSE.  See the above copyright notice for more information.
 ##============================================================================
-cmake_minimum_required(VERSION 3.12...3.15 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 project(Tetrahedra CXX)
 
 #Find the Viskores package

--- a/tutorial/CMakeLists.txt
+++ b/tutorial/CMakeLists.txt
@@ -23,7 +23,7 @@
 #file is, we can add the location to look to CMAKE_PREFIX_PATH.
 set(CMAKE_PREFIX_PATH ${Viskores_BINARY_DIR}/${Viskores_INSTALL_CONFIG_DIR})
 
-cmake_minimum_required(VERSION 3.12...3.15 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 project(Viskores_tut)
 
 #Find the Viskores package


### PR DESCRIPTION
The documentation states that the minimum CMake is 3.15, but several CMake configuration files considered earlier versions. Instead, use the real minimum to avoid issues with the CI.