### PR TITLE
Disable CellLocatorBoundingIntervalHierarchy

### DIFF
--- a/docs/users-guide/examples/GuideExampleCellLocator.cxx
+++ b/docs/users-guide/examples/GuideExampleCellLocator.cxx
@@ -21,7 +21,6 @@
 #include <viskores/worklet/WorkletMapField.h>
 
 #include <viskores/cont/ArrayCopy.h>
-#include <viskores/cont/CellLocatorBoundingIntervalHierarchy.h>
 #include <viskores/cont/CellLocatorChooser.h>
 #include <viskores/cont/CellLocatorGeneral.h>
 #include <viskores/cont/DataSetBuilderRectilinear.h>

--- a/docs/users-guide/locators.rst
+++ b/docs/users-guide/locators.rst
@@ -104,15 +104,15 @@ This is implemented with :class:`viskores::cont::CellLocatorUniformBins`.
 .. doxygenclass:: viskores::cont::CellLocatorUniformBins
    :members:
 
-In contrast, a very irregular data set may have multiple orders of magnitude difference in the size of its cells.
-If the cell distribution is very irregular, the :class:`viskores::cont::CellLocatorTwoLevel` can be left with bins containing a large number of cells in a regions with very small cells.
-In these cases, :class:`viskores::cont::CellLocatorBoundingIntervalHierarchy` can be used to capture the diversity in cell distribution.
-:class:`viskores::cont::CellLocatorBoundingIntervalHierarchy` builds a search structure by recursively dividing the space of cells.
-This creates a deeper structure than :class:`viskores::cont::CellLocatorTwoLevel`, so it can take longer to find a containing bin when searching for a cell.
-However, the deeper structure means that each bin is guaranteed to contain a small number of cells.
+.. In contrast, a very irregular data set may have multiple orders of magnitude difference in the size of its cells.
+.. If the cell distribution is very irregular, the :class:`viskores::cont::CellLocatorTwoLevel` can be left with bins containing a large number of cells in a regions with very small cells.
+.. In these cases, :class:`viskores::cont::CellLocatorBoundingIntervalHierarchy` can be used to capture the diversity in cell distribution.
+.. :class:`viskores::cont::CellLocatorBoundingIntervalHierarchy` builds a search structure by recursively dividing the space of cells.
+.. This creates a deeper structure than :class:`viskores::cont::CellLocatorTwoLevel`, so it can take longer to find a containing bin when searching for a cell.
+.. However, the deeper structure means that each bin is guaranteed to contain a small number of cells.
 
-.. doxygenclass:: viskores::cont::CellLocatorBoundingIntervalHierarchy
-   :members:
+.. .. doxygenclass:: viskores::cont::CellLocatorBoundingIntervalHierarchy
+..    :members:
 
 Cell Locators for Unknown Cell Sets
 ----------------------------------------

--- a/viskores/cont/CellLocatorBoundingIntervalHierarchy.h
+++ b/viskores/cont/CellLocatorBoundingIntervalHierarchy.h
@@ -21,6 +21,7 @@
 
 #include <viskores/cont/viskores_cont_export.h>
 
+#include <viskores/Deprecated.h>
 #include <viskores/Types.h>
 #include <viskores/cont/ArrayHandle.h>
 #include <viskores/cont/ArrayHandleTransform.h>
@@ -46,8 +47,10 @@ namespace cont
 /// The algorithm then recurses into each region and repeats the process until the regions
 /// are divided to the point where the contain no more than a maximum number of cells
 /// (specified with `SetMaxLeafSize()`).
-class VISKORES_CONT_EXPORT CellLocatorBoundingIntervalHierarchy
-  : public viskores::cont::CellLocatorBase
+class VISKORES_DEPRECATED(
+  1.2,
+  "CellLocatorBoundingIntervalHierarchy is deprecated. Use one of the other cell locator types.")
+  VISKORES_CONT_EXPORT CellLocatorBoundingIntervalHierarchy : public viskores::cont::CellLocatorBase
 {
 public:
   using SupportedCellSets = VISKORES_DEFAULT_CELL_SET_LIST;

--- a/viskores/cont/testing/UnitTestCellLocatorUnstructured.cxx
+++ b/viskores/cont/testing/UnitTestCellLocatorUnstructured.cxx
@@ -21,7 +21,6 @@
 #include <viskores/cont/Algorithm.h>
 #include <viskores/cont/ArrayCopy.h>
 #include <viskores/cont/ArrayHandleGroupVecVariable.h>
-#include <viskores/cont/CellLocatorBoundingIntervalHierarchy.h>
 #include <viskores/cont/CellLocatorTwoLevel.h>
 #include <viskores/cont/CellLocatorUniformBins.h>
 #include <viskores/cont/ConvertNumComponentsToOffsets.h>
@@ -618,11 +617,6 @@ void TestingCellLocatorUnstructured()
   TestCellLocator(locator2L, viskores::Id3(8), 512);  // 3D dataset
   TestCellLocator(locator2L, viskores::Id2(18), 512); // 2D dataset
   TestFindAllCells(locator2L);
-
-  viskores::cont::CellLocatorBoundingIntervalHierarchy locatorBIH;
-  std::cout << "Testing CellLocatorBoundingIntervalHierarchy" << std::endl;
-  TestCellLocator(locatorBIH, viskores::Id3(8), 512, false);  // 3D dataset
-  TestCellLocator(locatorBIH, viskores::Id2(18), 512, false); // 2D dataset
 
   //Test viskores::cont::CellLocatorUniformBins
   viskores::cont::CellLocatorUniformBins locatorUB;

--- a/viskores/exec/CellLocatorBoundingIntervalHierarchy.h
+++ b/viskores/exec/CellLocatorBoundingIntervalHierarchy.h
@@ -18,6 +18,7 @@
 #ifndef viskores_exec_CellLocatorBoundingIntervalHierarchy_h
 #define viskores_exec_CellLocatorBoundingIntervalHierarchy_h
 
+#include <viskores/Deprecated.h>
 #include <viskores/TopologyElementTag.h>
 #include <viskores/VecFromPortalPermute.h>
 #include <viskores/cont/ArrayHandle.h>
@@ -76,7 +77,10 @@ struct CellLocatorBoundingIntervalHierarchyNode
 /// This class is provided by `viskores::cont::CellLocatorBoundingIntervalHierarchy`
 /// when passed to a worklet.
 template <typename CellSetType>
-class VISKORES_ALWAYS_EXPORT CellLocatorBoundingIntervalHierarchy
+class VISKORES_DEPRECATED(
+  1.2,
+  "CellLocatorBoundingIntervalHierarchy is deprecated. Use one of the other cell locator types.")
+  VISKORES_ALWAYS_EXPORT CellLocatorBoundingIntervalHierarchy
 {
   using NodeArrayHandle =
     viskores::cont::ArrayHandle<viskores::exec::CellLocatorBoundingIntervalHierarchyNode>;

--- a/viskores/filter/flow/testing/UnitTestLagrangianFilter.cxx
+++ b/viskores/filter/flow/testing/UnitTestLagrangianFilter.cxx
@@ -17,7 +17,6 @@
 //============================================================================
 
 #include <iostream>
-#include <viskores/cont/CellLocatorBoundingIntervalHierarchy.h>
 #include <viskores/cont/DataSetBuilderUniform.h>
 #include <viskores/cont/testing/Testing.h>
 #include <viskores/filter/flow/Lagrangian.h>


### PR DESCRIPTION
Issue #183 describes a periodic failure in the unit tests for CellLocatorBoundingIntervalHierarchy. Disabling this test for now while the bug is investigated.