### PR TITLE
Simplify code for ArrayHandleSOA portal (backport)

### DIFF
--- a/viskores/cont/ArrayExtractComponent.h
+++ b/viskores/cont/ArrayExtractComponent.h
@@ -52,7 +52,7 @@ ArrayExtractComponentFallback(const viskores::cont::ArrayHandle<T, S>& src,
 {
   if (allowCopy != viskores::CopyFlag::On)
   {
-    throw viskores::cont::ErrorBadValue(
+    throw viskores::cont::ErrorBadType(
       "Cannot extract component of " +
       viskores::cont::TypeToString<viskores::cont::ArrayHandle<T, S>>() + " without copying");
   }

--- a/viskores/cont/ArrayHandleSOA.h
+++ b/viskores/cont/ArrayHandleSOA.h
@@ -44,7 +44,7 @@ namespace internal
 /// This will only work if \c VecTraits is defined for the type.
 ///
 template <typename ValueType_, typename ComponentPortalType>
-class ArrayPortalSOA
+class ArrayPortalSOARead
 {
 public:
   using ValueType = ValueType_;
@@ -54,74 +54,49 @@ private:
   using ComponentType = typename VTraits::ComponentType;
   static constexpr viskores::IdComponent NUM_COMPONENTS = VTraits::NUM_COMPONENTS;
 
+protected:
   ComponentPortalType Portals[NUM_COMPONENTS];
-  viskores::Id NumberOfValues;
 
 public:
-  VISKORES_SUPPRESS_EXEC_WARNINGS
-  VISKORES_EXEC_CONT explicit ArrayPortalSOA(viskores::Id numValues = 0)
-    : NumberOfValues(numValues)
-  {
-  }
-
-  VISKORES_SUPPRESS_EXEC_WARNINGS
-  VISKORES_EXEC_CONT void SetPortal(viskores::IdComponent index, const ComponentPortalType& portal)
+  VISKORES_CONT void SetPortal(viskores::IdComponent index, const ComponentPortalType& portal)
   {
     this->Portals[index] = portal;
   }
 
-  VISKORES_EXEC_CONT viskores::Id GetNumberOfValues() const { return this->NumberOfValues; }
+  VISKORES_EXEC_CONT viskores::Id GetNumberOfValues() const
+  {
+    return this->Portals[0].GetNumberOfValues();
+  }
 
-  template <typename SPT = ComponentPortalType,
-            typename Supported = typename viskores::internal::PortalSupportsGets<SPT>::type,
-            typename = typename std::enable_if<Supported::value>::type>
   VISKORES_EXEC_CONT ValueType Get(viskores::Id valueIndex) const
   {
-    return this->Get(valueIndex, viskoresstd::make_index_sequence<NUM_COMPONENTS>());
-  }
-
-  template <typename SPT = ComponentPortalType,
-            typename Supported = typename viskores::internal::PortalSupportsSets<SPT>::type,
-            typename = typename std::enable_if<Supported::value>::type>
-  VISKORES_EXEC_CONT void Set(viskores::Id valueIndex, const ValueType& value) const
-  {
-    this->Set(valueIndex, value, viskoresstd::make_index_sequence<NUM_COMPONENTS>());
-  }
-
-private:
-  VISKORES_SUPPRESS_EXEC_WARNINGS
-  template <std::size_t I>
-  VISKORES_EXEC_CONT bool GetComponent(ValueType& value, viskores::Id valueIndex) const
-  {
-    VTraits::SetComponent(value, I, this->Portals[I].Get(valueIndex));
-    return true;
-  }
-
-  template <std::size_t... I>
-  VISKORES_EXEC_CONT ValueType Get(viskores::Id valueIndex, viskoresstd::index_sequence<I...>) const
-  {
     ValueType value;
-    // Is there a better way to unpack an expression and execute them with no other side effects?
-    (void)std::initializer_list<bool>{ this->GetComponent<I>(value, valueIndex)... };
+    for (viskores::IdComponent compIndex = 0; compIndex < NUM_COMPONENTS; ++compIndex)
+    {
+      VTraits::SetComponent(value, compIndex, this->Portals[compIndex].Get(valueIndex));
+    }
     return value;
   }
+};
 
-  VISKORES_SUPPRESS_EXEC_WARNINGS
-  template <std::size_t I>
-  VISKORES_EXEC_CONT bool SetComponent(viskores::Id valueIndex, const ValueType& value) const
-  {
-    this->Portals[I].Set(valueIndex,
-                         VTraits::GetComponent(value, static_cast<viskores::IdComponent>(I)));
-    return true;
-  }
+template <typename ValueType_, typename ComponentPortalType>
+class ArrayPortalSOAWrite : public ArrayPortalSOARead<ValueType_, ComponentPortalType>
+{
+public:
+  using ValueType = ValueType_;
 
-  template <std::size_t... I>
-  VISKORES_EXEC_CONT void Set(viskores::Id valueIndex,
-                              const ValueType& value,
-                              viskoresstd::index_sequence<I...>) const
+private:
+  using VTraits = viskores::VecTraits<ValueType>;
+  using ComponentType = typename VTraits::ComponentType;
+  static constexpr viskores::IdComponent NUM_COMPONENTS = VTraits::NUM_COMPONENTS;
+
+public:
+  VISKORES_EXEC_CONT void Set(viskores::Id valueIndex, const ValueType& value) const
   {
-    // Is there a better way to unpack an expression and execute them with no other side effects?
-    (void)std::initializer_list<bool>{ this->SetComponent<I>(valueIndex, value)... };
+    for (viskores::IdComponent compIndex = 0; compIndex < NUM_COMPONENTS; ++compIndex)
+    {
+      this->Portals[compIndex].Set(valueIndex, VTraits::GetComponent(value, compIndex));
+    }
   }
 };
 
@@ -145,11 +120,10 @@ class VISKORES_ALWAYS_EXPORT
 
 public:
   using ReadPortalType =
-    viskores::internal::ArrayPortalSOA<ValueType,
-                                       viskores::internal::ArrayPortalBasicRead<ComponentType>>;
-  using WritePortalType =
-    viskores::internal::ArrayPortalSOA<ValueType,
-                                       viskores::internal::ArrayPortalBasicWrite<ComponentType>>;
+    viskores::internal::ArrayPortalSOARead<ValueType,
+                                           viskores::internal::ArrayPortalBasicRead<ComponentType>>;
+  using WritePortalType = viskores::internal::
+    ArrayPortalSOAWrite<ValueType, viskores::internal::ArrayPortalBasicWrite<ComponentType>>;
 
   VISKORES_CONT static std::vector<viskores::cont::internal::Buffer> CreateBuffers()
   {
@@ -209,7 +183,7 @@ public:
     viskores::cont::Token& token)
   {
     viskores::Id numValues = GetNumberOfValues(buffers);
-    ReadPortalType portal(numValues);
+    ReadPortalType portal;
     for (viskores::IdComponent componentIndex = 0; componentIndex < NUM_COMPONENTS;
          ++componentIndex)
     {
@@ -229,7 +203,7 @@ public:
     viskores::cont::Token& token)
   {
     viskores::Id numValues = GetNumberOfValues(buffers);
-    WritePortalType portal(numValues);
+    WritePortalType portal;
     for (viskores::IdComponent componentIndex = 0; componentIndex < NUM_COMPONENTS;
          ++componentIndex)
     {

--- a/viskores/cont/ArrayHandleSOAStride.cxx
+++ b/viskores/cont/ArrayHandleSOAStride.cxx
@@ -27,6 +27,7 @@ namespace cont
 {
 
 #define VISKORES_ARRAYHANDLE_SOA_STRIDE_INSTANTIATE(Type)                                       \
+  template class VISKORES_CONT_EXPORT ArrayHandle<Type, StorageTagSOAStride>;                   \
   template class VISKORES_CONT_EXPORT ArrayHandle<viskores::Vec<Type, 2>, StorageTagSOAStride>; \
   template class VISKORES_CONT_EXPORT ArrayHandle<viskores::Vec<Type, 3>, StorageTagSOAStride>; \
   template class VISKORES_CONT_EXPORT ArrayHandle<viskores::Vec<Type, 4>, StorageTagSOAStride>;

--- a/viskores/cont/ArrayHandleStride.h
+++ b/viskores/cont/ArrayHandleStride.h
@@ -32,10 +32,10 @@ namespace internal
 struct ArrayStrideInfo
 {
   viskores::Id NumberOfValues = 0;
-  viskores::Id Stride = 1;
-  viskores::Id Offset = 0;
-  viskores::Id Modulo = 0;
-  viskores::Id Divisor = 0;
+  viskores::IdComponent Stride = 1;
+  viskores::IdComponent Offset = 0;
+  viskores::IdComponent Modulo = 0;
+  viskores::IdComponent Divisor = 0;
 
   ArrayStrideInfo() = default;
 

--- a/viskores/cont/testing/UnitTestArrayHandleSOA.cxx
+++ b/viskores/cont/testing/UnitTestArrayHandleSOA.cxx
@@ -54,10 +54,11 @@ struct TestArrayPortalSOA
     using ValueType = viskores::Vec<ComponentType, NUM_COMPONENTS>;
     using ComponentArrayType = viskores::cont::ArrayHandle<ComponentType>;
     using SOAPortalType =
-      viskores::internal::ArrayPortalSOA<ValueType, typename ComponentArrayType::WritePortalType>;
+      viskores::internal::ArrayPortalSOAWrite<ValueType,
+                                              typename ComponentArrayType::WritePortalType>;
 
     std::cout << "Test SOA portal reflects data in component portals." << std::endl;
-    SOAPortalType soaPortalIn(ARRAY_SIZE);
+    SOAPortalType soaPortalIn;
 
     std::array<viskores::cont::ArrayHandle<ComponentType>, NUM_COMPONENTS> implArrays;
     for (viskores::IdComponent componentIndex = 0; componentIndex < NUM_COMPONENTS;
@@ -81,7 +82,7 @@ struct TestArrayPortalSOA
 
     std::cout << "Test data set in SOA portal gets set in component portals." << std::endl;
     {
-      SOAPortalType soaPortalOut(ARRAY_SIZE);
+      SOAPortalType soaPortalOut;
       for (viskores::IdComponent componentIndex = 0; componentIndex < NUM_COMPONENTS;
            ++componentIndex)
       {

--- a/viskores/cont/testing/UnitTestUnknownArrayHandle.cxx
+++ b/viskores/cont/testing/UnitTestUnknownArrayHandle.cxx
@@ -177,6 +177,7 @@ void CheckAsArrayHandle(const ArrayHandleType& array)
     ArrayHandleType retreivedArray2 = arrayUnknown.AsArrayHandle<ArrayHandleType>();
     VISKORES_TEST_ASSERT(array == retreivedArray2, "Did not get back same array.");
 
+    std::cout << "    Get as SOA Stride" << std::endl;
     viskores::cont::ArrayHandleSOAStride<T> strideArray;
     arrayUnknown.AsArrayHandle(strideArray);
     VISKORES_TEST_ASSERT(test_equal_ArrayHandles(array, strideArray),


### PR DESCRIPTION
The ArrayPortalSOA had some clever template code to set and get values in multiple arrays. However, we have found that some device compilers get bogged down resolving all these template parameters in kernels and the complexity of the code, so the code has been significantly simplified.

We have also removed support for div and mod in SOAStride. This reduces the storage and code required for the array portal.

However, since div and mod are not supported there, some tests need to be cleaned up. Also needed some exceptions suppressed and replaced with workarounds and warnings.