### PR TITLE
Probe filter with points

### DIFF
--- a/viskores/filter/resampling/Probe.cxx
+++ b/viskores/filter/resampling/Probe.cxx
@@ -15,6 +15,7 @@
 //  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
 //  PURPOSE.  See the above copyright notice for more information.
 //============================================================================
+#include <viskores/cont/DataSetBuilderExplicit.h>
 #include <viskores/cont/internal/CastInvalidValue.h>
 
 #include <viskores/filter/MapFieldPermutation.h>
@@ -93,6 +94,19 @@ bool DoMapField(viskores::cont::DataSet& result,
   }
 }
 } // anonymous namespace
+
+void Probe::SetGeometry(const viskores::cont::ArrayHandle<viskores::Vec3f>& points)
+{
+  viskores::Id numPoints = points.GetNumberOfValues();
+
+  viskores::cont::ArrayHandle<viskores::Id> connectivity;
+  viskores::cont::ArrayCopy(viskores::cont::make_ArrayHandleIndex(numPoints), connectivity);
+
+  auto ds = viskores::cont::DataSetBuilderExplicit::Create(
+    points, viskores::CellShapeTagVertex(), 1, connectivity);
+
+  this->SetGeometry(ds);
+}
 
 viskores::cont::DataSet Probe::DoExecute(const viskores::cont::DataSet& input)
 {

--- a/viskores/filter/resampling/Probe.h
+++ b/viskores/filter/resampling/Probe.h
@@ -18,6 +18,7 @@
 #ifndef viskores_filter_resampling_Probe_h
 #define viskores_filter_resampling_Probe_h
 
+#include <viskores/cont/ArrayCopy.h>
 #include <viskores/filter/Filter.h>
 #include <viskores/filter/resampling/viskores_filter_resampling_export.h>
 
@@ -52,6 +53,30 @@ public:
   {
     this->Geometry = viskores::cont::DataSet();
     this->Geometry.CopyStructure(geometry);
+  }
+
+  /// @brief Sets the geometry of the filter from an array of point coordinates.
+  ///
+  /// This convenience method constructs an explicit dataset internally, using
+  /// the provided array of 3D points as the coordinate system. Each point is
+  /// represented as a vertex cell (`CellSetSingleType` with cell type `Vertex`),
+  /// resulting in an explicit vertex dataset.
+  ///
+  /// The constructed dataset is then used as the input geometry for the filter.
+  /// This is equivalent to manually creating an explicit dataset with vertex
+  /// cells and passing it to `SetGeometry(const DataSet&)`.
+  ///
+  /// Note: The output dataset of the filter will contain:
+  ///   - A coordinate system defined by the input points.
+  ///   - A cell set of type `CellSetSingleType`, where each cell is a single
+  ///     vertex corresponding to one input point.
+  VISKORES_CONT void SetGeometry(const viskores::cont::ArrayHandle<viskores::Vec3f>& points);
+
+  /// @brief Convenience method for setting the geometry with an array of points.
+  VISKORES_CONT void SetGeometry(const std::vector<viskores::Vec3f>& points,
+                                 viskores::CopyFlag copyFlag = viskores::CopyFlag::On)
+  {
+    this->SetGeometry(viskores::cont::make_ArrayHandle(points, copyFlag));
   }
 
   /// @copydoc SetGeometry

--- a/viskores/filter/resampling/testing/UnitTestProbe.cxx
+++ b/viskores/filter/resampling/testing/UnitTestProbe.cxx
@@ -269,6 +269,7 @@ class TestProbe
 private:
   using FieldArrayType = viskores::cont::ArrayHandle<viskores::Float32>;
   using HiddenArrayType = viskores::cont::ArrayHandle<viskores::UInt8>;
+  using CoordArrayType = viskores::cont::ArrayHandle<viskores::Vec3f>;
 
   static void ExplicitToUnifrom()
   {
@@ -277,19 +278,39 @@ private:
     auto input = ConvertDataSetUniformToExplicit(MakeInputDataSet());
     auto geometry = MakeGeometryDataSet();
 
-    viskores::filter::resampling::Probe probe;
-    probe.SetGeometry(geometry);
-    probe.SetFieldsToPass({ "pointdata", "celldata" });
-    auto output = probe.Execute(input);
+    //Test dataset as geometry and points as geometry
+    for (int i = 0; i < 2; i++)
+    {
+      viskores::filter::resampling::Probe probe;
+      std::vector<viskores::UInt8> expectedHidenCellData;
 
-    TestResultArray(viskores::cont::Cast<FieldArrayType>(output.GetField("pointdata").GetData()),
-                    GetExpectedPointData());
-    TestResultArray(viskores::cont::Cast<FieldArrayType>(output.GetField("celldata").GetData()),
-                    GetExpectedCellData());
-    TestResultArray(viskores::cont::Cast<HiddenArrayType>(output.GetPointField("HIDDEN").GetData()),
-                    GetExpectedHiddenPoints());
-    TestResultArray(viskores::cont::Cast<HiddenArrayType>(output.GetCellField("HIDDEN").GetData()),
-                    GetExpectedHiddenCells());
+      if (i == 0)
+      {
+        probe.SetGeometry(geometry);
+        expectedHidenCellData = GetExpectedHiddenCells();
+      }
+      else
+      {
+        auto tmp = ConvertDataSetUniformToExplicit(geometry);
+        probe.SetGeometry(tmp.GetCoordinateSystem().GetData().AsArrayHandle<CoordArrayType>());
+        //Number of cells == number of points.
+        expectedHidenCellData = GetExpectedHiddenPoints();
+      }
+
+      probe.SetFieldsToPass({ "pointdata", "celldata" });
+      auto output = probe.Execute(input);
+
+      TestResultArray(viskores::cont::Cast<FieldArrayType>(output.GetField("pointdata").GetData()),
+                      GetExpectedPointData());
+      TestResultArray(viskores::cont::Cast<FieldArrayType>(output.GetField("celldata").GetData()),
+                      GetExpectedCellData());
+      TestResultArray(
+        viskores::cont::Cast<HiddenArrayType>(output.GetPointField("HIDDEN").GetData()),
+        GetExpectedHiddenPoints());
+      TestResultArray(
+        viskores::cont::Cast<HiddenArrayType>(output.GetCellField("HIDDEN").GetData()),
+        expectedHidenCellData);
+    }
   }
 
   static void UniformToExplict()
@@ -299,19 +320,38 @@ private:
     auto input = MakeInputDataSet();
     auto geometry = ConvertDataSetUniformToExplicit(MakeGeometryDataSet());
 
-    viskores::filter::resampling::Probe probe;
-    probe.SetGeometry(geometry);
-    probe.SetFieldsToPass({ "pointdata", "celldata" });
-    auto output = probe.Execute(input);
+    //Test dataset as geometry and points as geometry
+    for (int i = 0; i < 2; i++)
+    {
+      viskores::filter::resampling::Probe probe;
+      std::vector<viskores::UInt8> expectedHidenCellData;
 
-    TestResultArray(viskores::cont::Cast<FieldArrayType>(output.GetField("pointdata").GetData()),
-                    GetExpectedPointData());
-    TestResultArray(viskores::cont::Cast<FieldArrayType>(output.GetField("celldata").GetData()),
-                    GetExpectedCellData());
-    TestResultArray(viskores::cont::Cast<HiddenArrayType>(output.GetPointField("HIDDEN").GetData()),
-                    GetExpectedHiddenPoints());
-    TestResultArray(viskores::cont::Cast<HiddenArrayType>(output.GetCellField("HIDDEN").GetData()),
-                    GetExpectedHiddenCells());
+      if (i == 0)
+      {
+        probe.SetGeometry(geometry);
+        expectedHidenCellData = GetExpectedHiddenCells();
+      }
+      else
+      {
+        probe.SetGeometry(geometry.GetCoordinateSystem().GetData().AsArrayHandle<CoordArrayType>());
+        //Number of cells == number of points.
+        expectedHidenCellData = GetExpectedHiddenPoints();
+      }
+
+      probe.SetFieldsToPass({ "pointdata", "celldata" });
+      auto output = probe.Execute(input);
+
+      TestResultArray(viskores::cont::Cast<FieldArrayType>(output.GetField("pointdata").GetData()),
+                      GetExpectedPointData());
+      TestResultArray(
+        viskores::cont::Cast<HiddenArrayType>(output.GetPointField("HIDDEN").GetData()),
+        GetExpectedHiddenPoints());
+      TestResultArray(viskores::cont::Cast<FieldArrayType>(output.GetField("celldata").GetData()),
+                      GetExpectedCellData());
+      TestResultArray(
+        viskores::cont::Cast<HiddenArrayType>(output.GetCellField("HIDDEN").GetData()),
+        expectedHidenCellData);
+    }
   }
 
   static void ExplicitToExplict()
@@ -321,19 +361,38 @@ private:
     auto input = ConvertDataSetUniformToExplicit(MakeInputDataSet());
     auto geometry = ConvertDataSetUniformToExplicit(MakeGeometryDataSet());
 
-    viskores::filter::resampling::Probe probe;
-    probe.SetGeometry(geometry);
-    probe.SetFieldsToPass({ "pointdata", "celldata" });
-    auto output = probe.Execute(input);
+    //Test dataset as geometry and points as geometry
+    for (int i = 0; i < 2; i++)
+    {
+      viskores::filter::resampling::Probe probe;
+      std::vector<viskores::UInt8> expectedHidenCellData;
 
-    TestResultArray(viskores::cont::Cast<FieldArrayType>(output.GetField("pointdata").GetData()),
-                    GetExpectedPointData());
-    TestResultArray(viskores::cont::Cast<FieldArrayType>(output.GetField("celldata").GetData()),
-                    GetExpectedCellData());
-    TestResultArray(viskores::cont::Cast<HiddenArrayType>(output.GetPointField("HIDDEN").GetData()),
-                    GetExpectedHiddenPoints());
-    TestResultArray(viskores::cont::Cast<HiddenArrayType>(output.GetCellField("HIDDEN").GetData()),
-                    GetExpectedHiddenCells());
+      if (i == 0)
+      {
+        probe.SetGeometry(geometry);
+        expectedHidenCellData = GetExpectedHiddenCells();
+      }
+      else
+      {
+        probe.SetGeometry(geometry.GetCoordinateSystem().GetData().AsArrayHandle<CoordArrayType>());
+        //Number of cells == number of points.
+        expectedHidenCellData = GetExpectedHiddenPoints();
+      }
+
+      probe.SetFieldsToPass({ "pointdata", "celldata" });
+      auto output = probe.Execute(input);
+
+      TestResultArray(viskores::cont::Cast<FieldArrayType>(output.GetField("pointdata").GetData()),
+                      GetExpectedPointData());
+      TestResultArray(
+        viskores::cont::Cast<HiddenArrayType>(output.GetPointField("HIDDEN").GetData()),
+        GetExpectedHiddenPoints());
+      TestResultArray(viskores::cont::Cast<FieldArrayType>(output.GetField("celldata").GetData()),
+                      GetExpectedCellData());
+      TestResultArray(
+        viskores::cont::Cast<HiddenArrayType>(output.GetCellField("HIDDEN").GetData()),
+        expectedHidenCellData);
+    }
   }
 
 public:


### PR DESCRIPTION
add a convenience method to use viskores::filter::resampling::Probe with an array of points as the geometry. This saves the user from explicitly creating a viskores::cont::DataSet from the points in order to perform the probe.