### PR TITLE
Fix compile issue with SYCL

### DIFF
--- a/docs/changelog/variant-union-destructor.md
+++ b/docs/changelog/variant-union-destructor.md
@@ -1,0 +1,19 @@
+## Fixed variant compilation for SYCL
+
+The SYCL compilation was running into a compile error with the destructor for
+`VariantUnionNTD`. The following compile error was issued.
+
+```
+viskores/internal/VariantImplDetail.h:232:19: error: SYCL kernel cannot call an undefined function without SYCL_EXTERNAL attribute
+232 | VISKORES_DEVICE ~VariantUnionNTD() { }
+```
+
+This is a strange error as the `VISKORES_DEVICE` should contain the method
+modifiers needed. Nevertheless, the problem can be solved by changing the
+destructor to be `default`.
+
+However, many compilers have a problem with default destructors. For very in the
+weeds reasons, the compiler removes the default destructor and causes subsequent
+compile issues. Using an explicit destructor seems like the "right" thing to do,
+but a special exception for SYCL compilations with C++20 and above uses a
+default destructor.

--- a/viskores/internal/VariantImplDetail.h
+++ b/viskores/internal/VariantImplDetail.h
@@ -229,7 +229,11 @@ union VariantUnionNTD<T0>
   T0 V0;
   VISKORES_DEVICE VariantUnionNTD(viskores::internal::NullType) { }
   VariantUnionNTD() = default;
+#if (__cplusplus >= 202002L) && defined(VISKORES_ICC)
+  ~VariantUnionNTD() = default;
+#else
   VISKORES_DEVICE ~VariantUnionNTD() { }
+#endif
 };
 
 template <typename T0, typename T1>
@@ -255,7 +259,11 @@ union VariantUnionNTD<T0, T1>
   T1 V1;
   VISKORES_DEVICE VariantUnionNTD(viskores::internal::NullType) { }
   VariantUnionNTD() = default;
+#if (__cplusplus >= 202002L) && defined(VISKORES_ICC)
+  ~VariantUnionNTD() = default;
+#else
   VISKORES_DEVICE ~VariantUnionNTD() { }
+#endif
 };
 
 template <typename T0, typename T1, typename T2>
@@ -283,7 +291,11 @@ union VariantUnionNTD<T0, T1, T2>
   T2 V2;
   VISKORES_DEVICE VariantUnionNTD(viskores::internal::NullType) { }
   VariantUnionNTD() = default;
+#if (__cplusplus >= 202002L) && defined(VISKORES_ICC)
+  ~VariantUnionNTD() = default;
+#else
   VISKORES_DEVICE ~VariantUnionNTD() { }
+#endif
 };
 
 template <typename T0, typename T1, typename T2, typename T3>
@@ -313,7 +325,11 @@ union VariantUnionNTD<T0, T1, T2, T3>
   T3 V3;
   VISKORES_DEVICE VariantUnionNTD(viskores::internal::NullType) { }
   VariantUnionNTD() = default;
+#if (__cplusplus >= 202002L) && defined(VISKORES_ICC)
+  ~VariantUnionNTD() = default;
+#else
   VISKORES_DEVICE ~VariantUnionNTD() { }
+#endif
 };
 
 template <typename T0, typename T1, typename T2, typename T3, typename T4>
@@ -345,7 +361,11 @@ union VariantUnionNTD<T0, T1, T2, T3, T4>
   T4 V4;
   VISKORES_DEVICE VariantUnionNTD(viskores::internal::NullType) { }
   VariantUnionNTD() = default;
+#if (__cplusplus >= 202002L) && defined(VISKORES_ICC)
+  ~VariantUnionNTD() = default;
+#else
   VISKORES_DEVICE ~VariantUnionNTD() { }
+#endif
 };
 
 template <typename T0, typename T1, typename T2, typename T3, typename T4, typename T5>
@@ -379,7 +399,11 @@ union VariantUnionNTD<T0, T1, T2, T3, T4, T5>
   T5 V5;
   VISKORES_DEVICE VariantUnionNTD(viskores::internal::NullType) { }
   VariantUnionNTD() = default;
+#if (__cplusplus >= 202002L) && defined(VISKORES_ICC)
+  ~VariantUnionNTD() = default;
+#else
   VISKORES_DEVICE ~VariantUnionNTD() { }
+#endif
 };
 
 template <typename T0, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6>
@@ -415,7 +439,11 @@ union VariantUnionNTD<T0, T1, T2, T3, T4, T5, T6>
   T6 V6;
   VISKORES_DEVICE VariantUnionNTD(viskores::internal::NullType) { }
   VariantUnionNTD() = default;
+#if (__cplusplus >= 202002L) && defined(VISKORES_ICC)
+  ~VariantUnionNTD() = default;
+#else
   VISKORES_DEVICE ~VariantUnionNTD() { }
+#endif
 };
 
 template <typename T0, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7>
@@ -453,7 +481,11 @@ union VariantUnionNTD<T0, T1, T2, T3, T4, T5, T6, T7>
   T7 V7;
   VISKORES_DEVICE VariantUnionNTD(viskores::internal::NullType) { }
   VariantUnionNTD() = default;
+#if (__cplusplus >= 202002L) && defined(VISKORES_ICC)
+  ~VariantUnionNTD() = default;
+#else
   VISKORES_DEVICE ~VariantUnionNTD() { }
+#endif
 };
 
 
@@ -499,7 +531,11 @@ union VariantUnionNTD<T0, T1, T2, T3, T4, T5, T6, T7, T8, Ts...>
 
   VISKORES_DEVICE VariantUnionNTD(viskores::internal::NullType) { }
   VariantUnionNTD() = default;
+#if (__cplusplus >= 202002L) && defined(VISKORES_ICC)
+  ~VariantUnionNTD() = default;
+#else
   VISKORES_DEVICE ~VariantUnionNTD() { }
+#endif
 };
 
 //clang-format on

--- a/viskores/internal/VariantImplDetail.h.in
+++ b/viskores/internal/VariantImplDetail.h.in
@@ -267,7 +267,11 @@ $for(param_index in range(param_length + 1))\
 $endfor\
   VISKORES_DEVICE VariantUnionNTD(viskores::internal::NullType) { }
   VariantUnionNTD() = default;
+#if (__cplusplus >= 202002L) && defined(VISKORES_ICC)
+  ~VariantUnionNTD() = default;
+#else
   VISKORES_DEVICE ~VariantUnionNTD() { }
+#endif
 };
 
 $endfor\
@@ -304,7 +308,11 @@ $endfor\
 
   VISKORES_DEVICE VariantUnionNTD(viskores::internal::NullType) { }
   VariantUnionNTD() = default;
+#if (__cplusplus >= 202002L) && defined(VISKORES_ICC)
+  ~VariantUnionNTD() = default;
+#else
   VISKORES_DEVICE ~VariantUnionNTD() { }
+#endif
 };
 
 //clang-format on


### PR DESCRIPTION
The latest SYCL compiler has a problem with how the destructor of the variant union was declared.