### PR TITLE
Separate the storage for fields and coordinates

### DIFF
--- a/docs/changelog/separate-field-coord-storage.md
+++ b/docs/changelog/separate-field-coord-storage.md
@@ -1,0 +1,19 @@
+## Separated the storage types for fields and coordinate systems
+
+The storage types that are typically used for coordinate systems have been
+removed from `VISKORES_DEFAULT_STORAGE_LIST` and a new list named
+`VISKORES_DEFAULT_STORAGE_LIST_COORDINATES` contains the storage types typical
+for coordinate systems.
+
+Although a coordinate system is really just a field with a special attribute,
+there are special array types to represent structured coordinate systems that
+make little sense elsewhere. Previously, these types were listed for all fields.
+However, now there is a backup representation in `ArrayHandleSOAStride` that can
+reasonably represent these specific types. When operating directly on cells with
+a coordinate system, it may matter what the type of coordinate system array is
+because, for example, operations like gradients and location are much faster in
+axis-aligned coordinates. However, for general vector operations, there is
+little benefit to operating on the direct array type.
+
+To compensate for these two use cases, Viskores now provides separate storage
+lists for these two cases.

--- a/docs/users-guide/unknown-array-handle.rst
+++ b/docs/users-guide/unknown-array-handle.rst
@@ -227,6 +227,7 @@ The macros :c:macro:`VISKORES_DEFAULT_TYPE_LIST` and :c:macro:`VISKORES_DEFAULT_
 
 .. doxygendefine:: VISKORES_DEFAULT_TYPE_LIST
 .. doxygendefine:: VISKORES_DEFAULT_STORAGE_LIST
+.. doxygendefine:: VISKORES_DEFAULT_STORAGE_LIST_COORDINATES
 
 .. load-example:: UsingCastAndCallForTypes
    :file: GuideExampleUnknownArrayHandle.cxx

--- a/viskores/cont/CoordinateSystem.h
+++ b/viskores/cont/CoordinateSystem.h
@@ -96,12 +96,14 @@ private:
       viskores::cont::ArrayHandleCast<viskores::Vec3f, viskores::cont::ArrayHandle<Vec3f_nd, S>>;
   };
 
-  using ArraysFloatDefault = viskores::ListTransform<
-    viskores::ListRemoveIf<VISKORES_DEFAULT_STORAGE_LIST, StorageToArrayDefault::IsInvalid>,
-    StorageToArrayDefault::Transform>;
-  using ArraysFloatNonDefault = viskores::ListTransform<
-    viskores::ListRemoveIf<VISKORES_DEFAULT_STORAGE_LIST, StorageToArrayNonDefault::IsInvalid>,
-    StorageToArrayNonDefault::Transform>;
+  using ArraysFloatDefault =
+    viskores::ListTransform<viskores::ListRemoveIf<VISKORES_DEFAULT_STORAGE_LIST_COORDINATES,
+                                                   StorageToArrayDefault::IsInvalid>,
+                            StorageToArrayDefault::Transform>;
+  using ArraysFloatNonDefault =
+    viskores::ListTransform<viskores::ListRemoveIf<VISKORES_DEFAULT_STORAGE_LIST_COORDINATES,
+                                                   StorageToArrayNonDefault::IsInvalid>,
+                            StorageToArrayNonDefault::Transform>;
 
 public:
   using MultiplexerArrayType = //

--- a/viskores/cont/DefaultTypes.h.in
+++ b/viskores/cont/DefaultTypes.h.in
@@ -26,6 +26,8 @@
 //     should directly operate on (where applicable).
 // VISKORES_DEFAULT_STORAGE_LIST - a viskores::List of storage tags for fields that
 //     filters should directly operate on.
+// VISKORES_DEFAULT_STORAGE_LIST_COORDINATES - a viskores::List of storage tags similar to
+//     VISKORES_DEFAULT_STORAGE_LIST but with added storage types common in coordinate systems.
 // VISKORES_DEFAULT_CELL_SET_LIST_STRUCTURED - a viskores::List of viskores::cont::CellSet types
 //     that filters should operate on as a strutured cell set.
 // VISKORES_DEFAULT_CELL_SET_LIST_UNSTRUCTURED - a viskores::List of viskores::cont::CellSet types
@@ -71,6 +73,18 @@
 #define VISKORES_DEFAULT_STORAGE_LIST ::viskores::cont::StorageListCommon
 #endif // VISKORES_DEFAULT_STORAGE_LIST
 
+#ifndef VISKORES_DEFAULT_STORAGE_LIST_COORDINATES
+#include <viskores/cont/StorageList.h>
+
+/// @brief A list of default storage types to use for unknown arrays and coordinate systems.
+///
+/// This macro resolves to a `viskores::List` filled with storage tags for array
+/// containers that are typically expected in coordinate system arrays. This is
+/// similar to `VISKORES_DEFAULT_STORAGE_LIST` but has some added storage types
+/// common for coordinate systems but not other arrays.
+#define VISKORES_DEFAULT_STORAGE_LIST_COORDINATES ::viskores::cont::StorageListCoordinates
+#endif // VISKORES_DEFAULT_STORAGE_LIST_COORDINATES
+
 #ifndef VISKORES_DEFAULT_CELL_SET_LIST_STRUCTURED
 #include <viskores/cont/CellSetList.h>
 
@@ -104,7 +118,8 @@ namespace cont
 namespace internal
 {
 
-using CellSetList = viskores::ListAppend<VISKORES_DEFAULT_CELL_SET_LIST_STRUCTURED, VISKORES_DEFAULT_CELL_SET_LIST_UNSTRUCTURED>;
+using CellSetList = viskores::ListAppend<VISKORES_DEFAULT_CELL_SET_LIST_STRUCTURED,
+                                         VISKORES_DEFAULT_CELL_SET_LIST_UNSTRUCTURED>;
 
 }
 }

--- a/viskores/cont/StorageList.h
+++ b/viskores/cont/StorageList.h
@@ -33,12 +33,15 @@ namespace cont
 using StorageListBasic = viskores::List<viskores::cont::StorageTagBasic>;
 
 using StorageListCommon =
+  viskores::List<viskores::cont::StorageTagBasic, viskores::cont::StorageTagSOAStride>;
+
+using StorageListCoordinates =
   viskores::List<viskores::cont::StorageTagBasic,
+                 viskores::cont::StorageTagSOAStride,
                  viskores::cont::StorageTagUniformPoints,
                  viskores::cont::StorageTagCartesianProduct<viskores::cont::StorageTagBasic,
                                                             viskores::cont::StorageTagBasic,
-                                                            viskores::cont::StorageTagBasic>,
-                 viskores::cont::StorageTagSOAStride>;
+                                                            viskores::cont::StorageTagBasic>>;
 
 }
 } // namespace viskores::cont

--- a/viskores/cont/internal/DefaultTypesAscent.h.in
+++ b/viskores/cont/internal/DefaultTypesAscent.h.in
@@ -65,6 +65,12 @@ namespace internal
 using StorageListAscent = viskores::List<
   // Basic storage should always be included
   viskores::cont::StorageTagBasic,
+  // Catchall for other storage
+  viskores::cont::StorageTagSOAStride>;
+
+using StorageListCoordinatesAscent = viskores::List<
+  // Basic storage should always be included
+  viskores::cont::StorageTagBasic,
   // Support separate arrays for each component
   viskores::cont::StorageTagSOA,
   // Support uniform structured grids
@@ -77,9 +83,13 @@ using StorageListAscent = viskores::List<
   viskores::cont::StorageTagSOAStride>;
 
 }
+
 }
 } // namespace viskores::cont::internal
 
 #define VISKORES_DEFAULT_STORAGE_LIST ::viskores::cont::internal::StorageListAscent
+
+#define VISKORES_DEFAULT_STORAGE_LIST_COORDINATES \
+  ::viskores::cont::internal::StorageListCoordinatesAscent
 
 #endif //viskores_cont_internal_DefaultTypesAscent_h

--- a/viskores/cont/internal/DefaultTypesVTK.h.in
+++ b/viskores/cont/internal/DefaultTypesVTK.h.in
@@ -118,9 +118,9 @@ using CellListAllInVTK = viskores::ListAppend<CellListStructuredInVTK, CellListU
 using CellListAllOutVTK = viskores::ListAppend<CellListStructuredOutVTK, CellListUnstructuredOutVTK>;
 
 #ifdef VISKORES_ADD_XGC_DEFAULT_TYPES
-using StorageListField = viskores::ListAppend<
+using StorageListCoordinates = viskores::ListAppend<
   viskores::List<viskores::cont::StorageTagXGCCoordinates>,
-  viskores::cont::StorageListCommon>;
+  viskores::cont::StorageListCoordinates>;
 #endif
 
 } // end namespace toviskores
@@ -130,7 +130,7 @@ using StorageListField = viskores::ListAppend<
 #define VISKORES_DEFAULT_CELL_SET_LIST_UNSTRUCTURED ::toviskores::CellListUnstructuredInVTK
 
 #ifdef VISKORES_ADD_XGC_DEFAULT_TYPES
-#define VISKORES_DEFAULT_STORAGE_LIST ::toviskores::StorageListField
+#define VISKORES_DEFAULT_STORAGE_LIST_COORDINATES ::toviskores::StorageListCoordinates
 #endif
 
 #endif //viskores_cont_internal_DefaultTypesVTK_h

--- a/viskores/exec/CellLocatorTwoLevel.h
+++ b/viskores/exec/CellLocatorTwoLevel.h
@@ -118,7 +118,7 @@ private:
   using ReadPortal = typename viskores::cont::ArrayHandle<T>::ReadPortalType;
 
   using CoordsPortalType =
-    typename viskores::cont::CoordinateSystem::MultiplexerArrayType::ReadPortalType;
+    typename viskores::cont::ArrayHandleSOAStride<viskores::Vec3f>::ReadPortalType;
 
   // TODO: This function may return false positives for non 3D cells as the
   // tests are done on the projection of the point on the cell. Extra checks
@@ -168,7 +168,8 @@ public:
                                       viskores::TopologyElementTagCell{},
                                       viskores::TopologyElementTagPoint{},
                                       token))
-    , Coords(coords.GetDataAsMultiplexer().PrepareForInput(device, token))
+    , Coords(coords.GetData().ExtractArrayWithValueType<viskores::Vec3f>().PrepareForInput(device,
+                                                                                           token))
   {
   }
 


### PR DESCRIPTION
The storage types that are typically used for coordinate systems have been removed from `VISKORES_DEFAULT_STORAGE_LIST` and a new list named `VISKORES_DEFAULT_STORAGE_LIST_COORDINATES` contains the storage types typical for coordinate systems.

Although a coordinate system is really just a field with a special attribute, there are special array types to represent structured coordinate systems that make little sense elsewhere. Previously, these types were listed for all fields. However, now there is a backup representation in `ArrayHandleSOAStride` that can reasonably represent these specific types. When operating directly on cells with a coordinate system, it may matter what the type of coordinate system array is because, for example, operations like gradients and location are much faster in axis-aligned coordinates. However, for general vector operations, there is little benefit to operating on the direct array type.

To compensate for these two use cases, Viskores now provides separate storage lists for these two cases.