### PR TITLE
Remove redundant version information from libraries

### DIFF
--- a/CMake/ViskoresWrappers.cmake
+++ b/CMake/ViskoresWrappers.cmake
@@ -533,8 +533,6 @@ function(viskores_library)
   # their own version numbers etc.
   if(DEFINED Viskores_CUSTOM_LIBRARY_SUFFIX)
     set(_lib_suffix "${Viskores_CUSTOM_LIBRARY_SUFFIX}")
-  else()
-    set(_lib_suffix "-${Viskores_VERSION_MAJOR}.${Viskores_VERSION_MINOR}")
   endif()
   set_property(TARGET ${lib_name} PROPERTY OUTPUT_NAME ${lib_name}${_lib_suffix})
 

--- a/docs/changelog/lib-version-name.md
+++ b/docs/changelog/lib-version-name.md
@@ -1,0 +1,6 @@
+## Removed redundant version information from libraries
+
+The Viskores library files were created with redundant version information. The
+library name added the major.minor numbers to the filename, but then CMake
+automatically added these numbers a second time. This redundant information has
+been removed.


### PR DESCRIPTION
The Viskores library files were created with redundant version information. The library name added the major.minor numbers to the filename, but then CMake automatically added these numbers a second time. This redundant information has been removed.