### PR TITLE
Always use std to check for class triviality

### DIFF
--- a/docs/changelog/always-check-is-trivial.md
+++ b/docs/changelog/always-check-is-trivial.md
@@ -1,0 +1,20 @@
+## Checking of class triviality is improved
+
+When Viskores packages classes to send between host and device as well as when
+Viskores usings Variants to build unions of objects, it can be important to
+check trivial aspects of classes. For example, it is sometimes important to know
+whether the class executes code for its constructors or destructor.
+
+Early forms of Viskores (actually its predecessor VTK-m) used compilers that did
+not give reliable results for `std::is_trivial` and related type checks. To get
+around this problem on these compilers, Viskores implemented alternate forms of
+these checks that reported nothing as trivial so that proper construction copy
+or destruction happened. This alternate implementation also reported that
+everything _was_ trivial during assert checks in places where objects needed to
+be memory copied. (Other compilers were used to ensure that these checks passed
+correctly.)
+
+Now that Viskores requires C++17 or better, compilers _should_ properly
+implement these checks that have been around since C++11. Thus, the workarounds
+for bad implementations of `std::is_trivial` should not be necessary, and they
+have been removed.

--- a/viskoresstd/is_trivial.h
+++ b/viskoresstd/is_trivial.h
@@ -23,7 +23,12 @@
 
 #include <type_traits>
 
-#if defined(VISKORES_GCC) && !defined(VISKORES_USING_GLIBCXX_4)
+// In the early days of C++11/14, we had issues with some compilers (GCC 4.9 and
+// some versions of Clang) not implementing the is_trivial traits correctly.
+// With that C++ version in our rear-view mirror, we should be able to rely on
+// the the compiler's is_trivial.
+// #if defined(VISKORES_GCC) && !defined(VISKORES_USING_GLIBCXX_4)
+#if 1
 #define VISKORES_USE_STD_IS_TRIVIAL
 #endif
 


### PR DESCRIPTION
When Viskores packages classes to send between host and device as well as when Viskores usings Variants to build unions of objects, it can be important to check trivial aspects of classes. For example, it is sometimes important to know whether the class executes code for its constructors or destructor.

Early forms of Viskores (actually its predecessor VTK-m) used compilers that did not give reliable results for `std::is_trivial` and related type checks. To get around this problem on these compilers, Viskores implemented alternate forms of these checks that reported nothing as trivial so that proper construction copy or destruction happened. This alternate implementation also reported that everything _was_ trivial during assert checks in places where objects needed to be memory copied. (Other compilers were used to ensure that these checks passed correctly.)

Now that Viskores requires C++17 or better, compilers _should_ properly implement these checks that have been around since C++11. Thus, the workarounds for bad implementations of `std::is_trivial` should not be necessary, and they have been removed.