### PR TITLE
Initial ANARI device

### DIFF
--- a/CMake/ViskoresCheckLicense.cmake
+++ b/CMake/ViskoresCheckLicense.cmake
@@ -46,6 +46,9 @@ set(EXCEPTIONS
   DCO.txt
   README.txt
   docs/users-guide/requirements.txt
+  # Common directories with build files
+  .venv
+  build
   )
 
 if (NOT Viskores_SOURCE_DIR)

--- a/CMake/testing/ViskoresCheckSourceInInstall.cmake
+++ b/CMake/testing/ViskoresCheckSourceInInstall.cmake
@@ -125,6 +125,9 @@ function(do_verify root_dir prefix)
   string(REPLACE ":" ";" directory_exceptions "${DIR_EXCEPTIONS}")
   #by default every header in a testing directory doesn't need to be installed
   list(APPEND directory_exceptions ".*/testing")
+  # ANARI device should only be accessed through ANARI interface.
+  # Headers do not need to be installed.
+  list(APPEND directory_exceptions "rendering/anari-device")
   # These exceptions should be based on the status of the associated
   # cmake option
   if (NOT Viskores_ENABLE_HDF5_IO)

--- a/docs/changelog/anari-device.md
+++ b/docs/changelog/anari-device.md
@@ -1,0 +1,13 @@
+## New ANARI device enabled by Viskores
+
+Viskores now provides an ANARI device that can be used by applications that use
+ANARI for rendering. The intention of this device is to provide a simple,
+portable, accelerated ANARI device that will be available in HPC systems
+regardless of vendor support. We hope this will help jumpstart the support of
+ANARI for scientific visualization applications at HPC centers.
+
+This device is still in its experimental phase. Although functional, it is
+missing many features that applications will expect to be supported. The
+inclusion of the device into Viskores in this early phase should help promote
+development and simplify the integration of any changes necessary in the
+rendering library.

--- a/viskores/rendering/anari-device/CMakeLists.txt
+++ b/viskores/rendering/anari-device/CMakeLists.txt
@@ -1,0 +1,87 @@
+##=============================================================================
+##
+##  The contents of this file are covered by the Viskores license. See
+##  LICENSE.txt for details.
+##
+##  By contributing to this file, all contributors agree to the Developer
+##  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+##
+##=============================================================================
+
+find_package(anari 0.15.0 REQUIRED)
+
+## Build device target ##
+
+set (sources
+  ViskoresDevice.cpp
+  ViskoresDeviceGlobalState.cpp
+  ViskoresLibrary.cpp
+  Object.cpp
+  array/Array1D.cpp
+  array/Array2D.cpp
+  array/Array3D.cpp
+  array/ObjectArray.cpp
+  camera/Camera.cpp
+  camera/Orthographic.cpp
+  camera/Perspective.cpp
+  renderer/Renderer.cpp
+  scene/Group.cpp
+  scene/Instance.cpp
+  scene/World.cpp
+  scene/light/Light.cpp
+  scene/surface/Surface.cpp
+  scene/surface/geometry/Geometry.cpp
+  scene/surface/geometry/Triangle.cpp
+  scene/surface/geometry/Sphere.cpp
+  scene/surface/material/Material.cpp
+  scene/surface/material/MatteMaterial.cpp
+  scene/surface/material/sampler/Image1DSampler.cpp
+  scene/surface/material/sampler/Sampler.cpp
+  scene/volume/TransferFunction1D.cpp
+  scene/volume/Volume.cpp
+  scene/volume/spatial_field/SpatialField.cpp
+  scene/volume/spatial_field/StructuredRegularField.cpp
+  )
+
+set(device_sources
+  array/ArrayConversion.cpp
+  frame/Frame.cpp
+  )
+
+viskores_library(
+  NAME anari_library_viskores
+  SOURCES ${sources}
+  DEVICE_SOURCES ${device_sources}
+  )
+
+target_link_libraries(anari_library_viskores
+PRIVATE
+  anari::helium
+  )
+
+include(GenerateExportHeader)
+generate_export_header(anari_library_viskores
+  EXPORT_MACRO_NAME "VISKORES_LIBRARY_INTERFACE"
+)
+
+target_include_directories(anari_library_viskores
+PRIVATE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+)
+
+## Code generation ##
+
+anari_generate_queries(
+  DEVICE_TARGET anari_library_viskores
+  CPP_NAMESPACE viskores_device
+  JSON_DEFINITIONS_FILE ${CMAKE_CURRENT_SOURCE_DIR}/viskores_device.json
+)
+
+## Installation ##
+
+install(TARGETS anari_library_viskores
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)

--- a/viskores/rendering/anari-device/Object.cpp
+++ b/viskores/rendering/anari-device/Object.cpp
@@ -1,0 +1,88 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#include "Object.h"
+
+namespace viskores_device
+{
+
+// Object definitions /////////////////////////////////////////////////////////
+
+Object::Object(ANARIDataType type, ViskoresDeviceGlobalState* s)
+  : helium::BaseObject(type, s)
+{
+}
+
+bool Object::getProperty(const std::string_view& name,
+                         ANARIDataType type,
+                         void* ptr,
+                         uint64_t size,
+                         uint32_t flags)
+{
+  (void)size;  // ignored
+  (void)flags; // ignored
+  if (name == "valid" && type == ANARI_BOOL)
+  {
+    helium::writeToVoidP(ptr, isValid());
+    return true;
+  }
+
+  return false;
+}
+
+bool Object::isValid() const
+{
+  return true;
+}
+
+ViskoresDeviceGlobalState* Object::deviceState() const
+{
+  return (ViskoresDeviceGlobalState*)helium::BaseObject::m_state;
+}
+
+void Object::printParameters()
+{
+  for (auto&& paramItr = this->params_begin(); paramItr != this->params_end(); ++paramItr)
+  {
+    std::cout << paramItr->first << "\n";
+  }
+}
+
+// UnknownObject definitions //////////////////////////////////////////////////
+
+UnknownObject::UnknownObject(ANARIDataType type, ViskoresDeviceGlobalState* s)
+  : Object(type, s)
+{
+  s->objectCounts.unknown++;
+}
+
+UnknownObject::~UnknownObject()
+{
+  deviceState()->objectCounts.unknown--;
+}
+
+void UnknownObject::commitParameters()
+{
+  // no-op
+}
+
+void UnknownObject::finalize()
+{
+  // no-op
+}
+
+bool UnknownObject::isValid() const
+{
+  return false;
+}
+
+} // namespace viskores_device
+
+VISKORES_ANARI_TYPEFOR_DEFINITION(viskores_device::Object*);

--- a/viskores/rendering/anari-device/Object.h
+++ b/viskores/rendering/anari-device/Object.h
@@ -1,0 +1,53 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#pragma once
+
+#include "ViskoresDeviceGlobalState.h"
+#include "viskores_device_math.h"
+// helium
+#include <helium/BaseObject.h>
+#include <helium/utility/ChangeObserverPtr.h>
+// std
+#include <string_view>
+
+namespace viskores_device
+{
+
+struct Object : public helium::BaseObject
+{
+  Object(ANARIDataType type, ViskoresDeviceGlobalState* s);
+  virtual ~Object() = default;
+
+  bool getProperty(const std::string_view& name,
+                   ANARIDataType type,
+                   void* ptr,
+                   uint64_t size,
+                   uint32_t flags) override;
+
+  bool isValid() const override;
+
+  ViskoresDeviceGlobalState* deviceState() const;
+
+  void printParameters();
+};
+
+struct UnknownObject : public Object
+{
+  UnknownObject(ANARIDataType type, ViskoresDeviceGlobalState* s);
+  ~UnknownObject() override;
+  void commitParameters() override;
+  void finalize() override;
+  bool isValid() const override;
+};
+
+} // namespace viskores_device
+
+VISKORES_ANARI_TYPEFOR_SPECIALIZATION(viskores_device::Object*, ANARI_OBJECT);

--- a/viskores/rendering/anari-device/README.md
+++ b/viskores/rendering/anari-device/README.md
@@ -1,0 +1,14 @@
+## Viskores Implementation of an ANARI Rendering Device
+
+This code provides an implementation of an ANARI rendering device that uses
+functionality in Viskores worklets to generate images. This device can be used
+both for Viskores applications as well as other ANARI clients that do not use
+Viskores. Clients use the standard ANARI device connection to the device named
+`viskores`, which should link to the `libanari_library_viskores.so` shared
+library (or equivalent name for the OS being used).
+
+This implementation is based on the Helium device stubs provided by the ANARI
+SDK. Because the code in this directory is an ANARI implementation, the coding
+style in this directory deviates from that typical elsewhere in Viskores. In
+particular, things like file extensions, identifier names, and include
+conventions are different than elsewhere in Viskores.

--- a/viskores/rendering/anari-device/RenderingSemaphore.h
+++ b/viskores/rendering/anari-device/RenderingSemaphore.h
@@ -1,0 +1,67 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#pragma once
+
+#include <condition_variable>
+#include <mutex>
+
+namespace viskores_device
+{
+
+struct RenderingSemaphore
+{
+  RenderingSemaphore() = default;
+
+  void arrayMapAcquire();
+  void arrayMapRelease();
+
+  void frameStart();
+  void frameEnd();
+
+private:
+  std::mutex m_mutex;
+  std::condition_variable m_conditionArrays;
+  std::condition_variable m_conditionFrame;
+  unsigned long m_arraysMapped{ 0 };
+  bool m_frameInFlight{ false };
+};
+
+// Inlined definitions ////////////////////////////////////////////////////////
+
+inline void RenderingSemaphore::arrayMapAcquire()
+{
+  std::unique_lock<std::mutex> frameLock(m_mutex);
+  m_conditionFrame.wait(frameLock, [&]() { return !m_frameInFlight; });
+  m_arraysMapped++;
+}
+
+inline void RenderingSemaphore::arrayMapRelease()
+{
+  std::lock_guard<std::mutex> lock(m_mutex);
+  m_arraysMapped--;
+  if (m_arraysMapped == 0)
+    m_conditionArrays.notify_one();
+}
+
+inline void RenderingSemaphore::frameStart()
+{
+  std::unique_lock<std::mutex> arraysLock(m_mutex);
+  m_conditionArrays.wait(arraysLock, [&]() { return m_arraysMapped == 0; });
+  m_frameInFlight = true;
+}
+
+inline void RenderingSemaphore::frameEnd()
+{
+  m_frameInFlight = false;
+  m_conditionFrame.notify_all();
+}
+
+} // namespace viskores_device

--- a/viskores/rendering/anari-device/ViskoresDevice.cpp
+++ b/viskores/rendering/anari-device/ViskoresDevice.cpp
@@ -1,0 +1,345 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#include "ViskoresDevice.h"
+
+#include "array/Array1D.h"
+#include "array/Array2D.h"
+#include "array/Array3D.h"
+#include "array/ObjectArray.h"
+#include "frame/Frame.h"
+#include "scene/volume/spatial_field/SpatialField.h"
+
+#include "anari_library_viskores_queries.h"
+
+#include <algorithm>
+#include <viskores/Version.h>
+
+namespace viskores_device
+{
+
+///////////////////////////////////////////////////////////////////////////////
+// Helper functions ///////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////
+
+template <typename HANDLE_T, typename OBJECT_T>
+inline HANDLE_T getHandleForAPI(OBJECT_T* object)
+{
+  return (HANDLE_T)object;
+}
+
+template <typename OBJECT_T, typename HANDLE_T, typename... Args>
+inline HANDLE_T createObjectForAPI(ViskoresDeviceGlobalState* s, Args&&... args)
+{
+  return getHandleForAPI<HANDLE_T>(new OBJECT_T(s, std::forward<Args>(args)...));
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// ViskoresDevice definitions
+// /////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////
+
+// Data Arrays ////////////////////////////////////////////////////////////////
+
+void* ViskoresDevice::mapArray(ANARIArray a)
+{
+  deviceState()->renderingSemaphore.arrayMapAcquire();
+  return helium::BaseDevice::mapArray(a);
+}
+
+void ViskoresDevice::unmapArray(ANARIArray a)
+{
+  helium::BaseDevice::unmapArray(a);
+  deviceState()->renderingSemaphore.arrayMapRelease();
+}
+
+// API Objects ////////////////////////////////////////////////////////////////
+
+ANARIArray1D ViskoresDevice::newArray1D(const void* appMemory,
+                                        ANARIMemoryDeleter deleter,
+                                        const void* userData,
+                                        ANARIDataType type,
+                                        uint64_t numItems)
+{
+  initDevice();
+
+  Array1DMemoryDescriptor md;
+  md.appMemory = appMemory;
+  md.deleter = deleter;
+  md.deleterPtr = userData;
+  md.elementType = type;
+  md.numItems = numItems;
+
+  if (anari::isObject(type))
+    return createObjectForAPI<ObjectArray, ANARIArray1D>(deviceState(), md);
+  else
+    return createObjectForAPI<Array1D, ANARIArray1D>(deviceState(), md);
+}
+
+ANARIArray2D ViskoresDevice::newArray2D(const void* appMemory,
+                                        ANARIMemoryDeleter deleter,
+                                        const void* userData,
+                                        ANARIDataType type,
+                                        uint64_t numItems1,
+                                        uint64_t numItems2)
+{
+  initDevice();
+
+  Array2DMemoryDescriptor md;
+  md.appMemory = appMemory;
+  md.deleter = deleter;
+  md.deleterPtr = userData;
+  md.elementType = type;
+  md.numItems1 = numItems1;
+  md.numItems2 = numItems2;
+
+  return createObjectForAPI<Array2D, ANARIArray2D>(deviceState(), md);
+}
+
+ANARIArray3D ViskoresDevice::newArray3D(const void* appMemory,
+                                        ANARIMemoryDeleter deleter,
+                                        const void* userData,
+                                        ANARIDataType type,
+                                        uint64_t numItems1,
+                                        uint64_t numItems2,
+                                        uint64_t numItems3)
+{
+  initDevice();
+
+  Array3DMemoryDescriptor md;
+  md.appMemory = appMemory;
+  md.deleter = deleter;
+  md.deleterPtr = userData;
+  md.elementType = type;
+  md.numItems1 = numItems1;
+  md.numItems2 = numItems2;
+  md.numItems3 = numItems3;
+
+  return createObjectForAPI<Array3D, ANARIArray3D>(deviceState(), md);
+}
+
+ANARICamera ViskoresDevice::newCamera(const char* subtype)
+{
+  initDevice();
+  return getHandleForAPI<ANARICamera>(Camera::createInstance(subtype, deviceState()));
+}
+
+ANARIFrame ViskoresDevice::newFrame()
+{
+  initDevice();
+  return createObjectForAPI<Frame, ANARIFrame>(deviceState());
+}
+
+ANARIGeometry ViskoresDevice::newGeometry(const char* subtype)
+{
+  initDevice();
+  return getHandleForAPI<ANARIGeometry>(Geometry::createInstance(subtype, deviceState()));
+}
+
+ANARIGroup ViskoresDevice::newGroup()
+{
+  initDevice();
+  return createObjectForAPI<Group, ANARIGroup>(deviceState());
+}
+
+ANARIInstance ViskoresDevice::newInstance(const char* /*subtype*/)
+{
+  initDevice();
+  return createObjectForAPI<Instance, ANARIInstance>(deviceState());
+}
+
+ANARILight ViskoresDevice::newLight(const char* subtype)
+{
+  initDevice();
+  return getHandleForAPI<ANARILight>(Light::createInstance(subtype, deviceState()));
+}
+
+ANARIMaterial ViskoresDevice::newMaterial(const char* subtype)
+{
+  initDevice();
+  return getHandleForAPI<ANARIMaterial>(Material::createInstance(subtype, deviceState()));
+}
+
+ANARIRenderer ViskoresDevice::newRenderer(const char* subtype)
+{
+  initDevice();
+  return getHandleForAPI<ANARIRenderer>(Renderer::createInstance(subtype, deviceState()));
+}
+
+ANARISampler ViskoresDevice::newSampler(const char* subtype)
+{
+  initDevice();
+  return getHandleForAPI<ANARISampler>(Sampler::createInstance(subtype, deviceState()));
+}
+
+ANARISpatialField ViskoresDevice::newSpatialField(const char* subtype)
+{
+  initDevice();
+  return getHandleForAPI<ANARISpatialField>(SpatialField::createInstance(subtype, deviceState()));
+}
+
+ANARISurface ViskoresDevice::newSurface()
+{
+  initDevice();
+  return createObjectForAPI<Surface, ANARISurface>(deviceState());
+}
+
+ANARIVolume ViskoresDevice::newVolume(const char* subtype)
+{
+  initDevice();
+  return getHandleForAPI<ANARIVolume>(Volume::createInstance(subtype, deviceState()));
+}
+
+ANARIWorld ViskoresDevice::newWorld()
+{
+  initDevice();
+  return createObjectForAPI<World, ANARIWorld>(deviceState());
+}
+
+// Query functions ////////////////////////////////////////////////////////////
+
+const char** ViskoresDevice::getObjectSubtypes(ANARIDataType objectType)
+{
+  return viskores_device::query_object_types(objectType);
+}
+
+const void* ViskoresDevice::getObjectInfo(ANARIDataType objectType,
+                                          const char* objectSubtype,
+                                          const char* infoName,
+                                          ANARIDataType infoType)
+{
+  return viskores_device::query_object_info(objectType, objectSubtype, infoName, infoType);
+}
+
+const void* ViskoresDevice::getParameterInfo(ANARIDataType objectType,
+                                             const char* objectSubtype,
+                                             const char* parameterName,
+                                             ANARIDataType parameterType,
+                                             const char* infoName,
+                                             ANARIDataType infoType)
+{
+  return viskores_device::query_param_info(
+    objectType, objectSubtype, parameterName, parameterType, infoName, infoType);
+}
+
+// Object + Parameter Lifetime Management /////////////////////////////////////
+
+int ViskoresDevice::getProperty(ANARIObject object,
+                                const char* name,
+                                ANARIDataType type,
+                                void* mem,
+                                uint64_t size,
+                                uint32_t mask)
+{
+  if (mask == ANARI_WAIT)
+  {
+    auto lock = scopeLockObject();
+    deviceState()->waitOnCurrentFrame();
+  }
+
+  return helium::BaseDevice::getProperty(object, name, type, mem, size, mask);
+}
+
+
+// Other ViskoresDevice definitions
+// /////////////////////////////////////////////
+
+ViskoresDevice::ViskoresDevice(ANARIStatusCallback cb, const void* ptr)
+  : helium::BaseDevice(cb, ptr)
+{
+  m_state = std::make_unique<ViskoresDeviceGlobalState>(this_device());
+  deviceCommitParameters();
+}
+
+ViskoresDevice::ViskoresDevice(ANARILibrary l)
+  : helium::BaseDevice(l)
+{
+  m_state = std::make_unique<ViskoresDeviceGlobalState>(this_device());
+  deviceCommitParameters();
+}
+
+ViskoresDevice::~ViskoresDevice()
+{
+  reportMessage(ANARI_SEVERITY_DEBUG, "destroying Viskores device (%p)", this);
+
+  auto& state = *deviceState();
+  state.commitBuffer.clear();
+}
+
+void ViskoresDevice::initDevice()
+{
+  if (m_initialized)
+    return;
+
+  reportMessage(ANARI_SEVERITY_DEBUG, "initializing Viskores device (%p)", this);
+
+  m_initialized = true;
+}
+
+void ViskoresDevice::deviceCommitParameters()
+{
+  helium::BaseDevice::deviceCommitParameters();
+}
+
+int ViskoresDevice::deviceGetProperty(const char* name,
+                                      ANARIDataType type,
+                                      void* mem,
+                                      uint64_t size,
+                                      uint32_t mask)
+{
+  std::string_view prop = name;
+  if (prop == "extension" && type == ANARI_STRING_LIST)
+  {
+    helium::writeToVoidP(mem, query_extensions());
+    return 1;
+  }
+  else if (prop == "viskores" && type == ANARI_BOOL)
+  {
+    helium::writeToVoidP(mem, true);
+    return 1;
+  }
+  else if ((prop == "version") && (type == ANARI_INT32))
+  {
+    viskores::Int32 version =
+      (VISKORES_VERSION_MAJOR * 10000) + (VISKORES_VERSION_MINOR * 100) + VISKORES_VERSION_PATCH;
+    helium::writeToVoidP(mem, version);
+  }
+  else if ((prop == "version.major") && (type == ANARI_INT32))
+  {
+    helium::writeToVoidP(mem, viskores::Int32(VISKORES_VERSION_MAJOR));
+    return 1;
+  }
+  else if ((prop == "version.minor") && (type == ANARI_INT32))
+  {
+    helium::writeToVoidP(mem, viskores::Int32(VISKORES_VERSION_MINOR));
+    return 1;
+  }
+  else if ((prop == "version.patch") && (type == ANARI_INT32))
+  {
+    helium::writeToVoidP(mem, viskores::Int32(VISKORES_VERSION_PATCH));
+    return 1;
+  }
+  else if (prop == "version.name" && type == ANARI_STRING)
+  {
+    std::memset(mem, 0, size);
+    std::memcpy(
+      mem, VISKORES_VERSION_FULL, std::min(uint64_t(sizeof(VISKORES_VERSION_FULL)), size - 1));
+    return 1;
+  }
+
+  return BaseDevice::deviceGetProperty(name, type, mem, size, mask);
+}
+
+ViskoresDeviceGlobalState* ViskoresDevice::deviceState() const
+{
+  return (ViskoresDeviceGlobalState*)helium::BaseDevice::m_state.get();
+}
+
+} // namespace viskores_device

--- a/viskores/rendering/anari-device/ViskoresDevice.h
+++ b/viskores/rendering/anari-device/ViskoresDevice.h
@@ -1,0 +1,113 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#pragma once
+
+// helium
+#include "helium/BaseDevice.h"
+// #include "ChangeObserverPtr.h"
+
+#include "Object.h"
+
+namespace viskores_device
+{
+
+struct ViskoresDevice : public helium::BaseDevice
+{
+  /////////////////////////////////////////////////////////////////////////////
+  // Main interface to accepting API calls
+  /////////////////////////////////////////////////////////////////////////////
+
+  // Data Arrays //////////////////////////////////////////////////////////////
+
+  void* mapArray(ANARIArray) override;
+  void unmapArray(ANARIArray) override;
+
+  // API Objects //////////////////////////////////////////////////////////////
+
+  ANARIArray1D newArray1D(const void* appMemory,
+                          ANARIMemoryDeleter deleter,
+                          const void* userdata,
+                          ANARIDataType,
+                          uint64_t numItems1) override;
+  ANARIArray2D newArray2D(const void* appMemory,
+                          ANARIMemoryDeleter deleter,
+                          const void* userdata,
+                          ANARIDataType,
+                          uint64_t numItems1,
+                          uint64_t numItems2) override;
+  ANARIArray3D newArray3D(const void* appMemory,
+                          ANARIMemoryDeleter deleter,
+                          const void* userdata,
+                          ANARIDataType,
+                          uint64_t numItems1,
+                          uint64_t numItems2,
+                          uint64_t numItems3) override;
+  ANARICamera newCamera(const char* type) override;
+  ANARIFrame newFrame() override;
+  ANARIGeometry newGeometry(const char* type) override;
+  ANARIGroup newGroup() override;
+  ANARIInstance newInstance(const char* type) override;
+  ANARILight newLight(const char* type) override;
+  ANARIMaterial newMaterial(const char* material_type) override;
+  ANARIRenderer newRenderer(const char* type) override;
+  ANARISampler newSampler(const char* type) override;
+  ANARISpatialField newSpatialField(const char* type) override;
+  ANARISurface newSurface() override;
+  ANARIVolume newVolume(const char* type) override;
+  ANARIWorld newWorld() override;
+
+  // Query functions //////////////////////////////////////////////////////////
+
+  const char** getObjectSubtypes(ANARIDataType objectType) override;
+  const void* getObjectInfo(ANARIDataType objectType,
+                            const char* objectSubtype,
+                            const char* infoName,
+                            ANARIDataType infoType) override;
+  const void* getParameterInfo(ANARIDataType objectType,
+                               const char* objectSubtype,
+                               const char* parameterName,
+                               ANARIDataType parameterType,
+                               const char* infoName,
+                               ANARIDataType infoType) override;
+
+  // Object + Parameter Lifetime Management ///////////////////////////////////
+
+  int getProperty(ANARIObject object,
+                  const char* name,
+                  ANARIDataType type,
+                  void* mem,
+                  uint64_t size,
+                  uint32_t mask) override;
+
+  /////////////////////////////////////////////////////////////////////////////
+  // Helper/other functions and data members
+  /////////////////////////////////////////////////////////////////////////////
+
+  ViskoresDevice(ANARIStatusCallback defaultCallback, const void* userPtr);
+  ViskoresDevice(ANARILibrary);
+  ~ViskoresDevice() override;
+
+  void initDevice();
+
+  void deviceCommitParameters() override;
+  int deviceGetProperty(const char* name,
+                        ANARIDataType type,
+                        void* mem,
+                        uint64_t size,
+                        uint32_t mask) override;
+
+private:
+  ViskoresDeviceGlobalState* deviceState() const;
+
+  bool m_initialized{ false };
+};
+
+} // namespace viskores_device

--- a/viskores/rendering/anari-device/ViskoresDeviceGlobalState.cpp
+++ b/viskores/rendering/anari-device/ViskoresDeviceGlobalState.cpp
@@ -1,0 +1,28 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#include "ViskoresDeviceGlobalState.h"
+#include "frame/Frame.h"
+
+namespace viskores_device
+{
+
+ViskoresDeviceGlobalState::ViskoresDeviceGlobalState(ANARIDevice d)
+  : helium::BaseGlobalDeviceState(d)
+{
+}
+
+void ViskoresDeviceGlobalState::waitOnCurrentFrame() const
+{
+  if (currentFrame)
+    currentFrame->wait();
+}
+
+} // namespace viskores_device

--- a/viskores/rendering/anari-device/ViskoresDeviceGlobalState.h
+++ b/viskores/rendering/anari-device/ViskoresDeviceGlobalState.h
@@ -1,0 +1,74 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#pragma once
+
+#include "RenderingSemaphore.h"
+#include "viskores_device_math.h"
+// helium
+#include "helium/BaseGlobalDeviceState.h"
+// std
+#include <atomic>
+#include <mutex>
+
+namespace viskores_device
+{
+
+struct Frame;
+
+struct ViskoresDeviceGlobalState : public helium::BaseGlobalDeviceState
+{
+  struct ObjectCounts
+  {
+    std::atomic<size_t> frames{ 0 };
+    std::atomic<size_t> cameras{ 0 };
+    std::atomic<size_t> renderers{ 0 };
+    std::atomic<size_t> worlds{ 0 };
+    std::atomic<size_t> instances{ 0 };
+    std::atomic<size_t> groups{ 0 };
+    std::atomic<size_t> surfaces{ 0 };
+    std::atomic<size_t> geometries{ 0 };
+    std::atomic<size_t> materials{ 0 };
+    std::atomic<size_t> samplers{ 0 };
+    std::atomic<size_t> volumes{ 0 };
+    std::atomic<size_t> spatialFields{ 0 };
+    std::atomic<size_t> arrays{ 0 };
+    std::atomic<size_t> unknown{ 0 };
+  } objectCounts;
+
+  RenderingSemaphore renderingSemaphore;
+  Frame* currentFrame{ nullptr };
+
+  // Helper methods //
+
+  ViskoresDeviceGlobalState(ANARIDevice d);
+  void waitOnCurrentFrame() const;
+};
+
+// Helper functions/macros ////////////////////////////////////////////////////
+
+inline ViskoresDeviceGlobalState* asViskoresDeviceState(helium::BaseGlobalDeviceState* s)
+{
+  return (ViskoresDeviceGlobalState*)s;
+}
+
+#define VISKORES_ANARI_TYPEFOR_SPECIALIZATION(type, anari_type) \
+  namespace anari                                               \
+  {                                                             \
+  ANARI_TYPEFOR_SPECIALIZATION(type, anari_type);               \
+  }
+
+#define VISKORES_ANARI_TYPEFOR_DEFINITION(type) \
+  namespace anari                               \
+  {                                             \
+  ANARI_TYPEFOR_DEFINITION(type);               \
+  }
+
+} // namespace viskores_device

--- a/viskores/rendering/anari-device/ViskoresLibrary.cpp
+++ b/viskores/rendering/anari-device/ViskoresLibrary.cpp
@@ -1,0 +1,58 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#include "ViskoresDevice.h"
+#include "anari/backend/LibraryImpl.h"
+#include "anari_library_viskores_export.h"
+
+#include <viskores/cont/Initialize.h>
+
+namespace viskores_device
+{
+
+struct ViskoresLibrary : public anari::LibraryImpl
+{
+  ViskoresLibrary(void* lib, ANARIStatusCallback defaultStatusCB, const void* statusCBPtr);
+
+  ANARIDevice newDevice(const char* subtype) override;
+  const char** getDeviceExtensions(const char* deviceType) override;
+};
+
+// Definitions ////////////////////////////////////////////////////////////////
+
+ViskoresLibrary::ViskoresLibrary(void* lib,
+                                 ANARIStatusCallback defaultStatusCB,
+                                 const void* statusCBPtr)
+  : anari::LibraryImpl(lib, defaultStatusCB, statusCBPtr)
+{
+  if (!viskores::cont::IsInitialized())
+  {
+    viskores::cont::Initialize();
+  }
+}
+
+ANARIDevice ViskoresLibrary::newDevice(const char* /*subtype*/)
+{
+  return (ANARIDevice) new ViskoresDevice(this_library());
+}
+
+const char** ViskoresLibrary::getDeviceExtensions(const char* /*deviceType*/)
+{
+  return nullptr;
+}
+
+} // namespace viskores_device
+
+// Define library entrypoint //////////////////////////////////////////////////
+
+extern "C" VISKORES_LIBRARY_INTERFACE ANARI_DEFINE_LIBRARY_ENTRYPOINT(viskores, handle, scb, scbPtr)
+{
+  return (ANARILibrary) new viskores_device::ViskoresLibrary(handle, scb, scbPtr);
+}

--- a/viskores/rendering/anari-device/ViskoresTypes.h
+++ b/viskores/rendering/anari-device/ViskoresTypes.h
@@ -1,0 +1,135 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#pragma once
+
+#include <viskores/VecVariable.h>
+#include <viskores/VectorAnalysis.h>
+
+#include <limits>
+
+namespace viskores_device
+{
+
+using float2 = viskores::Vec2f_32;
+using float3 = viskores::Vec3f_32;
+using float4 = viskores::Vec4f_32;
+
+#if 0
+struct float2
+{
+  float2(float v) {data[0]=v; data[1] = v;}
+  float2(float v1, float v2) {data[0]=v1;data[1]=v2;}
+  float operator[](std::size_t i) const {return data[i];}
+  float& operator[](std::size_t i) {return data[i];}
+  float x() const {return this->data[0];}
+  float& x() {return this->data[0];}
+  float y() const {return this->data[1];}
+  float& y() {return this->data[1];}
+
+  float data[2] = {0.f, 0.f};
+};
+struct float3
+{
+  float3(float v) {data[0]=v;data[1]=v;data[2]=v;}
+  float3(float v1, float v2, float v3) {data[0]=v1;data[1]=v2;data[2]=v3;}
+  float operator[](std::size_t i) const {return data[i];}
+  float& operator[](std::size_t i) {return data[i];}
+  float data[3];
+};
+struct float4
+{
+  float4(float v) {data[0]=v;data[1]=v;data[2]=v;data[3]=v;}
+  float4(float v1, float v2, float v3, float v4) {data[0]=v1;data[1]=v2;data[2]=v3;data[3]=v4;}
+  float4(const float3& f3, float v) {data[0]=f3[0];data[1]=f3[1];data[2]=f3[2];data[3]=v;}
+  float operator[](std::size_t i) const {return data[i];}
+  float& operator[](std::size_t i) {return data[i];}
+  float data[4];
+};
+#endif
+
+template <typename T>
+struct range_t
+{
+  using element_t = T;
+
+  range_t() = default;
+  range_t(const T& t)
+    : lower(t)
+    , upper(t)
+  {
+  }
+  range_t(const T& _lower, const T& _upper)
+    : lower(_lower)
+    , upper(_upper)
+  {
+  }
+
+  range_t<T>& extend(const T& t)
+  {
+    lower = min(lower, t);
+    upper = max(upper, t);
+    return *this;
+  }
+
+  range_t<T>& extend(const range_t<T>& t)
+  {
+    lower = min(lower, t.lower);
+    upper = max(upper, t.upper);
+    return *this;
+  }
+
+  T lower{ T(std::numeric_limits<float>::max()) };
+  T upper{ T(-std::numeric_limits<float>::max()) };
+};
+
+using box1 = range_t<float>;
+using box2 = range_t<float2>;
+using box3 = range_t<float3>;
+using uint32_t = unsigned int;
+
+//using float2 = float[2];
+//using float3 = float[3];
+//using float4 = float[4];
+
+struct Ray
+{
+  // Ray //
+
+  float3 org;
+  float tnear{ 0.f };
+  float3 dir;
+  float time{ 0.f };
+  float tfar{ std::numeric_limits<float>::max() };
+  unsigned int mask{ ~0u };
+  unsigned int id{ 0 };
+  unsigned int flags{ 0 };
+
+  // Hit //
+
+  float3 Ng;
+  float u;
+  float v;
+  unsigned int primID; //{RTC_INVALID_GEOMETRY_ID}; // primitive ID
+  unsigned int geomID; //{RTC_INVALID_GEOMETRY_ID}; // geometry ID
+  unsigned int instID; //{RTC_INVALID_GEOMETRY_ID}; // instance ID
+};
+
+struct Volume;
+struct VolumeRay
+{
+  float3 org;
+  float3 dir;
+  box1 t{ 0.f, std::numeric_limits<float>::max() };
+  Volume* volume{ nullptr };
+  uint32_t instID; //{RTC_INVALID_GEOMETRY_ID};
+};
+
+} //namespace viskores_device

--- a/viskores/rendering/anari-device/array/Array1D.cpp
+++ b/viskores/rendering/anari-device/array/Array1D.cpp
@@ -1,0 +1,48 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#include "Array1D.h"
+#include "ArrayConversion.h"
+
+namespace viskores_device
+{
+
+Array1D::Array1D(ViskoresDeviceGlobalState* state, const Array1DMemoryDescriptor& d)
+  : helium::Array1D(state, d)
+{
+  state->objectCounts.arrays++;
+}
+
+Array1D::~Array1D()
+{
+  asViskoresDeviceState(deviceState())->objectCounts.arrays--;
+}
+
+void Array1D::unmap()
+{
+  this->helium::Array1D::unmap();
+  // Invalidate Viskores ArrayHandle
+  this->m_ViskoresArray = viskores::cont::UnknownArrayHandle{};
+}
+
+viskores::cont::UnknownArrayHandle Array1D::dataAsViskoresArray() const
+{
+  if (!this->m_ViskoresArray.IsValid())
+  {
+    // Pull data from ANARI into Viskores.
+    const_cast<Array1D*>(this)->m_ViskoresArray = ANARIArrayToViskoresArray(this);
+  }
+
+  return this->m_ViskoresArray;
+}
+
+} // namespace viskores_device
+
+VISKORES_ANARI_TYPEFOR_DEFINITION(viskores_device::Array1D*);

--- a/viskores/rendering/anari-device/array/Array1D.h
+++ b/viskores/rendering/anari-device/array/Array1D.h
@@ -1,0 +1,44 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#pragma once
+
+#include "../ViskoresDeviceGlobalState.h"
+// helium
+#include "helium/array/Array1D.h"
+// Viskores
+#include <viskores/cont/UnknownArrayHandle.h>
+
+namespace viskores_device
+{
+
+using Array1DMemoryDescriptor = helium::Array1DMemoryDescriptor;
+
+struct Array1D : public helium::Array1D
+{
+  Array1D(ViskoresDeviceGlobalState* state, const Array1DMemoryDescriptor& d);
+  ~Array1D() override;
+
+  void unmap() override;
+
+  /// @brief Return the data for this array wrapped into a Viskores array handle.
+  ///
+  /// Note: Do not change the contents of the Viskores array handle. Although the
+  /// data are in a Viskores array, it is still managed by ANARI, and changing the
+  /// data outside of a map/unmap is forbidden.
+  viskores::cont::UnknownArrayHandle dataAsViskoresArray() const;
+
+private:
+  viskores::cont::UnknownArrayHandle m_ViskoresArray;
+};
+
+} // namespace viskores_device
+
+VISKORES_ANARI_TYPEFOR_SPECIALIZATION(viskores_device::Array1D*, ANARI_ARRAY1D);

--- a/viskores/rendering/anari-device/array/Array2D.cpp
+++ b/viskores/rendering/anari-device/array/Array2D.cpp
@@ -1,0 +1,48 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#include "Array2D.h"
+#include "ArrayConversion.h"
+
+namespace viskores_device
+{
+
+Array2D::Array2D(ViskoresDeviceGlobalState* state, const Array2DMemoryDescriptor& d)
+  : helium::Array2D(state, d)
+{
+  state->objectCounts.arrays++;
+}
+
+Array2D::~Array2D()
+{
+  asViskoresDeviceState(deviceState())->objectCounts.arrays--;
+}
+
+void Array2D::unmap()
+{
+  this->helium::Array2D::unmap();
+  // Invalidate Viskores ArrayHandle
+  this->m_ViskoresArray.ReleaseResources();
+}
+
+viskores::cont::UnknownArrayHandle Array2D::dataAsViskoresArray() const
+{
+  if (!this->m_ViskoresArray.IsValid())
+  {
+    // Pull data from ANARI into Viskores.
+    const_cast<Array2D*>(this)->m_ViskoresArray = ANARIArrayToViskoresArray(this);
+  }
+
+  return this->m_ViskoresArray;
+}
+
+} // namespace viskores_device
+
+VISKORES_ANARI_TYPEFOR_DEFINITION(viskores_device::Array2D*);

--- a/viskores/rendering/anari-device/array/Array2D.h
+++ b/viskores/rendering/anari-device/array/Array2D.h
@@ -1,0 +1,44 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#pragma once
+
+#include "../ViskoresDeviceGlobalState.h"
+// helium
+#include "helium/array/Array2D.h"
+// Viskores
+#include <viskores/cont/UnknownArrayHandle.h>
+
+namespace viskores_device
+{
+
+using Array2DMemoryDescriptor = helium::Array2DMemoryDescriptor;
+
+struct Array2D : public helium::Array2D
+{
+  Array2D(ViskoresDeviceGlobalState* state, const Array2DMemoryDescriptor& d);
+  ~Array2D() override;
+
+  void unmap() override;
+
+  /// @brief Return the data for this array wrapped into a Viskores array handle.
+  ///
+  /// Note: Do not change the contents of the Viskores array handle. Although the
+  /// data are in a Viskores array, it is still managed by ANARI, and changing the
+  /// data outside of a map/unmap is forbidden.
+  viskores::cont::UnknownArrayHandle dataAsViskoresArray() const;
+
+private:
+  viskores::cont::UnknownArrayHandle m_ViskoresArray;
+};
+
+} // namespace viskores_device
+
+VISKORES_ANARI_TYPEFOR_SPECIALIZATION(viskores_device::Array2D*, ANARI_ARRAY2D);

--- a/viskores/rendering/anari-device/array/Array3D.cpp
+++ b/viskores/rendering/anari-device/array/Array3D.cpp
@@ -1,0 +1,48 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#include "Array3D.h"
+#include "ArrayConversion.h"
+
+namespace viskores_device
+{
+
+Array3D::Array3D(ViskoresDeviceGlobalState* state, const Array3DMemoryDescriptor& d)
+  : helium::Array3D(state, d)
+{
+  state->objectCounts.arrays++;
+}
+
+Array3D::~Array3D()
+{
+  asViskoresDeviceState(deviceState())->objectCounts.arrays--;
+}
+
+void Array3D::unmap()
+{
+  this->helium::Array3D::unmap();
+  // Invalidate Viskores ArrayHandle
+  this->m_ViskoresArray.ReleaseResources();
+}
+
+viskores::cont::UnknownArrayHandle Array3D::dataAsViskoresArray() const
+{
+  if (!this->m_ViskoresArray.IsValid())
+  {
+    // Pull data from ANARI into Viskores.
+    const_cast<Array3D*>(this)->m_ViskoresArray = ANARIArrayToViskoresArray(this);
+  }
+
+  return this->m_ViskoresArray;
+}
+
+} // namespace viskores_device
+
+VISKORES_ANARI_TYPEFOR_DEFINITION(viskores_device::Array3D*);

--- a/viskores/rendering/anari-device/array/Array3D.h
+++ b/viskores/rendering/anari-device/array/Array3D.h
@@ -1,0 +1,44 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#pragma once
+
+#include "../ViskoresDeviceGlobalState.h"
+// helium
+#include "helium/array/Array3D.h"
+// Viskores
+#include <viskores/cont/UnknownArrayHandle.h>
+
+namespace viskores_device
+{
+
+using Array3DMemoryDescriptor = helium::Array3DMemoryDescriptor;
+
+struct Array3D : public helium::Array3D
+{
+  Array3D(ViskoresDeviceGlobalState* state, const Array3DMemoryDescriptor& d);
+  ~Array3D() override;
+
+  void unmap() override;
+
+  /// @brief Return the data for this array wrapped into a Viskores array handle.
+  ///
+  /// Note: Do not change the contents of the Viskores array handle. Although the
+  /// data are in a Viskores array, it is still managed by ANARI, and changing the
+  /// data outside of a map/unmap is forbidden.
+  viskores::cont::UnknownArrayHandle dataAsViskoresArray() const;
+
+private:
+  viskores::cont::UnknownArrayHandle m_ViskoresArray;
+};
+
+} // namespace viskores_device
+
+VISKORES_ANARI_TYPEFOR_SPECIALIZATION(viskores_device::Array3D*, ANARI_ARRAY3D);

--- a/viskores/rendering/anari-device/array/ArrayConversion.cpp
+++ b/viskores/rendering/anari-device/array/ArrayConversion.cpp
@@ -1,0 +1,141 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#include "ArrayConversion.h"
+#include "anari/frontend/type_utility.h"
+// Viskores
+#include <viskores/cont/Invoker.h>
+#include <viskores/worklet/WorkletMapField.h>
+// C++
+#include <limits>
+#include <type_traits>
+
+
+namespace
+{
+
+template <typename BaseType, int NumComponents>
+struct ViskoresTypeImpl
+{
+  using type = viskores::Vec<BaseType, static_cast<viskores::IdComponent>(NumComponents)>;
+};
+template <typename BaseType>
+struct ViskoresTypeImpl<BaseType, 1>
+{
+  using type = BaseType;
+};
+
+template <int ANARIDataTypeId>
+struct ANARIToViskoresTypeImpl
+{
+  using properties = anari::ANARITypeProperties<ANARIDataTypeId>;
+  using type =
+    typename ViskoresTypeImpl<typename properties::base_type, properties::components>::type;
+};
+
+template <int ANARIDataTypeId>
+using ANARIToViskoresType = typename ANARIToViskoresTypeImpl<ANARIDataTypeId>::type;
+
+template <int ANARIDataTypeId>
+struct ConstructArrayHandle
+{
+  using T = ANARIToViskoresType<ANARIDataTypeId>;
+  viskores::cont::UnknownArrayHandle operator()(const void* memory, viskores::Id numValues)
+  {
+    return this->DoIt(memory, numValues, std::is_pointer<T>{});
+  }
+
+  viskores::cont::UnknownArrayHandle DoIt(const void* memory,
+                                          viskores::Id numValues,
+                                          std::false_type /*is_pointer*/)
+  {
+    // TODO: The ANARI interface generally passes arrays in the host memory space.
+    // This can be really inefficient as data is pulled from GPU to CPU, passed to
+    // ANARI, and then copied right back to the GPU. Need an extension to allow
+    // client applications to pass device memory directly.
+    return viskores::cont::make_ArrayHandle(
+      reinterpret_cast<const T*>(memory), numValues, viskores::CopyFlag::Off);
+  }
+
+  viskores::cont::UnknownArrayHandle DoIt(const void*, viskores::Id, std::true_type /*is_pointer*/)
+  {
+    std::cout << "Cannot convert an array of type "
+              << anari::ANARITypeProperties<ANARIDataTypeId>::type_name << " to Viskores.\n";
+    return viskores::cont::UnknownArrayHandle{};
+  }
+};
+template <>
+struct ConstructArrayHandle<ANARI_UNKNOWN>
+{
+  viskores::cont::UnknownArrayHandle operator()(const void*, viskores::Id)
+  {
+    std::cout << "Cannot convert an array of type ANARI_UNKNOWN to Viskores.\n";
+    return viskores::cont::UnknownArrayHandle{};
+  }
+};
+
+
+struct ConvertColorValues : viskores::worklet::WorkletMapField
+{
+  using ControlSignature = void(FieldIn, FieldOut);
+  template <typename InType, typename OutType>
+  VISKORES_EXEC void operator()(const InType& inValue, OutType& outValue) const
+  {
+    using InComponentType = typename InType::ComponentType;
+    using OutComponentType = typename OutType::ComponentType;
+
+    constexpr OutComponentType scale = OutComponentType{ 1 } /
+      static_cast<OutComponentType>(std::numeric_limits<InComponentType>::max());
+    for (viskores::IdComponent index = 0; index < inValue.GetNumberOfComponents(); ++index)
+    {
+      outValue[index] = static_cast<OutComponentType>(inValue[index]) * scale;
+    }
+  }
+};
+
+template <typename T>
+inline void FixColorsForType(viskores::cont::UnknownArrayHandle& colorArray)
+{
+  using ArrayType = viskores::cont::ArrayHandle<viskores::Vec<T, 4>>;
+  if (colorArray.CanConvert<ArrayType>())
+  {
+    viskores::cont::ArrayHandle<viskores::Vec4f> retypedArray;
+    viskores::cont::Invoker invoke;
+    invoke(ConvertColorValues{}, colorArray.AsArrayHandle<ArrayType>(), retypedArray);
+    colorArray = retypedArray;
+  }
+}
+
+} // anonymous namespace
+
+namespace viskores_device
+{
+
+viskores::cont::UnknownArrayHandle ANARIArrayToViskoresArray(const helium::Array* anariArray)
+{
+  viskores::Id numValues = anariArray->totalSize();
+  const void* memory = anariArray->data();
+
+  return anari::anariTypeInvoke<viskores::cont::UnknownArrayHandle, ConstructArrayHandle>(
+    anariArray->elementType(), memory, numValues);
+}
+
+viskores::cont::UnknownArrayHandle ANARIColorsToViskoresColors(
+  const viskores::cont::UnknownArrayHandle& anariColors)
+{
+  viskores::cont::UnknownArrayHandle viskoresColors = anariColors;
+  FixColorsForType<viskores::UInt8>(viskoresColors);
+  FixColorsForType<viskores::UInt16>(viskoresColors);
+  FixColorsForType<viskores::UInt32>(viskoresColors);
+  FixColorsForType<viskores::UInt64>(viskoresColors);
+  return viskoresColors;
+}
+
+} // namespace viskores_device

--- a/viskores/rendering/anari-device/array/ArrayConversion.h
+++ b/viskores/rendering/anari-device/array/ArrayConversion.h
@@ -1,0 +1,38 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#pragma once
+
+#include "helium/array/Array.h"
+// Viskores
+#include <viskores/cont/UnknownArrayHandle.h>
+
+namespace viskores_device
+{
+
+/// @brief Convert an array provided by ANARI to an ArrayHandle managed by Viskores.
+///
+/// This routine allows you to take arrays of data provided in ANARI object parameters
+/// and move them over to a Viskores ArrayHandle. Memory is shared between the two arrays,
+/// so if the contents of the array is modified on one side, it can invalidate the other.
+viskores::cont::UnknownArrayHandle ANARIArrayToViskoresArray(const helium::Array* anariArray);
+
+/// @brief Convert an array of colors.
+///
+/// Given an array of values that are to represent colors, this function will look to see
+/// if the array is represented by integer (fixed-point) values. In this case,
+/// ANARI treats these values as color channels with the range of [0, MAX_VALUE]. Viskores
+/// assumes colors are represented by floating point values in the range [0, 1]. This routine
+/// will check for those cases and convert the values if necessary. If no conversion is
+/// necessary, the same array will be returned.
+viskores::cont::UnknownArrayHandle ANARIColorsToViskoresColors(
+  const viskores::cont::UnknownArrayHandle& anariColors);
+
+} // viskores_device

--- a/viskores/rendering/anari-device/array/ObjectArray.cpp
+++ b/viskores/rendering/anari-device/array/ObjectArray.cpp
@@ -1,0 +1,30 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#include "array/ObjectArray.h"
+#include "../ViskoresDeviceGlobalState.h"
+
+namespace viskores_device
+{
+
+ObjectArray::ObjectArray(ViskoresDeviceGlobalState* state, const Array1DMemoryDescriptor& d)
+  : helium::ObjectArray(state, d)
+{
+  state->objectCounts.arrays++;
+}
+
+ObjectArray::~ObjectArray()
+{
+  asViskoresDeviceState(deviceState())->objectCounts.arrays--;
+}
+
+} // namespace viskores_device
+
+VISKORES_ANARI_TYPEFOR_DEFINITION(viskores_device::ObjectArray*);

--- a/viskores/rendering/anari-device/array/ObjectArray.h
+++ b/viskores/rendering/anari-device/array/ObjectArray.h
@@ -1,0 +1,29 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#pragma once
+
+#include "../ViskoresDeviceGlobalState.h"
+#include "Array1D.h"
+// helium
+#include "helium/array/ObjectArray.h"
+
+namespace viskores_device
+{
+
+struct ObjectArray : public helium::ObjectArray
+{
+  ObjectArray(ViskoresDeviceGlobalState* state, const Array1DMemoryDescriptor& d);
+  ~ObjectArray() override;
+};
+
+} // namespace viskores_device
+
+VISKORES_ANARI_TYPEFOR_SPECIALIZATION(viskores_device::ObjectArray*, ANARI_ARRAY1D);

--- a/viskores/rendering/anari-device/camera/Camera.cpp
+++ b/viskores/rendering/anari-device/camera/Camera.cpp
@@ -1,0 +1,74 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#include "Camera.h"
+// specific types
+#include "Orthographic.h"
+#include "Perspective.h"
+
+namespace viskores_device
+{
+
+Camera::Camera(ViskoresDeviceGlobalState* s)
+  : Object(ANARI_CAMERA, s)
+{
+}
+
+Camera::~Camera() = default;
+
+Camera* Camera::createInstance(std::string_view type, ViskoresDeviceGlobalState* s)
+{
+  if (type == "perspective")
+    return new Perspective(s);
+  else if (type == "orthographic")
+    return new Orthographic(s);
+  else
+    return new UnknownCamera(s);
+}
+
+void Camera::commitParameters()
+{
+  this->m_position = getParam<viskores::Vec3f_32>("position", { 0.f, 0.f, 0.f });
+  this->m_direction =
+    viskores::Normal(getParam<viskores::Vec3f_32>("direction", { 0.f, 0.f, -1.f }));
+  this->m_up = viskores::Normal(getParam<viskores::Vec3f_32>("up", { 0.f, 1.f, 0.f }));
+  this->m_imageRegion = viskores::Vec4f_32(0.f, 0.f, 1.f, 1.f);
+  getParam("imageRegion", ANARI_FLOAT32_BOX2, &this->m_imageRegion);
+
+#if 0
+  std::cout << "Pos== " << this->m_position << std::endl;
+  std::cout << "Dir== " << this->m_direction << std::endl;
+  std::cout << "Up== " << this->m_up << std::endl;
+#endif
+
+  this->markUpdated();
+}
+
+void Camera::finalize()
+{
+  // no-op
+}
+
+UnknownCamera::UnknownCamera(ViskoresDeviceGlobalState* s)
+  : Camera(s){};
+
+viskores::rendering::Camera UnknownCamera::camera(const viskores::Bounds&) const
+{
+  return {};
+}
+
+bool UnknownCamera::isValid() const
+{
+  return false;
+}
+
+} // namespace viskores_device
+
+VISKORES_ANARI_TYPEFOR_DEFINITION(viskores_device::Camera*);

--- a/viskores/rendering/anari-device/camera/Camera.h
+++ b/viskores/rendering/anari-device/camera/Camera.h
@@ -1,0 +1,60 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#pragma once
+
+#include "../Object.h"
+#include "../ViskoresTypes.h"
+#include <viskores/interop/anari/ViskoresANARITypes.h>
+
+#include <viskores/rendering/Camera.h>
+
+namespace viskores_device
+{
+
+struct Camera : public Object
+{
+  Camera(ViskoresDeviceGlobalState* s);
+  ~Camera() override;
+
+  static Camera* createInstance(std::string_view type, ViskoresDeviceGlobalState* state);
+
+  virtual void commitParameters() override;
+  virtual void finalize() override;
+
+  float4 imageRegion() const
+  {
+    return float4(this->m_imageRegion[0],
+                  this->m_imageRegion[1],
+                  this->m_imageRegion[2],
+                  this->m_imageRegion[3]);
+  }
+
+  virtual viskores::rendering::Camera camera(const viskores::Bounds& bounds) const = 0;
+
+protected:
+  viskores::Vec3f_32 m_position;
+  viskores::Vec3f_32 m_direction;
+  viskores::Vec3f_32 m_up;
+  viskores::Vec4f_32 m_imageRegion;
+};
+
+struct UnknownCamera : public Camera
+{
+  UnknownCamera(ViskoresDeviceGlobalState* s);
+
+  viskores::rendering::Camera camera(const viskores::Bounds&) const override;
+
+  bool isValid() const override;
+};
+
+} // namespace viskores_device
+
+VISKORES_ANARI_TYPEFOR_SPECIALIZATION(viskores_device::Camera*, ANARI_CAMERA);

--- a/viskores/rendering/anari-device/camera/Orthographic.cpp
+++ b/viskores/rendering/anari-device/camera/Orthographic.cpp
@@ -1,0 +1,59 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#include "Orthographic.h"
+
+namespace viskores_device
+{
+
+Orthographic::Orthographic(ViskoresDeviceGlobalState* s)
+  : Camera(s)
+{
+}
+
+void Orthographic::commitParameters()
+{
+  Camera::commitParameters();
+
+  this->m_aspect = this->getParam("aspect", viskores::Float32(1));
+  this->m_height = this->getParam("height", viskores::Float32(1));
+  this->m_near = this->getParam("near", viskores::Float32(-1));
+  this->m_far = this->getParam("far", viskores::Float32(-1));
+}
+
+void Orthographic::finalize()
+{
+  Camera::finalize();
+}
+
+viskores::rendering::Camera Orthographic::camera(const viskores::Bounds& bounds) const
+{
+  // TODO: Implement orthographic projection correctly
+  viskores::rendering::Camera camera;
+
+  viskores::Vec3f_64 diagonal = { bounds.X.Length(), bounds.Y.Length(), bounds.Z.Length() };
+  viskores::Float32 length = static_cast<viskores::Float32>(viskores::Magnitude(diagonal));
+
+  camera.SetPosition(this->m_position);
+  camera.SetLookAt(this->m_position + (length * this->m_direction));
+  camera.SetViewUp(this->m_up);
+  camera.SetClippingRange((this->m_near > 0) ? this->m_near : (0.001f * length),
+                          (this->m_far > 0) ? this->m_far : (100.f * length));
+#if 0
+  camera.SetViewport(this->m_imageRegion[0],
+                     this->m_imageRegion[2],
+                     this->m_imageRegion[1],
+                     this->m_imageRegion[3]);
+#endif
+
+  return camera;
+}
+
+} // namespace viskores_device

--- a/viskores/rendering/anari-device/camera/Orthographic.h
+++ b/viskores/rendering/anari-device/camera/Orthographic.h
@@ -1,0 +1,33 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#pragma once
+
+#include "Camera.h"
+
+namespace viskores_device
+{
+
+struct Orthographic : public Camera
+{
+  Orthographic(ViskoresDeviceGlobalState* s);
+  void commitParameters() override;
+  void finalize() override;
+
+  viskores::rendering::Camera camera(const viskores::Bounds& bounds) const override;
+
+private:
+  viskores::Float32 m_aspect;
+  viskores::Float32 m_height;
+  viskores::Float32 m_near;
+  viskores::Float32 m_far;
+};
+
+} // namespace viskores_device

--- a/viskores/rendering/anari-device/camera/Perspective.cpp
+++ b/viskores/rendering/anari-device/camera/Perspective.cpp
@@ -1,0 +1,61 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#include "Perspective.h"
+
+namespace viskores_device
+{
+
+Perspective::Perspective(ViskoresDeviceGlobalState* s)
+  : Camera(s)
+{
+}
+
+void Perspective::commitParameters()
+{
+  Camera::commitParameters();
+
+  this->m_fovy = this->getParam("fovy", viskores::Pi_3f());
+  this->m_aspect = this->getParam("aspect", viskores::Float32(1));
+  this->m_near = this->getParam("near", viskores::Float32(-1));
+  this->m_far = this->getParam("far", viskores::Float32(-1));
+}
+
+void Perspective::finalize()
+{
+  Camera::finalize();
+}
+
+viskores::rendering::Camera Perspective::camera(const viskores::Bounds& bounds) const
+{
+  viskores::rendering::Camera camera;
+
+  viskores::Vec3f_64 diagonal = { bounds.X.Length(), bounds.Y.Length(), bounds.Z.Length() };
+  viskores::Float32 length = static_cast<viskores::Float32>(viskores::Magnitude(diagonal));
+
+  camera.SetPosition(this->m_position);
+  camera.SetLookAt(this->m_position + (length * this->m_direction));
+  camera.SetViewUp(this->m_up);
+  camera.SetFieldOfView(anari::degrees(this->m_fovy));
+  camera.SetClippingRange((this->m_near > 0) ? this->m_near : (0.01f * length),
+                          (this->m_far > 0) ? this->m_far : (1000.f * length));
+#if 0
+  camera.SetViewport(this->m_imageRegion[0],
+                     this->m_imageRegion[2],
+                     this->m_imageRegion[1],
+                     this->m_imageRegion[3]);
+#endif
+
+  // TODO: The aspect parameter is ignored. This is handled elsewhere
+
+  return camera;
+}
+
+} // namespace viskores_device

--- a/viskores/rendering/anari-device/camera/Perspective.h
+++ b/viskores/rendering/anari-device/camera/Perspective.h
@@ -1,0 +1,33 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#pragma once
+
+#include "Camera.h"
+
+namespace viskores_device
+{
+
+struct Perspective : public Camera
+{
+  Perspective(ViskoresDeviceGlobalState* s);
+  void commitParameters() override;
+  void finalize() override;
+
+  viskores::rendering::Camera camera(const viskores::Bounds& bounds) const override;
+
+private:
+  viskores::Float32 m_fovy;
+  viskores::Float32 m_aspect;
+  viskores::Float32 m_near;
+  viskores::Float32 m_far;
+};
+
+} // namespace viskores_device

--- a/viskores/rendering/anari-device/frame/Frame.cpp
+++ b/viskores/rendering/anari-device/frame/Frame.cpp
@@ -1,0 +1,442 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#include "Frame.h"
+// std
+#include <algorithm>
+#include <chrono>
+#include <random>
+#include <thread>
+
+#include <scene/World.h>
+
+#include <viskores/cont/ArrayHandleBasic.h>
+#include <viskores/rendering/Actor.h>
+#include <viskores/rendering/MapperRayTracer.h>
+#include <viskores/rendering/MapperVolume.h>
+#include <viskores/rendering/MapperWireframer.h>
+#include <viskores/rendering/Scene.h>
+#include <viskores/rendering/View3D.h>
+
+#include <viskores/cont/Invoker.h>
+#include <viskores/worklet/WorkletMapField.h>
+
+using viskores::rendering::CanvasRayTracer;
+using viskores::rendering::MapperRayTracer;
+using viskores::rendering::MapperVolume;
+using viskores::rendering::MapperWireframer;
+
+namespace viskores_device
+{
+
+constexpr float toneMap(viskores::Float32 v)
+{
+  return std::pow(v, 1.f / 2.2f);
+}
+
+constexpr uint32_t cvt_uint32(const viskores::Float32& f)
+{
+  return static_cast<uint32_t>(255.f * std::clamp(f, 0.f, 1.f));
+}
+
+constexpr uint32_t cvt_uint32(const viskores::Vec4f_32& v)
+{
+  return (cvt_uint32(v[0]) << 0) | (cvt_uint32(v[1]) << 8) | (cvt_uint32(v[2]) << 16) |
+    (cvt_uint32(v[3]) << 24);
+}
+
+constexpr uint32_t cvt_uint32_srgb(const viskores::Vec4f_32& v)
+{
+  return cvt_uint32(viskores::Vec4f_32(toneMap(v[0]), toneMap(v[1]), toneMap(v[2]), v[3]));
+}
+
+class ConvertToRGBA : public viskores::worklet::WorkletMapField
+{
+public:
+  using ControlSignature = void(FieldIn inputArray, FieldOut outputArray);
+  using ExecutionSignature = void(_1, _2);
+  using InputDomain = _1;
+
+  template <typename InFieldType, typename OutFieldType>
+  VISKORES_EXEC void operator()(const InFieldType& inField, OutFieldType& outField) const
+  {
+    outField = cvt_uint32(inField);
+  }
+};
+
+class ConvertToSRGBA : public viskores::worklet::WorkletMapField
+{
+public:
+  using ControlSignature = void(FieldIn inputArray, FieldOut outputArray);
+  using ExecutionSignature = void(_1, _2);
+  using InputDomain = _1;
+
+  template <typename InFieldType, typename OutFieldType>
+  VISKORES_EXEC void operator()(const InFieldType& inField, OutFieldType& outField) const
+  {
+    outField = cvt_uint32_srgb(inField);
+  }
+
+  //  private:
+  //   viskores::Float32 Exponent = 1.1f / 2.2f;
+};
+
+// Helper functions ///////////////////////////////////////////////////////////
+
+template <typename R, typename TASK_T>
+static std::future<R> async(TASK_T&& fcn)
+{
+  auto task = std::packaged_task<R()>(std::forward<TASK_T>(fcn));
+  auto future = task.get_future();
+  std::thread([task = std::move(task)]() mutable { task(); }).detach();
+  return future;
+}
+
+template <typename R>
+static bool is_ready(const std::future<R>& f)
+{
+  return !f.valid() || f.wait_for(std::chrono::seconds(0)) == std::future_status::ready;
+}
+
+// Frame definitions //////////////////////////////////////////////////////////
+
+Frame::Frame(ViskoresDeviceGlobalState* s)
+  : helium::BaseFrame(s)
+{
+}
+
+Frame::~Frame()
+{
+  wait();
+  deviceState()->objectCounts.frames--;
+}
+
+bool Frame::isValid() const
+{
+  return m_valid;
+}
+
+ViskoresDeviceGlobalState* Frame::deviceState() const
+{
+  return (ViskoresDeviceGlobalState*)helium::BaseObject::m_state;
+}
+
+void Frame::commitParameters()
+{
+  m_renderer = getParamObject<Renderer>("renderer");
+  if (!m_renderer)
+  {
+    reportMessage(ANARI_SEVERITY_WARNING, "missing required parameter 'renderer' on frame");
+  }
+
+  m_camera = getParamObject<Camera>("camera");
+  if (!m_camera)
+  {
+    reportMessage(ANARI_SEVERITY_WARNING, "missing required parameter 'camera' on frame");
+  }
+
+  m_world = getParamObject<World>("world");
+  if (!m_world)
+  {
+    reportMessage(ANARI_SEVERITY_WARNING, "missing required parameter 'world' on frame");
+  }
+
+  m_valid = m_renderer && m_renderer->isValid() && m_camera && m_camera->isValid() && m_world &&
+    m_world->isValid();
+
+  m_colorType = getParam<anari::DataType>("channel.color", ANARI_UNKNOWN);
+  m_depthType = getParam<anari::DataType>("channel.depth", ANARI_UNKNOWN);
+  m_primIdType = getParam<anari::DataType>("channel.primitiveId", ANARI_UNKNOWN);
+  m_objIdType = getParam<anari::DataType>("channel.objectId", ANARI_UNKNOWN);
+  m_instIdType = getParam<anari::DataType>("channel.instanceId", ANARI_UNKNOWN);
+
+  m_frameData.size = getParam<uint2>("size", uint2(10));
+}
+
+void Frame::finalize()
+{
+  this->Canvas =
+    viskores::rendering::CanvasRayTracer(this->m_frameData.size[0], this->m_frameData.size[1]);
+  this->Canvas.SetBackgroundColor(this->m_renderer->background());
+
+  const auto numPixels = m_frameData.size[0] * m_frameData.size[1];
+
+  m_perPixelBytes = 4 * (m_colorType == ANARI_FLOAT32_VEC4 ? 4 : 1);
+  m_pixelBuffer.resize(numPixels * m_perPixelBytes);
+
+  m_depthBuffer.resize(m_depthType == ANARI_FLOAT32 ? numPixels : 0);
+  m_frameChanged = true;
+
+  m_primIdBuffer.clear();
+  m_objIdBuffer.clear();
+  m_instIdBuffer.clear();
+
+  if (m_primIdType == ANARI_UINT32)
+    m_primIdBuffer.resize(numPixels);
+  if (m_objIdType == ANARI_UINT32)
+    m_objIdBuffer.resize(numPixels);
+  if (m_instIdType == ANARI_UINT32)
+    m_instIdBuffer.resize(numPixels);
+}
+
+bool Frame::getProperty(const std::string_view& name,
+                        ANARIDataType type,
+                        void* ptr,
+                        uint64_t viskoresNotUsed(size),
+                        uint32_t viskoresNotUsed(flags))
+{
+  if (type == ANARI_FLOAT32 && name == "duration")
+  {
+    helium::writeToVoidP(ptr, m_duration);
+    return true;
+  }
+
+  return 0;
+}
+
+void Frame::renderFrame()
+{
+  this->refInc(helium::RefType::INTERNAL);
+
+  auto* state = deviceState();
+  state->waitOnCurrentFrame();
+  state->currentFrame = this;
+
+  m_future = async<void>(
+    [&, state]()
+    {
+      auto start = std::chrono::steady_clock::now();
+      state->renderingSemaphore.frameStart();
+      state->commitBuffer.flush();
+
+      if (!m_renderer)
+      {
+        reportMessage(ANARI_SEVERITY_ERROR, "skipping render of incomplete frame object");
+        std::fill(m_pixelBuffer.begin(), m_pixelBuffer.end(), 0);
+      }
+      else
+      {
+        reportMessage(ANARI_SEVERITY_DEBUG, "rendering frame");
+
+        const auto& instances = this->m_world->instances();
+        auto camera = this->m_camera->camera(this->m_world->bounds());
+
+#if 0
+      std::cout << "\n\nANARI camera:" << std::endl;
+      camera.Print();
+#endif
+
+        std::vector<Surface*> surfacesToRender;
+        std::vector<Volume*> volumesToRender;
+
+        for (const auto& instance : instances)
+        {
+          if (!instance->isValid())
+          {
+            reportMessage(ANARI_SEVERITY_DEBUG, "skip rendering invalid group");
+            continue;
+          }
+
+          auto& surfaces = instance->group()->surfaces();
+          surfacesToRender.insert(surfacesToRender.end(), surfaces.begin(), surfaces.end());
+
+          auto& volumes = instance->group()->volumes();
+          volumesToRender.insert(volumesToRender.end(), volumes.begin(), volumes.end());
+        }
+
+        this->Canvas.Clear();
+
+        for (const auto& surface : surfacesToRender)
+        {
+          if (!surface || !surface->isValid())
+          {
+            reportMessage(ANARI_SEVERITY_DEBUG, "skip rendering invalid surface");
+            continue;
+          }
+          viskores::rendering::Scene scene;
+          scene.AddActor(*surface->actor());
+          std::unique_ptr<viskores::rendering::Mapper> mapper{
+            surface->geometry()->mapper()->NewCopy()
+          };
+          scene.Render(*mapper, this->Canvas, camera);
+        }
+
+        for (const auto& volume : volumesToRender)
+        {
+          if (!volume || !volume->isValid())
+          {
+            reportMessage(ANARI_SEVERITY_DEBUG, "skip rendering invalid volume");
+            continue;
+          }
+          viskores::rendering::Scene scene;
+          scene.AddActor(*volume->actor());
+          std::unique_ptr<viskores::rendering::Mapper> mapper{ volume->mapper()->NewCopy() };
+          scene.Render(*mapper, this->Canvas, camera);
+        }
+      }
+
+      this->Canvas.BlendBackground();
+
+      state->renderingSemaphore.frameEnd();
+      auto end = std::chrono::steady_clock::now();
+      m_duration = std::chrono::duration<float>(end - start).count();
+    });
+}
+
+void* Frame::map(std::string_view channel,
+                 uint32_t* width,
+                 uint32_t* height,
+                 ANARIDataType* pixelType)
+{
+  wait();
+
+  *width = m_frameData.size[0];
+  *height = m_frameData.size[1];
+
+  if (channel == "channel.color")
+  {
+    *pixelType = this->m_colorType;
+    if (this->m_colorType == ANARI_FLOAT32_VEC4)
+    {
+      // change this to GetReadPointer().
+      viskores::cont::ArrayHandleBasic<viskores::Vec4f_32> basicArray =
+        this->Canvas.GetColorBuffer();
+      return basicArray.GetWritePointer();
+    }
+    else if (this->m_colorType == ANARI_UFIXED8_VEC4)
+    {
+      this->m_intFrameBuffer.Allocate(*width * *height);
+      ConvertToRGBA worklet;
+      viskores::cont::Invoker invoker;
+      invoker(worklet, this->Canvas.GetColorBuffer(), this->m_intFrameBuffer);
+      viskores::cont::ArrayHandleBasic<viskores::UInt32> basicArray = this->m_intFrameBuffer;
+      return basicArray.GetWritePointer();
+    }
+    else if (this->m_colorType == ANARI_UFIXED8_RGBA_SRGB)
+    {
+      this->m_intFrameBuffer.Allocate(*width * *height);
+      ConvertToSRGBA worklet;
+      viskores::cont::Invoker invoker;
+      invoker(worklet, this->Canvas.GetColorBuffer(), this->m_intFrameBuffer);
+
+      viskores::cont::ArrayHandleBasic<viskores::UInt32> basicArray = this->m_intFrameBuffer;
+      // Note: Although we are returning a non-const pointer, this is
+      // essentially a mistake in the ANARI API. Client code is not supposed
+      // to modify the buffer.
+      return const_cast<viskores::UInt32*>(basicArray.GetReadPointer());
+    }
+  }
+  else if (channel == "channel.depth")
+  {
+    *pixelType = ANARI_FLOAT32;
+    viskores::cont::ArrayHandleBasic<viskores::Float32> basicArray = this->Canvas.GetDepthBuffer();
+    // Note: Although we are returning a non-const pointer, this is
+    // essentially a mistake in the ANARI API. Client code is not supposed
+    // to modify the buffer.
+    return const_cast<viskores::Float32*>(basicArray.GetReadPointer());
+  }
+  else if (channel == "channel.primitiveId" && !m_primIdBuffer.empty())
+  {
+    *pixelType = ANARI_UINT32;
+    return m_primIdBuffer.data();
+  }
+  else if (channel == "channel.objectId" && !m_objIdBuffer.empty())
+  {
+    *pixelType = ANARI_UINT32;
+    return m_objIdBuffer.data();
+  }
+  else if (channel == "channel.instanceId" && !m_instIdBuffer.empty())
+  {
+    *pixelType = ANARI_UINT32;
+    return m_instIdBuffer.data();
+  }
+
+  *width = 0;
+  *height = 0;
+  *pixelType = ANARI_UNKNOWN;
+  return nullptr;
+}
+
+void Frame::unmap(std::string_view /*channel*/)
+{
+  // no-op
+}
+
+int Frame::frameReady(ANARIWaitMask m)
+{
+  if (m == ANARI_NO_WAIT)
+    return ready();
+  else
+  {
+    wait();
+    return 1;
+  }
+}
+
+void Frame::discard()
+{
+  this->m_intFrameBuffer.ReleaseResources();
+}
+
+bool Frame::ready() const
+{
+  return is_ready(m_future);
+}
+
+void Frame::wait()
+{
+  if (m_future.valid())
+  {
+    m_future.get();
+    this->refDec(helium::RefType::INTERNAL);
+    if (deviceState()->currentFrame == this)
+      deviceState()->currentFrame = nullptr;
+  }
+}
+
+void Frame::writeSample(int x, int y, const PixelSample& s)
+{
+  const auto idx = y * m_frameData.size[0] + x;
+  auto* color = m_pixelBuffer.data() + (idx * m_perPixelBytes);
+  switch (m_colorType)
+  {
+    case ANARI_UFIXED8_VEC4:
+    {
+      auto c = cvt_uint32(s.color);
+      std::memcpy(color, &c, sizeof(c));
+      break;
+    }
+    case ANARI_UFIXED8_RGBA_SRGB:
+    {
+      auto c = cvt_uint32_srgb(s.color);
+      std::memcpy(color, &c, sizeof(c));
+      break;
+    }
+    case ANARI_FLOAT32_VEC4:
+    {
+      std::memcpy(color, &s.color, sizeof(s.color));
+      break;
+    }
+    default:
+      break;
+  }
+  if (!m_depthBuffer.empty())
+    m_depthBuffer[idx] = s.depth;
+  if (!m_primIdBuffer.empty())
+    m_primIdBuffer[idx] = s.primId;
+  if (!m_objIdBuffer.empty())
+    m_objIdBuffer[idx] = s.objId;
+  if (!m_instIdBuffer.empty())
+    m_instIdBuffer[idx] = s.instId;
+}
+
+} // namespace viskores_device
+
+VISKORES_ANARI_TYPEFOR_DEFINITION(viskores_device::Frame*);

--- a/viskores/rendering/anari-device/frame/Frame.h
+++ b/viskores/rendering/anari-device/frame/Frame.h
@@ -1,0 +1,107 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#pragma once
+
+#include "camera/Camera.h"
+#include "renderer/Renderer.h"
+#include "scene/World.h"
+// helium
+#include "helium/BaseFrame.h"
+// std
+#include "../ViskoresTypes.h"
+#include <future>
+#include <vector>
+
+#include <viskores/rendering/CanvasRayTracer.h>
+
+namespace viskores_device
+{
+
+struct Frame : public helium::BaseFrame
+{
+  Frame(ViskoresDeviceGlobalState* s);
+  ~Frame();
+
+  bool isValid() const override;
+
+  ViskoresDeviceGlobalState* deviceState() const;
+
+  bool getProperty(const std::string_view& name,
+                   ANARIDataType type,
+                   void* ptr,
+                   uint64_t size,
+                   uint32_t flags) override;
+
+  void commitParameters() override;
+  void finalize() override;
+
+  void renderFrame() override;
+
+  void* map(std::string_view channel,
+            uint32_t* width,
+            uint32_t* height,
+            ANARIDataType* pixelType) override;
+  void unmap(std::string_view channel) override;
+  int frameReady(ANARIWaitMask m) override;
+  void discard() override;
+
+  bool ready() const;
+  void wait();
+
+private:
+  float2 screenFromPixel(const float2& p) const;
+  void writeSample(int x, int y, const PixelSample& s);
+
+  //// Data ////
+
+  bool m_valid{ false };
+  int m_perPixelBytes{ 1 };
+
+  struct FrameData
+  {
+    int frameID{ 0 };
+    uint2 size;
+  } m_frameData;
+
+  anari::DataType m_colorType{ ANARI_UNKNOWN };
+  anari::DataType m_depthType{ ANARI_UNKNOWN };
+  anari::DataType m_primIdType{ ANARI_UNKNOWN };
+  anari::DataType m_objIdType{ ANARI_UNKNOWN };
+  anari::DataType m_instIdType{ ANARI_UNKNOWN };
+
+  std::vector<uint8_t> m_pixelBuffer;
+  std::vector<float> m_depthBuffer;
+  std::vector<uint32_t> m_primIdBuffer;
+  std::vector<uint32_t> m_objIdBuffer;
+  std::vector<uint32_t> m_instIdBuffer;
+
+  helium::IntrusivePtr<Renderer> m_renderer;
+  helium::IntrusivePtr<Camera> m_camera;
+  helium::IntrusivePtr<World> m_world;
+
+  viskores::rendering::CanvasRayTracer Canvas;
+  //viskores::cont::ArrayHandle<viskores::UInt8> m_bytesFrameBuffer;
+  viskores::cont::ArrayHandle<viskores::UInt32> m_intFrameBuffer;
+
+  float m_duration{ 0.f };
+
+  bool m_frameChanged{ false };
+  helium::TimeStamp m_cameraLastChanged{ 0 };
+  helium::TimeStamp m_rendererLastChanged{ 0 };
+  helium::TimeStamp m_worldLastChanged{ 0 };
+  helium::TimeStamp m_frameLastRendered{ 0 };
+
+  mutable std::future<void> m_future;
+};
+
+} // namespace viskores_device
+
+VISKORES_ANARI_TYPEFOR_SPECIALIZATION(viskores_device::Frame*, ANARI_FRAME);

--- a/viskores/rendering/anari-device/linalg.h
+++ b/viskores/rendering/anari-device/linalg.h
@@ -1,0 +1,792 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+// linalg.h - 2.2-beta - Single-header public domain linear algebra library
+//
+// The intent of this library is to provide the bulk of the functionality
+// you need to write programs that frequently use small, fixed-size vectors
+// and matrices, in domains such as computational geometry or computer
+// graphics. It strives for terse, readable source code.
+//
+// The original author of this software is Sterling Orsten, and its permanent
+// home is <http://github.com/sgorsten/linalg/>. If you find this software
+// useful, an acknowledgement in your source text and/or product documentation
+// is appreciated, but not required.
+//
+// The author acknowledges significant insights and contributions by:
+//     Stan Melax <http://github.com/melax/>
+//     Dimitri Diakopoulos <http://github.com/ddiakopoulos/>
+//
+// Some features are deprecated. Define LINALG_FORWARD_COMPATIBLE to remove
+// them.
+
+// This is free and unencumbered software released into the public domain.
+//
+// Anyone is free to copy, modify, publish, use, compile, sell, or
+// distribute this software, either in source code form or as a compiled
+// binary, for any purpose, commercial or non-commercial, and by any
+// means.
+//
+// In jurisdictions that recognize copyright laws, the author or authors
+// of this software dedicate any and all copyright interest in the
+// software to the public domain. We make this dedication for the benefit
+// of the public at large and to the detriment of our heirs and
+// successors. We intend this dedication to be an overt act of
+// relinquishment in perpetuity of all present and future rights to this
+// software under copyright law.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+// OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+//
+// For more information, please refer to <http://unlicense.org/>
+
+// clang-format off
+
+#pragma once
+#ifndef LINALG_H
+#define LINALG_H
+
+// anari_cpp
+#include "../Traits.h"
+
+#include <cmath>        // For various unary math functions, such as std::sqrt
+#include <cstdlib>      // To resolve std::abs ambiguity on clang
+#include <cstdint>      // For implementing namespace linalg::aliases
+#include <array>        // For std::array
+#include <iosfwd>       // For forward definitions of std::ostream
+#include <type_traits>  // For std::enable_if, std::is_same, std::declval
+#include <functional>   // For std::hash declaration
+
+// In Visual Studio 2015, `constexpr` applied to a member function implies `const`, which causes ambiguous overload resolution
+#if _MSC_VER <= 1900
+#define LINALG_CONSTEXPR14
+#else
+#define LINALG_CONSTEXPR14 constexpr
+#endif
+
+namespace linalg
+{
+    // Small, fixed-length vector type, consisting of exactly M elements of type T, and presumed to be a column-vector unless otherwise noted.
+    template<class T, int M> struct vec;
+
+    // Small, fixed-size matrix type, consisting of exactly M rows and N columns of type T, stored in column-major order.
+    template<class T, int M, int N> struct mat;
+
+    // Specialize converter<T,U> with a function application operator that converts type U to type T to enable implicit conversions
+    template<class T, class U> struct converter {};
+    namespace detail
+    {
+        template<class T, class U> using conv_t = typename std::enable_if<!std::is_same<T,U>::value, decltype(converter<T,U>{}(std::declval<U>()))>::type;
+
+        // Trait for retrieving scalar type of any linear algebra object
+        template<class A> struct scalar_type {};
+        template<class T, int M       > struct scalar_type<vec<T,M  >> { using type = T; };
+        template<class T, int M, int N> struct scalar_type<mat<T,M,N>> { using type = T; };
+
+        // Type returned by the compare(...) function which supports all six comparison operators against 0
+        template<class T> struct ord { T a,b; };
+        template<class T> constexpr bool operator == (const ord<T> & o, std::nullptr_t) { return o.a == o.b; }
+        template<class T> constexpr bool operator != (const ord<T> & o, std::nullptr_t) { return !(o.a == o.b); }
+        template<class T> constexpr bool operator < (const ord<T> & o, std::nullptr_t) { return o.a < o.b; }
+        template<class T> constexpr bool operator > (const ord<T> & o, std::nullptr_t) { return o.b < o.a; }
+        template<class T> constexpr bool operator <= (const ord<T> & o, std::nullptr_t) { return !(o.b < o.a); }
+        template<class T> constexpr bool operator >= (const ord<T> & o, std::nullptr_t) { return !(o.a < o.b); }
+
+        // Patterns which can be used with the compare(...) function
+        template<class A, class B> struct any_compare {};
+        template<class T> struct any_compare<vec<T,1>,vec<T,1>> { using type=ord<T>; constexpr ord<T> operator() (const vec<T,1> & a, const vec<T,1> & b) const { return ord<T>{a.x,b.x}; } };
+        template<class T> struct any_compare<vec<T,2>,vec<T,2>> { using type=ord<T>; constexpr ord<T> operator() (const vec<T,2> & a, const vec<T,2> & b) const { return !(a.x==b.x) ? ord<T>{a.x,b.x} : ord<T>{a.y,b.y}; } };
+        template<class T> struct any_compare<vec<T,3>,vec<T,3>> { using type=ord<T>; constexpr ord<T> operator() (const vec<T,3> & a, const vec<T,3> & b) const { return !(a.x==b.x) ? ord<T>{a.x,b.x} : !(a.y==b.y) ? ord<T>{a.y,b.y} : ord<T>{a.z,b.z}; } };
+        template<class T> struct any_compare<vec<T,4>,vec<T,4>> { using type=ord<T>; constexpr ord<T> operator() (const vec<T,4> & a, const vec<T,4> & b) const { return !(a.x==b.x) ? ord<T>{a.x,b.x} : !(a.y==b.y) ? ord<T>{a.y,b.y} : !(a.z==b.z) ? ord<T>{a.z,b.z} : ord<T>{a.w,b.w}; } };
+        template<class T, int M> struct any_compare<mat<T,M,1>,mat<T,M,1>> { using type=ord<T>; constexpr ord<T> operator() (const mat<T,M,1> & a, const mat<T,M,1> & b) const { return compare(a.x,b.x); } };
+        template<class T, int M> struct any_compare<mat<T,M,2>,mat<T,M,2>> { using type=ord<T>; constexpr ord<T> operator() (const mat<T,M,2> & a, const mat<T,M,2> & b) const { return a.x!=b.x ? compare(a.x,b.x) : compare(a.y,b.y); } };
+        template<class T, int M> struct any_compare<mat<T,M,3>,mat<T,M,3>> { using type=ord<T>; constexpr ord<T> operator() (const mat<T,M,3> & a, const mat<T,M,3> & b) const { return a.x!=b.x ? compare(a.x,b.x) : a.y!=b.y ? compare(a.y,b.y) : compare(a.z,b.z); } };
+        template<class T, int M> struct any_compare<mat<T,M,4>,mat<T,M,4>> { using type=ord<T>; constexpr ord<T> operator() (const mat<T,M,4> & a, const mat<T,M,4> & b) const { return a.x!=b.x ? compare(a.x,b.x) : a.y!=b.y ? compare(a.y,b.y) : a.z!=b.z ? compare(a.z,b.z) : compare(a.w,b.w); } };
+
+        // Helper for compile-time index-based access to members of vector and matrix types
+        template<int I> struct getter;
+        template<> struct getter<0> { template<class A> constexpr auto operator() (A & a) const -> decltype(a.x) { return a.x; } };
+        template<> struct getter<1> { template<class A> constexpr auto operator() (A & a) const -> decltype(a.y) { return a.y; } };
+        template<> struct getter<2> { template<class A> constexpr auto operator() (A & a) const -> decltype(a.z) { return a.z; } };
+        template<> struct getter<3> { template<class A> constexpr auto operator() (A & a) const -> decltype(a.w) { return a.w; } };
+
+        // Stand-in for std::integer_sequence/std::make_integer_sequence
+        template<int... I> struct seq {};
+        template<int A, int N> struct make_seq_impl;
+        template<int A> struct make_seq_impl<A,0> { using type=seq<>; };
+        template<int A> struct make_seq_impl<A,1> { using type=seq<A+0>; };
+        template<int A> struct make_seq_impl<A,2> { using type=seq<A+0,A+1>; };
+        template<int A> struct make_seq_impl<A,3> { using type=seq<A+0,A+1,A+2>; };
+        template<int A> struct make_seq_impl<A,4> { using type=seq<A+0,A+1,A+2,A+3>; };
+        template<int A, int B> using make_seq = typename make_seq_impl<A,B-A>::type;
+        template<class T, int M, int... I> vec<T,sizeof...(I)> constexpr swizzle(const vec<T,M> & v, seq<I...> i) { return {getter<I>{}(v)...}; }
+        template<class T, int M, int N, int... I, int... J> mat<T,sizeof...(I),sizeof...(J)> constexpr swizzle(const mat<T,M,N> & m, seq<I...> i, seq<J...> j) { return {swizzle(getter<J>{}(m),i)...}; }
+
+        // SFINAE helpers to determine result of function application
+        template<class F, class... T> using ret_t = decltype(std::declval<F>()(std::declval<T>()...));
+
+        // SFINAE helper which is defined if all provided types are scalars
+        struct empty {};
+        template<class... T> struct scalars;
+        template<> struct scalars<> { using type=void; };
+        template<class T, class... U> struct scalars<T,U...> : std::conditional<std::is_arithmetic<T>::value, scalars<U...>, empty>::type {};
+        template<class... T> using scalars_t = typename scalars<T...>::type;
+
+        // Helpers which indicate how apply(F, ...) should be called for various arguments
+        template<class F, class Void, class... T> struct apply {}; // Patterns which contain only vectors or scalars
+        template<class F, int M, class A                  > struct apply<F, scalars_t<   >, vec<A,M>                    > { using type=vec<ret_t<F,A    >,M>; enum {size=M, mm=0}; template<int... I> static constexpr type impl(seq<I...>, F f, const vec<A,M> & a                                        ) { return {f(getter<I>{}(a)                                )...}; } };
+        template<class F, int M, class A, class B         > struct apply<F, scalars_t<   >, vec<A,M>, vec<B,M>          > { using type=vec<ret_t<F,A,B  >,M>; enum {size=M, mm=0}; template<int... I> static constexpr type impl(seq<I...>, F f, const vec<A,M> & a, const vec<B,M> & b                    ) { return {f(getter<I>{}(a), getter<I>{}(b)                )...}; } };
+        template<class F, int M, class A, class B         > struct apply<F, scalars_t<B  >, vec<A,M>, B                 > { using type=vec<ret_t<F,A,B  >,M>; enum {size=M, mm=0}; template<int... I> static constexpr type impl(seq<I...>, F f, const vec<A,M> & a, B                b                    ) { return {f(getter<I>{}(a), b                             )...}; } };
+        template<class F, int M, class A, class B         > struct apply<F, scalars_t<A  >, A,        vec<B,M>          > { using type=vec<ret_t<F,A,B  >,M>; enum {size=M, mm=0}; template<int... I> static constexpr type impl(seq<I...>, F f, A                a, const vec<B,M> & b                    ) { return {f(a,              getter<I>{}(b)                )...}; } };
+        template<class F, int M, class A, class B, class C> struct apply<F, scalars_t<   >, vec<A,M>, vec<B,M>, vec<C,M>> { using type=vec<ret_t<F,A,B,C>,M>; enum {size=M, mm=0}; template<int... I> static constexpr type impl(seq<I...>, F f, const vec<A,M> & a, const vec<B,M> & b, const vec<C,M> & c) { return {f(getter<I>{}(a), getter<I>{}(b), getter<I>{}(c))...}; } };
+        template<class F, int M, class A, class B, class C> struct apply<F, scalars_t<C  >, vec<A,M>, vec<B,M>, C       > { using type=vec<ret_t<F,A,B,C>,M>; enum {size=M, mm=0}; template<int... I> static constexpr type impl(seq<I...>, F f, const vec<A,M> & a, const vec<B,M> & b, C                c) { return {f(getter<I>{}(a), getter<I>{}(b), c             )...}; } };
+        template<class F, int M, class A, class B, class C> struct apply<F, scalars_t<B  >, vec<A,M>, B,        vec<C,M>> { using type=vec<ret_t<F,A,B,C>,M>; enum {size=M, mm=0}; template<int... I> static constexpr type impl(seq<I...>, F f, const vec<A,M> & a, B                b, const vec<C,M> & c) { return {f(getter<I>{}(a), b,              getter<I>{}(c))...}; } };
+        template<class F, int M, class A, class B, class C> struct apply<F, scalars_t<B,C>, vec<A,M>, B,        C       > { using type=vec<ret_t<F,A,B,C>,M>; enum {size=M, mm=0}; template<int... I> static constexpr type impl(seq<I...>, F f, const vec<A,M> & a, B                b, C                c) { return {f(getter<I>{}(a), b,              c             )...}; } };
+        template<class F, int M, class A, class B, class C> struct apply<F, scalars_t<A  >, A,        vec<B,M>, vec<C,M>> { using type=vec<ret_t<F,A,B,C>,M>; enum {size=M, mm=0}; template<int... I> static constexpr type impl(seq<I...>, F f, A                a, const vec<B,M> & b, const vec<C,M> & c) { return {f(a,              getter<I>{}(b), getter<I>{}(c))...}; } };
+        template<class F, int M, class A, class B, class C> struct apply<F, scalars_t<A,C>, A,        vec<B,M>, C       > { using type=vec<ret_t<F,A,B,C>,M>; enum {size=M, mm=0}; template<int... I> static constexpr type impl(seq<I...>, F f, A                a, const vec<B,M> & b, C                c) { return {f(a,              getter<I>{}(b), c             )...}; } };
+        template<class F, int M, class A, class B, class C> struct apply<F, scalars_t<A,B>, A,        B,        vec<C,M>> { using type=vec<ret_t<F,A,B,C>,M>; enum {size=M, mm=0}; template<int... I> static constexpr type impl(seq<I...>, F f, A                a, B                b, const vec<C,M> & c) { return {f(a,              b,              getter<I>{}(c))...}; } };
+        template<class F, int M, int N, class A         > struct apply<F, scalars_t< >, mat<A,M,N>            > { using type=mat<ret_t<F,A  >,M,N>; enum {size=N, mm=0}; template<int... J> static constexpr type impl(seq<J...>, F f, const mat<A,M,N> & a                      ) { return {apply<F, void, vec<A,M>          >::impl(make_seq<0,M>{}, f, getter<J>{}(a)                )...}; } };
+        template<class F, int M, int N, class A, class B> struct apply<F, scalars_t< >, mat<A,M,N>, mat<B,M,N>> { using type=mat<ret_t<F,A,B>,M,N>; enum {size=N, mm=1}; template<int... J> static constexpr type impl(seq<J...>, F f, const mat<A,M,N> & a, const mat<B,M,N> & b) { return {apply<F, void, vec<A,M>, vec<B,M>>::impl(make_seq<0,M>{}, f, getter<J>{}(a), getter<J>{}(b))...}; } };
+        template<class F, int M, int N, class A, class B> struct apply<F, scalars_t<B>, mat<A,M,N>, B         > { using type=mat<ret_t<F,A,B>,M,N>; enum {size=N, mm=0}; template<int... J> static constexpr type impl(seq<J...>, F f, const mat<A,M,N> & a, B                  b) { return {apply<F, void, vec<A,M>, B       >::impl(make_seq<0,M>{}, f, getter<J>{}(a), b             )...}; } };
+        template<class F, int M, int N, class A, class B> struct apply<F, scalars_t<A>, A,          mat<B,M,N>> { using type=mat<ret_t<F,A,B>,M,N>; enum {size=N, mm=0}; template<int... J> static constexpr type impl(seq<J...>, F f, A                  a, const mat<B,M,N> & b) { return {apply<F, void, A,        vec<B,M>>::impl(make_seq<0,M>{}, f, a,              getter<J>{}(b))...}; } };
+        template<class F, class... A> struct apply<F, scalars_t<A...>, A...> { using type = ret_t<F,A...>; enum {size=0, mm=0}; static constexpr type impl(seq<>, F f, A... a) { return f(a...); } };
+
+        // Function objects for selecting between alternatives
+        struct min    { template<class A, class B> constexpr auto operator() (A a, B b) const -> typename std::remove_reference<decltype(a<b ? a : b)>::type { return a<b ? a : b; } };
+        struct max    { template<class A, class B> constexpr auto operator() (A a, B b) const -> typename std::remove_reference<decltype(a<b ? b : a)>::type { return a<b ? b : a; } };
+        struct clamp  { template<class A, class B, class C> constexpr auto operator() (A a, B b, C c) const -> typename std::remove_reference<decltype(a<b ? b : a<c ? a : c)>::type { return a<b ? b : a<c ? a : c; } };
+        struct select { template<class A, class B, class C> constexpr auto operator() (A a, B b, C c) const -> typename std::remove_reference<decltype(a ? b : c)>::type             { return a ? b : c; } };
+        struct lerp   { template<class A, class B, class C> constexpr auto operator() (A a, B b, C c) const -> decltype(a*(1-c) + b*c)                                               { return a*(1-c) + b*c; } };
+
+        // Function objects for applying operators
+        struct op_pos { template<class A> constexpr auto operator() (A a) const -> decltype(+a) { return +a; } };
+        struct op_neg { template<class A> constexpr auto operator() (A a) const -> decltype(-a) { return -a; } };
+        struct op_not { template<class A> constexpr auto operator() (A a) const -> decltype(!a) { return !a; } };
+        struct op_cmp { template<class A> constexpr auto operator() (A a) const -> decltype(~(a)) { return ~a; } };
+        struct op_mul { template<class A, class B> constexpr auto operator() (A a, B b) const -> decltype(a * b)  { return a * b; } };
+        struct op_div { template<class A, class B> constexpr auto operator() (A a, B b) const -> decltype(a / b)  { return a / b; } };
+        struct op_mod { template<class A, class B> constexpr auto operator() (A a, B b) const -> decltype(a % b)  { return a % b; } };
+        struct op_add { template<class A, class B> constexpr auto operator() (A a, B b) const -> decltype(a + b)  { return a + b; } };
+        struct op_sub { template<class A, class B> constexpr auto operator() (A a, B b) const -> decltype(a - b)  { return a - b; } };
+        struct op_lsh { template<class A, class B> constexpr auto operator() (A a, B b) const -> decltype(a << b) { return a << b; } };
+        struct op_rsh { template<class A, class B> constexpr auto operator() (A a, B b) const -> decltype(a >> b) { return a >> b; } };
+        struct op_lt  { template<class A, class B> constexpr auto operator() (A a, B b) const -> decltype(a < b)  { return a < b; } };
+        struct op_gt  { template<class A, class B> constexpr auto operator() (A a, B b) const -> decltype(a > b)  { return a > b; } };
+        struct op_le  { template<class A, class B> constexpr auto operator() (A a, B b) const -> decltype(a <= b) { return a <= b; } };
+        struct op_ge  { template<class A, class B> constexpr auto operator() (A a, B b) const -> decltype(a >= b) { return a >= b; } };
+        struct op_eq  { template<class A, class B> constexpr auto operator() (A a, B b) const -> decltype(a == b) { return a == b; } };
+        struct op_ne  { template<class A, class B> constexpr auto operator() (A a, B b) const -> decltype(a != b) { return a != b; } };
+        struct op_int { template<class A, class B> constexpr auto operator() (A a, B b) const -> decltype(a & b)  { return a & b; } };
+        struct op_xor { template<class A, class B> constexpr auto operator() (A a, B b) const -> decltype(a ^ b)  { return a ^ b; } };
+        struct op_un  { template<class A, class B> constexpr auto operator() (A a, B b) const -> decltype(a | b)  { return a | b; } };
+        struct op_and { template<class A, class B> constexpr auto operator() (A a, B b) const -> decltype(a && b) { return a && b; } };
+        struct op_or  { template<class A, class B> constexpr auto operator() (A a, B b) const -> decltype(a || b) { return a || b; } };
+
+        // Function objects for applying standard library math functions
+        struct std_abs      { template<class A> auto operator() (A a) const -> decltype(std::abs  (a)) { return std::abs  (a); } };
+        struct std_floor    { template<class A> auto operator() (A a) const -> decltype(std::floor(a)) { return std::floor(a); } };
+        struct std_ceil     { template<class A> auto operator() (A a) const -> decltype(std::ceil (a)) { return std::ceil (a); } };
+        struct std_exp      { template<class A> auto operator() (A a) const -> decltype(std::exp  (a)) { return std::exp  (a); } };
+        struct std_log      { template<class A> auto operator() (A a) const -> decltype(std::log  (a)) { return std::log  (a); } };
+        struct std_log10    { template<class A> auto operator() (A a) const -> decltype(std::log10(a)) { return std::log10(a); } };
+        struct std_sqrt     { template<class A> auto operator() (A a) const -> decltype(std::sqrt (a)) { return std::sqrt (a); } };
+        struct std_sin      { template<class A> auto operator() (A a) const -> decltype(std::sin  (a)) { return std::sin  (a); } };
+        struct std_cos      { template<class A> auto operator() (A a) const -> decltype(std::cos  (a)) { return std::cos  (a); } };
+        struct std_tan      { template<class A> auto operator() (A a) const -> decltype(std::tan  (a)) { return std::tan  (a); } };
+        struct std_asin     { template<class A> auto operator() (A a) const -> decltype(std::asin (a)) { return std::asin (a); } };
+        struct std_acos     { template<class A> auto operator() (A a) const -> decltype(std::acos (a)) { return std::acos (a); } };
+        struct std_atan     { template<class A> auto operator() (A a) const -> decltype(std::atan (a)) { return std::atan (a); } };
+        struct std_sinh     { template<class A> auto operator() (A a) const -> decltype(std::sinh (a)) { return std::sinh (a); } };
+        struct std_cosh     { template<class A> auto operator() (A a) const -> decltype(std::cosh (a)) { return std::cosh (a); } };
+        struct std_tanh     { template<class A> auto operator() (A a) const -> decltype(std::tanh (a)) { return std::tanh (a); } };
+        struct std_round    { template<class A> auto operator() (A a) const -> decltype(std::round(a)) { return std::round(a); } };
+        struct std_fmod     { template<class A, class B> auto operator() (A a, B b) const -> decltype(std::fmod    (a, b)) { return std::fmod    (a, b); } };
+        struct std_pow      { template<class A, class B> auto operator() (A a, B b) const -> decltype(std::pow     (a, b)) { return std::pow     (a, b); } };
+        struct std_atan2    { template<class A, class B> auto operator() (A a, B b) const -> decltype(std::atan2   (a, b)) { return std::atan2   (a, b); } };
+        struct std_copysign { template<class A, class B> auto operator() (A a, B b) const -> decltype(std::copysign(a, b)) { return std::copysign(a, b); } };
+    }
+
+    // Small, fixed-length vector type, consisting of exactly M elements of type T, and presumed to be a column-vector unless otherwise noted
+    template<class T> struct vec<T,1>
+    {
+        T                           x;
+        constexpr                   vec()                               : x() {}
+        constexpr                   vec(const T & x_)                   : x(x_) {}
+        // NOTE: vec<T,1> does NOT have a constructor from pointer, this can conflict with initializing its single element from zero
+        template<class U>
+        constexpr explicit          vec(const vec<U,1> & v)             : vec(static_cast<T>(v.x)) {}
+        constexpr const T &         operator[] (int i) const            { return x; }
+        LINALG_CONSTEXPR14 T &      operator[] (int i)                  { return x; }
+
+        template<class U, class=detail::conv_t<vec,U>> constexpr vec(const U & u) : vec(converter<vec,U>{}(u)) {}
+        template<class U, class=detail::conv_t<U,vec>> constexpr operator U () const { return converter<U,vec>{}(*this); }
+    };
+    template<class T> struct vec<T,2>
+    {
+        T                           x,y;
+        constexpr                   vec()                               : x(), y() {}
+        constexpr                   vec(const T & x_, const T & y_)     : x(x_), y(y_) {}
+        constexpr explicit          vec(const T & s)                    : vec(s, s) {}
+        constexpr explicit          vec(const T * p)                    : vec(p[0], p[1]) {}
+        template<class U>
+        constexpr explicit          vec(const vec<U,2> & v)             : vec(static_cast<T>(v.x), static_cast<T>(v.y)) {}
+        constexpr const T &         operator[] (int i) const            { return i==0?x:y; }
+        LINALG_CONSTEXPR14 T &      operator[] (int i)                  { return i==0?x:y; }
+
+        template<class U, class=detail::conv_t<vec,U>> constexpr vec(const U & u) : vec(converter<vec,U>{}(u)) {}
+        template<class U, class=detail::conv_t<U,vec>> constexpr operator U () const { return converter<U,vec>{}(*this); }
+    };
+    template<class T> struct vec<T,3>
+    {
+        T                           x,y,z;
+        constexpr                   vec()                               : x(), y(), z() {}
+        constexpr                   vec(const T & x_, const T & y_,
+                                        const T & z_)                   : x(x_), y(y_), z(z_) {}
+        constexpr                   vec(const vec<T,2> & xy,
+                                        const T & z_)                   : vec(xy.x, xy.y, z_) {}
+        constexpr explicit          vec(const T & s)                    : vec(s, s, s) {}
+        constexpr explicit          vec(const T * p)                    : vec(p[0], p[1], p[2]) {}
+        template<class U>
+        constexpr explicit          vec(const vec<U,3> & v)             : vec(static_cast<T>(v.x), static_cast<T>(v.y), static_cast<T>(v.z)) {}
+        constexpr const T &         operator[] (int i) const            { return i==0?x:i==1?y:z; }
+        LINALG_CONSTEXPR14 T &      operator[] (int i)                  { return i==0?x:i==1?y:z; }
+        constexpr const vec<T,2> &  xy() const                          { return *reinterpret_cast<const vec<T,2> *>(this); }
+        vec<T,2> &                  xy()                                { return *reinterpret_cast<vec<T,2> *>(this); }
+
+        template<class U, class=detail::conv_t<vec,U>> constexpr vec(const U & u) : vec(converter<vec,U>{}(u)) {}
+        template<class U, class=detail::conv_t<U,vec>> constexpr operator U () const { return converter<U,vec>{}(*this); }
+    };
+    template<class T> struct vec<T,4>
+    {
+        T                           x,y,z,w;
+        constexpr                   vec()                               : x(), y(), z(), w() {}
+        constexpr                   vec(const T & x_, const T & y_,
+                                        const T & z_, const T & w_)     : x(x_), y(y_), z(z_), w(w_) {}
+        constexpr                   vec(const vec<T,2> & xy,
+                                        const T & z_, const T & w_)     : vec(xy.x, xy.y, z_, w_) {}
+        constexpr                   vec(const vec<T,3> & xyz,
+                                        const T & w_)                   : vec(xyz.x, xyz.y, xyz.z, w_) {}
+        constexpr explicit          vec(const T & s)                    : vec(s, s, s, s) {}
+        constexpr explicit          vec(const T * p)                    : vec(p[0], p[1], p[2], p[3]) {}
+        template<class U>
+        constexpr explicit          vec(const vec<U,4> & v)             : vec(static_cast<T>(v.x), static_cast<T>(v.y), static_cast<T>(v.z), static_cast<T>(v.w)) {}
+        constexpr const T &         operator[] (int i) const            { return i==0?x:i==1?y:i==2?z:w; }
+        LINALG_CONSTEXPR14 T &      operator[] (int i)                  { return i==0?x:i==1?y:i==2?z:w; }
+        constexpr const vec<T,2> &  xy() const                          { return *reinterpret_cast<const vec<T,2> *>(this); }
+        constexpr const vec<T,3> &  xyz() const                         { return *reinterpret_cast<const vec<T,3> *>(this); }
+        vec<T,2> &                  xy()                                { return *reinterpret_cast<vec<T,2> *>(this); }
+        vec<T,3> &                  xyz()                               { return *reinterpret_cast<vec<T,3> *>(this); }
+
+        template<class U, class=detail::conv_t<vec,U>> constexpr vec(const U & u) : vec(converter<vec,U>{}(u)) {}
+        template<class U, class=detail::conv_t<U,vec>> constexpr operator U () const { return converter<U,vec>{}(*this); }
+    };
+
+    // Small, fixed-size matrix type, consisting of exactly M rows and N columns of type T, stored in column-major order.
+    template<class T, int M> struct mat<T,M,1>
+    {
+        typedef vec<T,M>            V;
+        V                           x;
+        constexpr                   mat()                               : x() {}
+        constexpr                   mat(const V & x_)                   : x(x_) {}
+        constexpr explicit          mat(const T & s)                    : x(s) {}
+        constexpr explicit          mat(const T * p)                    : x(p+M*0) {}
+        template<class U>
+        constexpr explicit          mat(const mat<U,M,1> & m)           : mat(V(m.x)) {}
+        constexpr vec<T,1>          row(int i) const                    { return {x[i]}; }
+        constexpr const V &         operator[] (int j) const            { return x; }
+        LINALG_CONSTEXPR14 V &      operator[] (int j)                  { return x; }
+
+        template<class U, class=detail::conv_t<mat,U>> constexpr mat(const U & u) : mat(converter<mat,U>{}(u)) {}
+        template<class U, class=detail::conv_t<U,mat>> constexpr operator U () const { return converter<U,mat>{}(*this); }
+    };
+    template<class T, int M> struct mat<T,M,2>
+    {
+        typedef vec<T,M>            V;
+        V                           x,y;
+        constexpr                   mat()                               : x(), y() {}
+        constexpr                   mat(const V & x_, const V & y_)     : x(x_), y(y_) {}
+        constexpr explicit          mat(const T & s)                    : x(s), y(s) {}
+        constexpr explicit          mat(const T * p)                    : x(p+M*0), y(p+M*1) {}
+        template<class U>
+        constexpr explicit          mat(const mat<U,M,2> & m)           : mat(V(m.x), V(m.y)) {}
+        constexpr vec<T,2>          row(int i) const                    { return {x[i], y[i]}; }
+        constexpr const V &         operator[] (int j) const            { return j==0?x:y; }
+        LINALG_CONSTEXPR14 V &      operator[] (int j)                  { return j==0?x:y; }
+
+        template<class U, class=detail::conv_t<mat,U>> constexpr mat(const U & u) : mat(converter<mat,U>{}(u)) {}
+        template<class U, class=detail::conv_t<U,mat>> constexpr operator U () const { return converter<U,mat>{}(*this); }
+    };
+    template<class T, int M> struct mat<T,M,3>
+    {
+        typedef vec<T,M>            V;
+        V                           x,y,z;
+        constexpr                   mat()                               : x(), y(), z() {}
+        constexpr                   mat(const V & x_, const V & y_,
+                                        const V & z_)                   : x(x_), y(y_), z(z_) {}
+        constexpr explicit          mat(const T & s)                    : x(s), y(s), z(s) {}
+        constexpr explicit          mat(const T * p)                    : x(p+M*0), y(p+M*1), z(p+M*2) {}
+        template<class U>
+        constexpr explicit          mat(const mat<U,M,3> & m)           : mat(V(m.x), V(m.y), V(m.z)) {}
+        constexpr vec<T,3>          row(int i) const                    { return {x[i], y[i], z[i]}; }
+        constexpr const V &         operator[] (int j) const            { return j==0?x:j==1?y:z; }
+        LINALG_CONSTEXPR14 V &      operator[] (int j)                  { return j==0?x:j==1?y:z; }
+
+        template<class U, class=detail::conv_t<mat,U>> constexpr mat(const U & u) : mat(converter<mat,U>{}(u)) {}
+        template<class U, class=detail::conv_t<U,mat>> constexpr operator U () const { return converter<U,mat>{}(*this); }
+    };
+    template<class T, int M> struct mat<T,M,4>
+    {
+        typedef vec<T,M>            V;
+        V                           x,y,z,w;
+        constexpr                   mat()                               : x(), y(), z(), w() {}
+        constexpr                   mat(const V & x_, const V & y_,
+                                        const V & z_, const V & w_)     : x(x_), y(y_), z(z_), w(w_) {}
+        constexpr explicit          mat(const T & s)                    : x(s), y(s), z(s), w(s) {}
+        constexpr explicit          mat(const T * p)                    : x(p+M*0), y(p+M*1), z(p+M*2), w(p+M*3) {}
+        template<class U>
+        constexpr explicit          mat(const mat<U,M,4> & m)           : mat(V(m.x), V(m.y), V(m.z), V(m.w)) {}
+        constexpr vec<T,4>          row(int i) const                    { return {x[i], y[i], z[i], w[i]}; }
+        constexpr const V &         operator[] (int j) const            { return j==0?x:j==1?y:j==2?z:w; }
+        LINALG_CONSTEXPR14 V &      operator[] (int j)                  { return j==0?x:j==1?y:j==2?z:w; }
+
+        template<class U, class=detail::conv_t<mat,U>> constexpr mat(const U & u) : mat(converter<mat,U>{}(u)) {}
+        template<class U, class=detail::conv_t<U,mat>> constexpr operator U () const { return converter<U,mat>{}(*this); }
+    };
+
+    // Define a type which will convert to the multiplicative identity of any square matrix
+    struct identity_t { constexpr explicit identity_t(int) {} };
+    template<class T> struct converter<mat<T,1,1>, identity_t> { constexpr mat<T,1,1> operator() (identity_t) const { return {vec<T,1>{1}}; } };
+    template<class T> struct converter<mat<T,2,2>, identity_t> { constexpr mat<T,2,2> operator() (identity_t) const { return {{1,0},{0,1}}; } };
+    template<class T> struct converter<mat<T,3,3>, identity_t> { constexpr mat<T,3,3> operator() (identity_t) const { return {{1,0,0},{0,1,0},{0,0,1}}; } };
+    template<class T> struct converter<mat<T,4,4>, identity_t> { constexpr mat<T,4,4> operator() (identity_t) const { return {{1,0,0,0},{0,1,0,0},{0,0,1,0},{0,0,0,1}}; } };
+    constexpr identity_t identity {1};
+
+    // Produce a scalar by applying f(A,B) -> A to adjacent pairs of elements from a vec/mat in left-to-right/column-major order (matching the associativity of arithmetic and logical operators)
+    template<class F, class A, class B> constexpr A fold(F f, A a, const vec<B,1> & b) { return f(a, b.x); }
+    template<class F, class A, class B> constexpr A fold(F f, A a, const vec<B,2> & b) { return f(f(a, b.x), b.y); }
+    template<class F, class A, class B> constexpr A fold(F f, A a, const vec<B,3> & b) { return f(f(f(a, b.x), b.y), b.z); }
+    template<class F, class A, class B> constexpr A fold(F f, A a, const vec<B,4> & b) { return f(f(f(f(a, b.x), b.y), b.z), b.w); }
+    template<class F, class A, class B, int M> constexpr A fold(F f, A a, const mat<B,M,1> & b) { return fold(f, a, b.x); }
+    template<class F, class A, class B, int M> constexpr A fold(F f, A a, const mat<B,M,2> & b) { return fold(f, fold(f, a, b.x), b.y); }
+    template<class F, class A, class B, int M> constexpr A fold(F f, A a, const mat<B,M,3> & b) { return fold(f, fold(f, fold(f, a, b.x), b.y), b.z); }
+    template<class F, class A, class B, int M> constexpr A fold(F f, A a, const mat<B,M,4> & b) { return fold(f, fold(f, fold(f, fold(f, a, b.x), b.y), b.z), b.w); }
+
+    // Type aliases for the result of calling apply(...) with various arguments, can be used with return type SFINAE to constrian overload sets
+    template<class F, class... A> using apply_t = typename detail::apply<F,void,A...>::type;
+    template<class F, class... A> using mm_apply_t = typename std::enable_if<detail::apply<F,void,A...>::mm, apply_t<F,A...>>::type;
+    template<class F, class... A> using no_mm_apply_t = typename std::enable_if<!detail::apply<F,void,A...>::mm, apply_t<F,A...>>::type;
+    template<class A> using scalar_t = typename detail::scalar_type<A>::type; // Underlying scalar type when performing elementwise operations
+
+    // apply(f,...) applies the provided function in an elementwise fashion to its arguments, producing an object of the same dimensions
+    template<class F, class... A> constexpr apply_t<F,A...> apply(F func, const A & ... args) { return detail::apply<F,void,A...>::impl(detail::make_seq<0,detail::apply<F,void,A...>::size>{}, func, args...); }
+
+    // map(a,f) is equivalent to apply(f,a)
+    template<class A, class F> constexpr apply_t<F,A> map(const A & a, F func) { return apply(func, a); }
+
+    // zip(a,b,f) is equivalent to apply(f,a,b)
+    template<class A, class B, class F> constexpr apply_t<F,A,B> zip(const A & a, const B & b, F func) { return apply(func, a, b); }
+
+    // Relational operators are defined to compare the elements of two vectors or matrices lexicographically, in column-major order
+    template<class A, class B> constexpr typename detail::any_compare<A,B>::type compare(const A & a, const B & b) { return detail::any_compare<A,B>()(a,b); }
+    template<class A, class B> constexpr auto operator == (const A & a, const B & b) -> decltype(compare(a,b) == 0) { return compare(a,b) == 0; }
+    template<class A, class B> constexpr auto operator != (const A & a, const B & b) -> decltype(compare(a,b) != 0) { return compare(a,b) != 0; }
+    template<class A, class B> constexpr auto operator <  (const A & a, const B & b) -> decltype(compare(a,b) <  0) { return compare(a,b) <  0; }
+    template<class A, class B> constexpr auto operator >  (const A & a, const B & b) -> decltype(compare(a,b) >  0) { return compare(a,b) >  0; }
+    template<class A, class B> constexpr auto operator <= (const A & a, const B & b) -> decltype(compare(a,b) <= 0) { return compare(a,b) <= 0; }
+    template<class A, class B> constexpr auto operator >= (const A & a, const B & b) -> decltype(compare(a,b) >= 0) { return compare(a,b) >= 0; }
+
+    // Functions for coalescing scalar values
+    template<class A> constexpr bool any (const A & a) { return fold(detail::op_or{}, false, a); }
+    template<class A> constexpr bool all (const A & a) { return fold(detail::op_and{}, true, a); }
+    template<class A> constexpr scalar_t<A> sum    (const A & a) { return fold(detail::op_add{}, scalar_t<A>(0), a); }
+    template<class A> constexpr scalar_t<A> product(const A & a) { return fold(detail::op_mul{}, scalar_t<A>(1), a); }
+    template<class A> constexpr scalar_t<A> minelem(const A & a) { return fold(detail::min{}, a.x, a); }
+    template<class A> constexpr scalar_t<A> maxelem(const A & a) { return fold(detail::max{}, a.x, a); }
+    template<class T, int M> int argmin(const vec<T,M> & a) { int j=0; for(int i=1; i<M; ++i) if(a[i] < a[j]) j = i; return j; }
+    template<class T, int M> int argmax(const vec<T,M> & a) { int j=0; for(int i=1; i<M; ++i) if(a[i] > a[j]) j = i; return j; }
+
+    // Unary operators are defined component-wise for linalg types
+    template<class A> constexpr apply_t<detail::op_pos, A> operator + (const A & a) { return apply(detail::op_pos{}, a); }
+    template<class A> constexpr apply_t<detail::op_neg, A> operator - (const A & a) { return apply(detail::op_neg{}, a); }
+    template<class A> constexpr apply_t<detail::op_cmp, A> operator ~ (const A & a) { return apply(detail::op_cmp{}, a); }
+    template<class A> constexpr apply_t<detail::op_not, A> operator ! (const A & a) { return apply(detail::op_not{}, a); }
+
+    // Binary operators are defined component-wise for linalg types, EXCEPT for `operator *`
+    template<class A, class B> constexpr apply_t<detail::op_add, A, B> operator +  (const A & a, const B & b) { return apply(detail::op_add{}, a, b); }
+    template<class A, class B> constexpr apply_t<detail::op_sub, A, B> operator -  (const A & a, const B & b) { return apply(detail::op_sub{}, a, b); }
+    template<class A, class B> constexpr apply_t<detail::op_mul, A, B> cmul        (const A & a, const B & b) { return apply(detail::op_mul{}, a, b); }
+    template<class A, class B> constexpr apply_t<detail::op_div, A, B> operator /  (const A & a, const B & b) { return apply(detail::op_div{}, a, b); }
+    template<class A, class B> constexpr apply_t<detail::op_mod, A, B> operator %  (const A & a, const B & b) { return apply(detail::op_mod{}, a, b); }
+    template<class A, class B> constexpr apply_t<detail::op_un,  A, B> operator |  (const A & a, const B & b) { return apply(detail::op_un{},  a, b); }
+    template<class A, class B> constexpr apply_t<detail::op_xor, A, B> operator ^  (const A & a, const B & b) { return apply(detail::op_xor{}, a, b); }
+    template<class A, class B> constexpr apply_t<detail::op_int, A, B> operator &  (const A & a, const B & b) { return apply(detail::op_int{}, a, b); }
+    template<class A, class B> constexpr apply_t<detail::op_lsh, A, B> operator << (const A & a, const B & b) { return apply(detail::op_lsh{}, a, b); }
+    template<class A, class B> constexpr apply_t<detail::op_rsh, A, B> operator >> (const A & a, const B & b) { return apply(detail::op_rsh{}, a, b); }
+
+    // Binary `operator *` was originally defined component-wise for all patterns, in a fashion consistent with the other operators. However,
+    // this was one of the most frequent sources of confusion among new users of this library, with the binary `operator *` being used accidentally
+    // by users who INTENDED the semantics of the algebraic matrix product, but RECEIVED the semantics of the Hadamard product. While there is
+    // precedent within the HLSL, Fortran, R, APL, J, and Mathematica programming languages for `operator *` having the semantics of the Hadamard
+    // product between matrices, it is counterintuitive to users of GLSL, Eigen, and many other languages and libraries that chose matrix product
+    // semantics for `operator *`.
+    //
+    // For these reasons, binary `operator *` is now DEPRECATED between pairs of matrices. Users may call `cmul(...)` for component-wise multiplication,
+    // or `mul(...)` for matrix multiplication. Binary `operator *` continues to be available for vector * vector, vector * scalar, matrix * scalar, etc.
+    template<class A, class B> constexpr no_mm_apply_t<detail::op_mul, A, B> operator * (const A & a, const B & b) { return cmul(a,b); }
+    #ifndef LINALG_FORWARD_COMPATIBLE
+    template<class A, class B> [[deprecated("`operator *` between pairs of matrices is deprecated. See the source text for details.")]] constexpr mm_apply_t<detail::op_mul, A, B> operator * (const A & a, const B & b) { return cmul(a,b); }
+    #endif
+
+    // Binary assignment operators a $= b is always defined as though it were explicitly written a = a $ b
+    template<class A, class B> constexpr auto operator +=  (A & a, const B & b) -> decltype(a = a + b) { return a = a + b; }
+    template<class A, class B> constexpr auto operator -=  (A & a, const B & b) -> decltype(a = a - b) { return a = a - b; }
+    template<class A, class B> constexpr auto operator *=  (A & a, const B & b) -> decltype(a = a * b) { return a = a * b; }
+    template<class A, class B> constexpr auto operator /=  (A & a, const B & b) -> decltype(a = a / b) { return a = a / b; }
+    template<class A, class B> constexpr auto operator %=  (A & a, const B & b) -> decltype(a = a % b) { return a = a % b; }
+    template<class A, class B> constexpr auto operator |=  (A & a, const B & b) -> decltype(a = a | b) { return a = a | b; }
+    template<class A, class B> constexpr auto operator ^=  (A & a, const B & b) -> decltype(a = a ^ b) { return a = a ^ b; }
+    template<class A, class B> constexpr auto operator &=  (A & a, const B & b) -> decltype(a = a & b) { return a = a & b; }
+    template<class A, class B> constexpr auto operator <<= (A & a, const B & b) -> decltype(a = a << b) { return a = a << b; }
+    template<class A, class B> constexpr auto operator >>= (A & a, const B & b) -> decltype(a = a >> b) { return a = a >> b; }
+
+    // Swizzles and subobjects
+    template<int... I, class T, int M>                              constexpr vec<T,sizeof...(I)>   swizzle(const vec<T,M> & a)   { return {detail::getter<I>{}(a)...}; }
+    template<int I0, int I1, class T, int M>                        constexpr vec<T,I1-I0>          subvec (const vec<T,M> & a)   { return detail::swizzle(a, detail::make_seq<I0,I1>{}); }
+    template<int I0, int J0, int I1, int J1, class T, int M, int N> constexpr mat<T,I1-I0,J1-J0>    submat (const mat<T,M,N> & a) { return detail::swizzle(a, detail::make_seq<I0,I1>{}, detail::make_seq<J0,J1>{}); }
+
+    // Component-wise standard library math functions
+    template<class A> apply_t<detail::std_abs,   A> abs  (const A & a) { return apply(detail::std_abs{},   a); }
+    template<class A> apply_t<detail::std_floor, A> floor(const A & a) { return apply(detail::std_floor{}, a); }
+    template<class A> apply_t<detail::std_ceil,  A> ceil (const A & a) { return apply(detail::std_ceil{},  a); }
+    template<class A> apply_t<detail::std_exp,   A> exp  (const A & a) { return apply(detail::std_exp{},   a); }
+    template<class A> apply_t<detail::std_log,   A> log  (const A & a) { return apply(detail::std_log{},   a); }
+    template<class A> apply_t<detail::std_log10, A> log10(const A & a) { return apply(detail::std_log10{}, a); }
+    template<class A> apply_t<detail::std_sqrt,  A> sqrt (const A & a) { return apply(detail::std_sqrt{},  a); }
+    template<class A> apply_t<detail::std_sin,   A> sin  (const A & a) { return apply(detail::std_sin{},   a); }
+    template<class A> apply_t<detail::std_cos,   A> cos  (const A & a) { return apply(detail::std_cos{},   a); }
+    template<class A> apply_t<detail::std_tan,   A> tan  (const A & a) { return apply(detail::std_tan{},   a); }
+    template<class A> apply_t<detail::std_asin,  A> asin (const A & a) { return apply(detail::std_asin{},  a); }
+    template<class A> apply_t<detail::std_acos,  A> acos (const A & a) { return apply(detail::std_acos{},  a); }
+    template<class A> apply_t<detail::std_atan,  A> atan (const A & a) { return apply(detail::std_atan{},  a); }
+    template<class A> apply_t<detail::std_sinh,  A> sinh (const A & a) { return apply(detail::std_sinh{},  a); }
+    template<class A> apply_t<detail::std_cosh,  A> cosh (const A & a) { return apply(detail::std_cosh{},  a); }
+    template<class A> apply_t<detail::std_tanh,  A> tanh (const A & a) { return apply(detail::std_tanh{},  a); }
+    template<class A> apply_t<detail::std_round, A> round(const A & a) { return apply(detail::std_round{}, a); }
+
+    template<class A, class B> apply_t<detail::std_fmod,     A, B> fmod    (const A & a, const B & b) { return apply(detail::std_fmod{},     a, b); }
+    template<class A, class B> apply_t<detail::std_pow,      A, B> pow     (const A & a, const B & b) { return apply(detail::std_pow{},      a, b); }
+    template<class A, class B> apply_t<detail::std_atan2,    A, B> atan2   (const A & a, const B & b) { return apply(detail::std_atan2{},    a, b); }
+    template<class A, class B> apply_t<detail::std_copysign, A, B> copysign(const A & a, const B & b) { return apply(detail::std_copysign{}, a, b); }
+
+    // Component-wise relational functions on vectors
+    template<class A, class B> constexpr apply_t<detail::op_eq, A, B> equal  (const A & a, const B & b) { return apply(detail::op_eq{}, a, b); }
+    template<class A, class B> constexpr apply_t<detail::op_ne, A, B> nequal (const A & a, const B & b) { return apply(detail::op_ne{}, a, b); }
+    template<class A, class B> constexpr apply_t<detail::op_lt, A, B> less   (const A & a, const B & b) { return apply(detail::op_lt{}, a, b); }
+    template<class A, class B> constexpr apply_t<detail::op_gt, A, B> greater(const A & a, const B & b) { return apply(detail::op_gt{}, a, b); }
+    template<class A, class B> constexpr apply_t<detail::op_le, A, B> lequal (const A & a, const B & b) { return apply(detail::op_le{}, a, b); }
+    template<class A, class B> constexpr apply_t<detail::op_ge, A, B> gequal (const A & a, const B & b) { return apply(detail::op_ge{}, a, b); }
+
+    // Component-wise selection functions on vectors
+    template<class A, class B> constexpr apply_t<detail::min, A, B> min(const A & a, const B & b) { return apply(detail::min{}, a, b); }
+    template<class A, class B> constexpr apply_t<detail::max, A, B> max(const A & a, const B & b) { return apply(detail::max{}, a, b); }
+    template<class X, class L, class H> constexpr apply_t<detail::clamp,  X, L, H> clamp (const X & x, const L & l, const H & h) { return apply(detail::clamp{},  x, l, h); }
+    template<class P, class A, class B> constexpr apply_t<detail::select, P, A, B> select(const P & p, const A & a, const B & b) { return apply(detail::select{}, p, a, b); }
+    template<class A, class B, class T> constexpr apply_t<detail::lerp,   A, B, T> lerp  (const A & a, const B & b, const T & t) { return apply(detail::lerp{},   a, b, t); }
+
+    // Support for vector algebra
+    template<class T> constexpr T        cross    (const vec<T,2> & a, const vec<T,2> & b)      { return a.x*b.y-a.y*b.x; }
+    template<class T> constexpr vec<T,2> cross    (T a, const vec<T,2> & b)                     { return {-a*b.y, a*b.x}; }
+    template<class T> constexpr vec<T,2> cross    (const vec<T,2> & a, T b)                     { return {a.y*b, -a.x*b}; }
+    template<class T> constexpr vec<T,3> cross    (const vec<T,3> & a, const vec<T,3> & b)      { return {a.y*b.z-a.z*b.y, a.z*b.x-a.x*b.z, a.x*b.y-a.y*b.x}; }
+    template<class T, int M> constexpr T dot      (const vec<T,M> & a, const vec<T,M> & b)      { return sum(a*b); }
+    template<class T, int M> constexpr T length2  (const vec<T,M> & a)                          { return dot(a,a); }
+    template<class T, int M> T           length   (const vec<T,M> & a)                          { return std::sqrt(length2(a)); }
+    template<class T, int M> vec<T,M>    normalize(const vec<T,M> & a)                          { return a / length(a); }
+    template<class T, int M> constexpr T distance2(const vec<T,M> & a, const vec<T,M> & b)      { return length2(b-a); }
+    template<class T, int M> T           distance (const vec<T,M> & a, const vec<T,M> & b)      { return length(b-a); }
+    template<class T, int M> T           uangle   (const vec<T,M> & a, const vec<T,M> & b)      { T d=dot(a,b); return d > 1 ? 0 : std::acos(d < -1 ? -1 : d); }
+    template<class T, int M> T           angle    (const vec<T,M> & a, const vec<T,M> & b)      { return uangle(normalize(a), normalize(b)); }
+    template<class T> vec<T,2>           rot      (T a, const vec<T,2> & v)                     { const T s = std::sin(a), c = std::cos(a); return {v.x*c - v.y*s, v.x*s + v.y*c}; }
+    template<class T, int M> vec<T,M>    nlerp    (const vec<T,M> & a, const vec<T,M> & b, T t) { return normalize(lerp(a,b,t)); }
+    template<class T, int M> vec<T,M>    slerp    (const vec<T,M> & a, const vec<T,M> & b, T t) { T th=uangle(a,b); return th == 0 ? a : a*(std::sin(th*(1-t))/std::sin(th)) + b*(std::sin(th*t)/std::sin(th)); }
+
+    // Support for quaternion algebra using 4D vectors, representing xi + yj + zk + w
+    template<class T> constexpr vec<T,4> qconj(const vec<T,4> & q)                     { return {-q.x,-q.y,-q.z,q.w}; }
+    template<class T> vec<T,4>           qinv (const vec<T,4> & q)                     { return qconj(q)/length2(q); }
+    template<class T> vec<T,4>           qexp (const vec<T,4> & q)                     { const auto v = q.xyz(); const auto vv = length(v); return std::exp(q.w) * vec<T,4>{v * (vv > 0 ? std::sin(vv)/vv : 0), std::cos(vv)}; }
+    template<class T> vec<T,4>           qlog (const vec<T,4> & q)                     { const auto v = q.xyz(); const auto vv = length(v), qq = length(q); return {v * (vv > 0 ? std::acos(q.w/qq)/vv : 0), std::log(qq)}; }
+    template<class T> vec<T,4>           qpow (const vec<T,4> & q, const T & p)        { const auto v = q.xyz(); const auto vv = length(v), qq = length(q), th = std::acos(q.w/qq); return std::pow(qq,p)*vec<T,4>{v * (vv > 0 ? std::sin(p*th)/vv : 0), std::cos(p*th)}; }
+    template<class T> constexpr vec<T,4> qmul (const vec<T,4> & a, const vec<T,4> & b) { return {a.x*b.w+a.w*b.x+a.y*b.z-a.z*b.y, a.y*b.w+a.w*b.y+a.z*b.x-a.x*b.z, a.z*b.w+a.w*b.z+a.x*b.y-a.y*b.x, a.w*b.w-a.x*b.x-a.y*b.y-a.z*b.z}; }
+    template<class T, class... R> constexpr vec<T,4> qmul(const vec<T,4> & a, R... r)  { return qmul(a, qmul(r...)); }
+
+    // Support for 3D spatial rotations using quaternions, via qmul(qmul(q, v), qconj(q))
+    template<class T> constexpr vec<T,3>   qxdir (const vec<T,4> & q)                          { return {q.w*q.w+q.x*q.x-q.y*q.y-q.z*q.z, (q.x*q.y+q.z*q.w)*2, (q.z*q.x-q.y*q.w)*2}; }
+    template<class T> constexpr vec<T,3>   qydir (const vec<T,4> & q)                          { return {(q.x*q.y-q.z*q.w)*2, q.w*q.w-q.x*q.x+q.y*q.y-q.z*q.z, (q.y*q.z+q.x*q.w)*2}; }
+    template<class T> constexpr vec<T,3>   qzdir (const vec<T,4> & q)                          { return {(q.z*q.x+q.y*q.w)*2, (q.y*q.z-q.x*q.w)*2, q.w*q.w-q.x*q.x-q.y*q.y+q.z*q.z}; }
+    template<class T> constexpr mat<T,3,3> qmat  (const vec<T,4> & q)                          { return {qxdir(q), qydir(q), qzdir(q)}; }
+    template<class T> constexpr vec<T,3>   qrot  (const vec<T,4> & q, const vec<T,3> & v)      { return qxdir(q)*v.x + qydir(q)*v.y + qzdir(q)*v.z; }
+    template<class T> T                    qangle(const vec<T,4> & q)                          { return std::atan2(length(q.xyz()), q.w)*2; }
+    template<class T> vec<T,3>             qaxis (const vec<T,4> & q)                          { return normalize(q.xyz()); }
+    template<class T> vec<T,4>             qnlerp(const vec<T,4> & a, const vec<T,4> & b, T t) { return nlerp(a, dot(a,b) < 0 ? -b : b, t); }
+    template<class T> vec<T,4>             qslerp(const vec<T,4> & a, const vec<T,4> & b, T t) { return slerp(a, dot(a,b) < 0 ? -b : b, t); }
+
+    // Support for matrix algebra
+    template<class T, int M> constexpr vec<T,M> mul(const mat<T,M,1> & a, const vec<T,1> & b) { return a.x*b.x; }
+    template<class T, int M> constexpr vec<T,M> mul(const mat<T,M,2> & a, const vec<T,2> & b) { return a.x*b.x + a.y*b.y; }
+    template<class T, int M> constexpr vec<T,M> mul(const mat<T,M,3> & a, const vec<T,3> & b) { return a.x*b.x + a.y*b.y + a.z*b.z; }
+    template<class T, int M> constexpr vec<T,M> mul(const mat<T,M,4> & a, const vec<T,4> & b) { return a.x*b.x + a.y*b.y + a.z*b.z + a.w*b.w; }
+    template<class T, int M, int N> constexpr mat<T,M,1> mul(const mat<T,M,N> & a, const mat<T,N,1> & b) { return {mul(a,b.x)}; }
+    template<class T, int M, int N> constexpr mat<T,M,2> mul(const mat<T,M,N> & a, const mat<T,N,2> & b) { return {mul(a,b.x), mul(a,b.y)}; }
+    template<class T, int M, int N> constexpr mat<T,M,3> mul(const mat<T,M,N> & a, const mat<T,N,3> & b) { return {mul(a,b.x), mul(a,b.y), mul(a,b.z)}; }
+    template<class T, int M, int N> constexpr mat<T,M,4> mul(const mat<T,M,N> & a, const mat<T,N,4> & b) { return {mul(a,b.x), mul(a,b.y), mul(a,b.z), mul(a,b.w)}; }
+    template<class T, int M, int N, int P> constexpr vec<T,M> mul(const mat<T,M,N> & a, const mat<T,N,P> & b, const vec<T,P> & c) { return mul(mul(a,b),c); }
+    template<class T, int M, int N, int P, int Q> constexpr mat<T,M,Q> mul(const mat<T,M,N> & a, const mat<T,N,P> & b, const mat<T,P,Q> & c) { return mul(mul(a,b),c); }
+    template<class T, int M, int N, int P, int Q> constexpr vec<T,M> mul(const mat<T,M,N> & a, const mat<T,N,P> & b, const mat<T,P,Q> & c, const vec<T,Q> & d) { return mul(mul(a,b,c),d); }
+    template<class T, int M, int N, int P, int Q, int R> constexpr mat<T,M,R> mul(const mat<T,M,N> & a, const mat<T,N,P> & b, const mat<T,P,Q> & c, const mat<T,Q,R> & d) { return mul(mul(a,b,c),d); }
+    template<class T, int M> constexpr mat<T,M,1> outerprod(const vec<T,M> & a, const vec<T,1> & b) { return {a*b.x}; }
+    template<class T, int M> constexpr mat<T,M,2> outerprod(const vec<T,M> & a, const vec<T,2> & b) { return {a*b.x, a*b.y}; }
+    template<class T, int M> constexpr mat<T,M,3> outerprod(const vec<T,M> & a, const vec<T,3> & b) { return {a*b.x, a*b.y, a*b.z}; }
+    template<class T, int M> constexpr mat<T,M,4> outerprod(const vec<T,M> & a, const vec<T,4> & b) { return {a*b.x, a*b.y, a*b.z, a*b.w}; }
+    template<class T> constexpr vec<T,1> diagonal(const mat<T,1,1> & a) { return {a.x.x}; }
+    template<class T> constexpr vec<T,2> diagonal(const mat<T,2,2> & a) { return {a.x.x, a.y.y}; }
+    template<class T> constexpr vec<T,3> diagonal(const mat<T,3,3> & a) { return {a.x.x, a.y.y, a.z.z}; }
+    template<class T> constexpr vec<T,4> diagonal(const mat<T,4,4> & a) { return {a.x.x, a.y.y, a.z.z, a.w.w}; }
+    template<class T, int N> constexpr T trace(const mat<T,N,N> & a) { return sum(diagonal(a)); }
+    template<class T, int M> constexpr mat<T,M,1> transpose(const mat<T,1,M> & m) { return {m.row(0)}; }
+    template<class T, int M> constexpr mat<T,M,2> transpose(const mat<T,2,M> & m) { return {m.row(0), m.row(1)}; }
+    template<class T, int M> constexpr mat<T,M,3> transpose(const mat<T,3,M> & m) { return {m.row(0), m.row(1), m.row(2)}; }
+    template<class T, int M> constexpr mat<T,M,4> transpose(const mat<T,4,M> & m) { return {m.row(0), m.row(1), m.row(2), m.row(3)}; }
+    template<class T, int M> constexpr mat<T,1,M> transpose(const vec<T,M> & m) { return transpose(mat<T,M,1>(m)); }
+    template<class T> constexpr mat<T,1,1> adjugate(const mat<T,1,1> & a) { return {vec<T,1>{1}}; }
+    template<class T> constexpr mat<T,2,2> adjugate(const mat<T,2,2> & a) { return {{a.y.y, -a.x.y}, {-a.y.x, a.x.x}}; }
+    template<class T> constexpr mat<T,3,3> adjugate(const mat<T,3,3> & a);
+    template<class T> constexpr mat<T,4,4> adjugate(const mat<T,4,4> & a);
+    template<class T, int N> constexpr mat<T,N,N> comatrix(const mat<T,N,N> & a) { return transpose(adjugate(a)); }
+    template<class T> constexpr T determinant(const mat<T,1,1> & a) { return a.x.x; }
+    template<class T> constexpr T determinant(const mat<T,2,2> & a) { return a.x.x*a.y.y - a.x.y*a.y.x; }
+    template<class T> constexpr T determinant(const mat<T,3,3> & a) { return a.x.x*(a.y.y*a.z.z - a.z.y*a.y.z) + a.x.y*(a.y.z*a.z.x - a.z.z*a.y.x) + a.x.z*(a.y.x*a.z.y - a.z.x*a.y.y); }
+    template<class T> constexpr T determinant(const mat<T,4,4> & a);
+    template<class T, int N> constexpr mat<T,N,N> inverse(const mat<T,N,N> & a) { return adjugate(a)/determinant(a); }
+
+    // Vectors and matrices can be used as ranges
+    template<class T, int M>       T * begin(      vec<T,M> & a) { return &a.x; }
+    template<class T, int M> const T * begin(const vec<T,M> & a) { return &a.x; }
+    template<class T, int M>       T * end  (      vec<T,M> & a) { return begin(a) + M; }
+    template<class T, int M> const T * end  (const vec<T,M> & a) { return begin(a) + M; }
+    template<class T, int M, int N>       vec<T,M> * begin(      mat<T,M,N> & a) { return &a.x; }
+    template<class T, int M, int N> const vec<T,M> * begin(const mat<T,M,N> & a) { return &a.x; }
+    template<class T, int M, int N>       vec<T,M> * end  (      mat<T,M,N> & a) { return begin(a) + N; }
+    template<class T, int M, int N> const vec<T,M> * end  (const mat<T,M,N> & a) { return begin(a) + N; }
+
+    // Factory functions for 3D spatial transformations (will possibly be removed or changed in a future version)
+    enum fwd_axis { neg_z, pos_z };                 // Should projection matrices be generated assuming forward is {0,0,-1} or {0,0,1}
+    enum z_range { neg_one_to_one, zero_to_one };   // Should projection matrices map z into the range of [-1,1] or [0,1]?
+    template<class T> vec<T,4>   rotation_quat     (const vec<T,3> & axis, T angle)         { return {axis*std::sin(angle/2), std::cos(angle/2)}; }
+    template<class T> vec<T,4>   rotation_quat     (const mat<T,3,3> & m);
+    template<class T> mat<T,4,4> translation_matrix(const vec<T,3> & translation)           { return {{1,0,0,0},{0,1,0,0},{0,0,1,0},{translation,1}}; }
+    template<class T> mat<T,4,4> rotation_matrix   (const vec<T,4> & rotation)              { return {{qxdir(rotation),0}, {qydir(rotation),0}, {qzdir(rotation),0}, {0,0,0,1}}; }
+    template<class T> mat<T,4,4> scaling_matrix    (const vec<T,3> & scaling)               { return {{scaling.x,0,0,0}, {0,scaling.y,0,0}, {0,0,scaling.z,0}, {0,0,0,1}}; }
+    template<class T> mat<T,4,4> pose_matrix       (const vec<T,4> & q, const vec<T,3> & p) { return {{qxdir(q),0}, {qydir(q),0}, {qzdir(q),0}, {p,1}}; }
+    template<class T> mat<T,4,4> lookat_matrix     (const vec<T,3> & eye, const vec<T,3> & center, const vec<T,3> & view_y_dir, fwd_axis fwd = neg_z);
+    template<class T> mat<T,4,4> frustum_matrix    (T x0, T x1, T y0, T y1, T n, T f, fwd_axis a = neg_z, z_range z = neg_one_to_one);
+    template<class T> mat<T,4,4> perspective_matrix(T fovy, T aspect, T n, T f, fwd_axis a = neg_z, z_range z = neg_one_to_one) { T y = n*std::tan(fovy / 2), x = y*aspect; return frustum_matrix(-x, x, -y, y, n, f, a, z); }
+
+    // Provide implicit conversion between linalg::vec<T,M> and std::array<T,M>
+    template<class T> struct converter<vec<T,1>, std::array<T,1>> { vec<T,1> operator() (const std::array<T,1> & a) const { return {a[0]}; } };
+    template<class T> struct converter<vec<T,2>, std::array<T,2>> { vec<T,2> operator() (const std::array<T,2> & a) const { return {a[0], a[1]}; } };
+    template<class T> struct converter<vec<T,3>, std::array<T,3>> { vec<T,3> operator() (const std::array<T,3> & a) const { return {a[0], a[1], a[2]}; } };
+    template<class T> struct converter<vec<T,4>, std::array<T,4>> { vec<T,4> operator() (const std::array<T,4> & a) const { return {a[0], a[1], a[2], a[3]}; } };
+
+    template<class T> struct converter<std::array<T,1>, vec<T,1>> { std::array<T,1> operator() (const vec<T,1> & a) const { return {a[0]}; } };
+    template<class T> struct converter<std::array<T,2>, vec<T,2>> { std::array<T,2> operator() (const vec<T,2> & a) const { return {a[0], a[1]}; } };
+    template<class T> struct converter<std::array<T,3>, vec<T,3>> { std::array<T,3> operator() (const vec<T,3> & a) const { return {a[0], a[1], a[2]}; } };
+    template<class T> struct converter<std::array<T,4>, vec<T,4>> { std::array<T,4> operator() (const vec<T,4> & a) const { return {a[0], a[1], a[2], a[3]}; } };
+
+    // Provide typedefs for common element types and vector/matrix sizes
+    namespace aliases
+    {
+        typedef vec<bool,1> bool1; typedef vec<uint8_t,1> byte1; typedef vec<int16_t,1> short1; typedef vec<uint16_t,1> ushort1;
+        typedef vec<bool,2> bool2; typedef vec<uint8_t,2> byte2; typedef vec<int16_t,2> short2; typedef vec<uint16_t,2> ushort2;
+        typedef vec<bool,3> bool3; typedef vec<uint8_t,3> byte3; typedef vec<int16_t,3> short3; typedef vec<uint16_t,3> ushort3;
+        typedef vec<bool,4> bool4; typedef vec<uint8_t,4> byte4; typedef vec<int16_t,4> short4; typedef vec<uint16_t,4> ushort4;
+        typedef vec<int,1> int1; typedef vec<unsigned,1> uint1; typedef vec<float,1> float1; typedef vec<double,1> double1;
+        typedef vec<int,2> int2; typedef vec<unsigned,2> uint2; typedef vec<float,2> float2; typedef vec<double,2> double2;
+        typedef vec<int,3> int3; typedef vec<unsigned,3> uint3; typedef vec<float,3> float3; typedef vec<double,3> double3;
+        typedef vec<int,4> int4; typedef vec<unsigned,4> uint4; typedef vec<float,4> float4; typedef vec<double,4> double4;
+        typedef mat<bool,1,1> bool1x1; typedef mat<int,1,1> int1x1; typedef mat<float,1,1> float1x1; typedef mat<double,1,1> double1x1;
+        typedef mat<bool,1,2> bool1x2; typedef mat<int,1,2> int1x2; typedef mat<float,1,2> float1x2; typedef mat<double,1,2> double1x2;
+        typedef mat<bool,1,3> bool1x3; typedef mat<int,1,3> int1x3; typedef mat<float,1,3> float1x3; typedef mat<double,1,3> double1x3;
+        typedef mat<bool,1,4> bool1x4; typedef mat<int,1,4> int1x4; typedef mat<float,1,4> float1x4; typedef mat<double,1,4> double1x4;
+        typedef mat<bool,2,1> bool2x1; typedef mat<int,2,1> int2x1; typedef mat<float,2,1> float2x1; typedef mat<double,2,1> double2x1;
+        typedef mat<bool,2,2> bool2x2; typedef mat<int,2,2> int2x2; typedef mat<float,2,2> float2x2; typedef mat<double,2,2> double2x2;
+        typedef mat<bool,2,3> bool2x3; typedef mat<int,2,3> int2x3; typedef mat<float,2,3> float2x3; typedef mat<double,2,3> double2x3;
+        typedef mat<bool,2,4> bool2x4; typedef mat<int,2,4> int2x4; typedef mat<float,2,4> float2x4; typedef mat<double,2,4> double2x4;
+        typedef mat<bool,3,1> bool3x1; typedef mat<int,3,1> int3x1; typedef mat<float,3,1> float3x1; typedef mat<double,3,1> double3x1;
+        typedef mat<bool,3,2> bool3x2; typedef mat<int,3,2> int3x2; typedef mat<float,3,2> float3x2; typedef mat<double,3,2> double3x2;
+        typedef mat<bool,3,3> bool3x3; typedef mat<int,3,3> int3x3; typedef mat<float,3,3> float3x3; typedef mat<double,3,3> double3x3;
+        typedef mat<bool,3,4> bool3x4; typedef mat<int,3,4> int3x4; typedef mat<float,3,4> float3x4; typedef mat<double,3,4> double3x4;
+        typedef mat<bool,4,1> bool4x1; typedef mat<int,4,1> int4x1; typedef mat<float,4,1> float4x1; typedef mat<double,4,1> double4x1;
+        typedef mat<bool,4,2> bool4x2; typedef mat<int,4,2> int4x2; typedef mat<float,4,2> float4x2; typedef mat<double,4,2> double4x2;
+        typedef mat<bool,4,3> bool4x3; typedef mat<int,4,3> int4x3; typedef mat<float,4,3> float4x3; typedef mat<double,4,3> double4x3;
+        typedef mat<bool,4,4> bool4x4; typedef mat<int,4,4> int4x4; typedef mat<float,4,4> float4x4; typedef mat<double,4,4> double4x4;
+    }
+
+    // Provide output streaming operators, writing something that resembles an aggregate literal that could be used to construct the specified value
+    namespace ostream_overloads
+    {
+        template<class C, class T> std::basic_ostream<C> & operator << (std::basic_ostream<C> & out, const vec<T,1> & v) { return out << '{' << v[0] << '}'; }
+        template<class C, class T> std::basic_ostream<C> & operator << (std::basic_ostream<C> & out, const vec<T,2> & v) { return out << '{' << v[0] << ',' << v[1] << '}'; }
+        template<class C, class T> std::basic_ostream<C> & operator << (std::basic_ostream<C> & out, const vec<T,3> & v) { return out << '{' << v[0] << ',' << v[1] << ',' << v[2] << '}'; }
+        template<class C, class T> std::basic_ostream<C> & operator << (std::basic_ostream<C> & out, const vec<T,4> & v) { return out << '{' << v[0] << ',' << v[1] << ',' << v[2] << ',' << v[3] << '}'; }
+
+        template<class C, class T, int M> std::basic_ostream<C> & operator << (std::basic_ostream<C> & out, const mat<T,M,1> & m) { return out << '{' << m[0] << '}'; }
+        template<class C, class T, int M> std::basic_ostream<C> & operator << (std::basic_ostream<C> & out, const mat<T,M,2> & m) { return out << '{' << m[0] << ',' << m[1] << '}'; }
+        template<class C, class T, int M> std::basic_ostream<C> & operator << (std::basic_ostream<C> & out, const mat<T,M,3> & m) { return out << '{' << m[0] << ',' << m[1] << ',' << m[2] << '}'; }
+        template<class C, class T, int M> std::basic_ostream<C> & operator << (std::basic_ostream<C> & out, const mat<T,M,4> & m) { return out << '{' << m[0] << ',' << m[1] << ',' << m[2] << ',' << m[3] << '}'; }
+    }
+}
+
+namespace std
+{
+    // Provide specializations for std::hash<...> with linalg types
+    template<class T> struct hash<linalg::vec<T,1>> { std::size_t operator()(const linalg::vec<T,1> & v) const { std::hash<T> h; return h(v.x); } };
+    template<class T> struct hash<linalg::vec<T,2>> { std::size_t operator()(const linalg::vec<T,2> & v) const { std::hash<T> h; return h(v.x) ^ (h(v.y) << 1); } };
+    template<class T> struct hash<linalg::vec<T,3>> { std::size_t operator()(const linalg::vec<T,3> & v) const { std::hash<T> h; return h(v.x) ^ (h(v.y) << 1) ^ (h(v.z) << 2); } };
+    template<class T> struct hash<linalg::vec<T,4>> { std::size_t operator()(const linalg::vec<T,4> & v) const { std::hash<T> h; return h(v.x) ^ (h(v.y) << 1) ^ (h(v.z) << 2) ^ (h(v.w) << 3); } };
+
+    template<class T, int M> struct hash<linalg::mat<T,M,1>> { std::size_t operator()(const linalg::mat<T,M,1> & v) const { std::hash<linalg::vec<T,M>> h; return h(v.x); } };
+    template<class T, int M> struct hash<linalg::mat<T,M,2>> { std::size_t operator()(const linalg::mat<T,M,2> & v) const { std::hash<linalg::vec<T,M>> h; return h(v.x) ^ (h(v.y) << M); } };
+    template<class T, int M> struct hash<linalg::mat<T,M,3>> { std::size_t operator()(const linalg::mat<T,M,3> & v) const { std::hash<linalg::vec<T,M>> h; return h(v.x) ^ (h(v.y) << M) ^ (h(v.z) << (M*2)); } };
+    template<class T, int M> struct hash<linalg::mat<T,M,4>> { std::size_t operator()(const linalg::mat<T,M,4> & v) const { std::hash<linalg::vec<T,M>> h; return h(v.x) ^ (h(v.y) << M) ^ (h(v.z) << (M*2)) ^ (h(v.w) << (M*3)); } };
+}
+
+// Definitions of functions too long to be defined inline
+template<class T> constexpr linalg::mat<T,3,3> linalg::adjugate(const mat<T,3,3> & a)
+{
+    return {{a.y.y*a.z.z - a.z.y*a.y.z, a.z.y*a.x.z - a.x.y*a.z.z, a.x.y*a.y.z - a.y.y*a.x.z},
+            {a.y.z*a.z.x - a.z.z*a.y.x, a.z.z*a.x.x - a.x.z*a.z.x, a.x.z*a.y.x - a.y.z*a.x.x},
+            {a.y.x*a.z.y - a.z.x*a.y.y, a.z.x*a.x.y - a.x.x*a.z.y, a.x.x*a.y.y - a.y.x*a.x.y}};
+}
+
+template<class T> constexpr linalg::mat<T,4,4> linalg::adjugate(const mat<T,4,4> & a)
+{
+    return {{a.y.y*a.z.z*a.w.w + a.w.y*a.y.z*a.z.w + a.z.y*a.w.z*a.y.w - a.y.y*a.w.z*a.z.w - a.z.y*a.y.z*a.w.w - a.w.y*a.z.z*a.y.w,
+             a.x.y*a.w.z*a.z.w + a.z.y*a.x.z*a.w.w + a.w.y*a.z.z*a.x.w - a.w.y*a.x.z*a.z.w - a.z.y*a.w.z*a.x.w - a.x.y*a.z.z*a.w.w,
+             a.x.y*a.y.z*a.w.w + a.w.y*a.x.z*a.y.w + a.y.y*a.w.z*a.x.w - a.x.y*a.w.z*a.y.w - a.y.y*a.x.z*a.w.w - a.w.y*a.y.z*a.x.w,
+             a.x.y*a.z.z*a.y.w + a.y.y*a.x.z*a.z.w + a.z.y*a.y.z*a.x.w - a.x.y*a.y.z*a.z.w - a.z.y*a.x.z*a.y.w - a.y.y*a.z.z*a.x.w},
+            {a.y.z*a.w.w*a.z.x + a.z.z*a.y.w*a.w.x + a.w.z*a.z.w*a.y.x - a.y.z*a.z.w*a.w.x - a.w.z*a.y.w*a.z.x - a.z.z*a.w.w*a.y.x,
+             a.x.z*a.z.w*a.w.x + a.w.z*a.x.w*a.z.x + a.z.z*a.w.w*a.x.x - a.x.z*a.w.w*a.z.x - a.z.z*a.x.w*a.w.x - a.w.z*a.z.w*a.x.x,
+             a.x.z*a.w.w*a.y.x + a.y.z*a.x.w*a.w.x + a.w.z*a.y.w*a.x.x - a.x.z*a.y.w*a.w.x - a.w.z*a.x.w*a.y.x - a.y.z*a.w.w*a.x.x,
+             a.x.z*a.y.w*a.z.x + a.z.z*a.x.w*a.y.x + a.y.z*a.z.w*a.x.x - a.x.z*a.z.w*a.y.x - a.y.z*a.x.w*a.z.x - a.z.z*a.y.w*a.x.x},
+            {a.y.w*a.z.x*a.w.y + a.w.w*a.y.x*a.z.y + a.z.w*a.w.x*a.y.y - a.y.w*a.w.x*a.z.y - a.z.w*a.y.x*a.w.y - a.w.w*a.z.x*a.y.y,
+             a.x.w*a.w.x*a.z.y + a.z.w*a.x.x*a.w.y + a.w.w*a.z.x*a.x.y - a.x.w*a.z.x*a.w.y - a.w.w*a.x.x*a.z.y - a.z.w*a.w.x*a.x.y,
+             a.x.w*a.y.x*a.w.y + a.w.w*a.x.x*a.y.y + a.y.w*a.w.x*a.x.y - a.x.w*a.w.x*a.y.y - a.y.w*a.x.x*a.w.y - a.w.w*a.y.x*a.x.y,
+             a.x.w*a.z.x*a.y.y + a.y.w*a.x.x*a.z.y + a.z.w*a.y.x*a.x.y - a.x.w*a.y.x*a.z.y - a.z.w*a.x.x*a.y.y - a.y.w*a.z.x*a.x.y},
+            {a.y.x*a.w.y*a.z.z + a.z.x*a.y.y*a.w.z + a.w.x*a.z.y*a.y.z - a.y.x*a.z.y*a.w.z - a.w.x*a.y.y*a.z.z - a.z.x*a.w.y*a.y.z,
+             a.x.x*a.z.y*a.w.z + a.w.x*a.x.y*a.z.z + a.z.x*a.w.y*a.x.z - a.x.x*a.w.y*a.z.z - a.z.x*a.x.y*a.w.z - a.w.x*a.z.y*a.x.z,
+             a.x.x*a.w.y*a.y.z + a.y.x*a.x.y*a.w.z + a.w.x*a.y.y*a.x.z - a.x.x*a.y.y*a.w.z - a.w.x*a.x.y*a.y.z - a.y.x*a.w.y*a.x.z,
+             a.x.x*a.y.y*a.z.z + a.z.x*a.x.y*a.y.z + a.y.x*a.z.y*a.x.z - a.x.x*a.z.y*a.y.z - a.y.x*a.x.y*a.z.z - a.z.x*a.y.y*a.x.z}};
+}
+
+template<class T> constexpr T linalg::determinant(const mat<T,4,4> & a)
+{
+    return a.x.x*(a.y.y*a.z.z*a.w.w + a.w.y*a.y.z*a.z.w + a.z.y*a.w.z*a.y.w - a.y.y*a.w.z*a.z.w - a.z.y*a.y.z*a.w.w - a.w.y*a.z.z*a.y.w)
+         + a.x.y*(a.y.z*a.w.w*a.z.x + a.z.z*a.y.w*a.w.x + a.w.z*a.z.w*a.y.x - a.y.z*a.z.w*a.w.x - a.w.z*a.y.w*a.z.x - a.z.z*a.w.w*a.y.x)
+         + a.x.z*(a.y.w*a.z.x*a.w.y + a.w.w*a.y.x*a.z.y + a.z.w*a.w.x*a.y.y - a.y.w*a.w.x*a.z.y - a.z.w*a.y.x*a.w.y - a.w.w*a.z.x*a.y.y)
+         + a.x.w*(a.y.x*a.w.y*a.z.z + a.z.x*a.y.y*a.w.z + a.w.x*a.z.y*a.y.z - a.y.x*a.z.y*a.w.z - a.w.x*a.y.y*a.z.z - a.z.x*a.w.y*a.y.z);
+}
+
+template<class T> linalg::vec<T,4> linalg::rotation_quat(const mat<T,3,3> & m)
+{
+    const vec<T,4> q {m.x.x-m.y.y-m.z.z, m.y.y-m.x.x-m.z.z, m.z.z-m.x.x-m.y.y, m.x.x+m.y.y+m.z.z}, s[] {
+        {1, m.x.y + m.y.x, m.z.x + m.x.z, m.y.z - m.z.y},
+        {m.x.y + m.y.x, 1, m.y.z + m.z.y, m.z.x - m.x.z},
+        {m.x.z + m.z.x, m.y.z + m.z.y, 1, m.x.y - m.y.x},
+        {m.y.z - m.z.y, m.z.x - m.x.z, m.x.y - m.y.x, 1}};
+    return copysign(normalize(sqrt(max(T(0), T(1)+q))), s[argmax(q)]);
+}
+
+template<class T> linalg::mat<T,4,4> linalg::lookat_matrix(const vec<T,3> & eye, const vec<T,3> & center, const vec<T,3> & view_y_dir, fwd_axis a)
+{
+    const vec<T,3> f = normalize(center - eye), z = a == pos_z ? f : -f, x = normalize(cross(view_y_dir, z)), y = cross(z, x);
+    return inverse(mat<T,4,4>{{x,0},{y,0},{z,0},{eye,1}});
+}
+
+template<class T> linalg::mat<T,4,4> linalg::frustum_matrix(T x0, T x1, T y0, T y1, T n, T f, fwd_axis a, z_range z)
+{
+    const T s = a == pos_z ? T(1) : T(-1), o = z == neg_one_to_one ? n : 0;
+    return {{2*n/(x1-x0),0,0,0}, {0,2*n/(y1-y0),0,0}, {-s*(x0+x1)/(x1-x0),-s*(y0+y1)/(y1-y0),s*(f+o)/(f-n),s}, {0,0,-(n+o)*f/(f-n),0}};
+}
+
+// clang-format on
+
+namespace anari
+{
+namespace math
+{
+
+using namespace linalg::aliases;
+using namespace linalg;
+using mat3 = float3x3;
+using mat4 = float4x4;
+
+} // namespace math
+} // namespace anari
+
+namespace anari
+{
+
+ANARI_TYPEFOR_SPECIALIZATION(math::float2, ANARI_FLOAT32_VEC2);
+ANARI_TYPEFOR_SPECIALIZATION(math::float3, ANARI_FLOAT32_VEC3);
+ANARI_TYPEFOR_SPECIALIZATION(math::float4, ANARI_FLOAT32_VEC4);
+ANARI_TYPEFOR_SPECIALIZATION(math::byte2, ANARI_UINT8_VEC2);
+ANARI_TYPEFOR_SPECIALIZATION(math::byte3, ANARI_UINT8_VEC3);
+ANARI_TYPEFOR_SPECIALIZATION(math::byte4, ANARI_UINT8_VEC4);
+ANARI_TYPEFOR_SPECIALIZATION(math::int2, ANARI_INT32_VEC2);
+ANARI_TYPEFOR_SPECIALIZATION(math::int3, ANARI_INT32_VEC3);
+ANARI_TYPEFOR_SPECIALIZATION(math::int4, ANARI_INT32_VEC4);
+ANARI_TYPEFOR_SPECIALIZATION(math::uint2, ANARI_UINT32_VEC2);
+ANARI_TYPEFOR_SPECIALIZATION(math::uint3, ANARI_UINT32_VEC3);
+ANARI_TYPEFOR_SPECIALIZATION(math::uint4, ANARI_UINT32_VEC4);
+ANARI_TYPEFOR_SPECIALIZATION(math::mat3, ANARI_FLOAT32_MAT3);
+ANARI_TYPEFOR_SPECIALIZATION(math::mat4, ANARI_FLOAT32_MAT4);
+
+#ifdef ANARI_LINALG_DEFINITIONS
+ANARI_TYPEFOR_DEFINITION(math::float2);
+ANARI_TYPEFOR_DEFINITION(math::float3);
+ANARI_TYPEFOR_DEFINITION(math::float4);
+ANARI_TYPEFOR_DEFINITION(math::int2);
+ANARI_TYPEFOR_DEFINITION(math::int3);
+ANARI_TYPEFOR_DEFINITION(math::int4);
+ANARI_TYPEFOR_DEFINITION(math::uint2);
+ANARI_TYPEFOR_DEFINITION(math::uint3);
+ANARI_TYPEFOR_DEFINITION(math::uint4);
+ANARI_TYPEFOR_DEFINITION(math::mat3);
+ANARI_TYPEFOR_DEFINITION(math::mat4);
+#endif
+
+inline float radians(float degrees)
+{
+  return degrees * float(M_PI) / 180.f;
+}
+
+inline float degrees(float radians)
+{
+  return radians * 180.f / float(M_PI);
+}
+
+} // namespace anari
+
+#endif

--- a/viskores/rendering/anari-device/renderer/Renderer.cpp
+++ b/viskores/rendering/anari-device/renderer/Renderer.cpp
@@ -1,0 +1,46 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#include "Renderer.h"
+#include "../ViskoresTypes.h"
+
+namespace viskores_device
+{
+
+Renderer::Renderer(ViskoresDeviceGlobalState* s)
+  : Object(ANARI_RENDERER, s)
+{
+}
+
+Renderer::~Renderer() = default;
+
+Renderer* Renderer::createInstance(std::string_view /* subtype */, ViskoresDeviceGlobalState* s)
+{
+  return new Renderer(s);
+}
+
+void Renderer::commitParameters()
+{
+  m_bgColor = getParam<float4>("background", float4(0.f, 0.f, 0.f, 1.f));
+}
+
+void Renderer::finalize()
+{
+  // no-op
+}
+
+float4 Renderer::background() const
+{
+  return m_bgColor;
+}
+
+} // namespace viskores_device
+
+VISKORES_ANARI_TYPEFOR_DEFINITION(viskores_device::Renderer*);

--- a/viskores/rendering/anari-device/renderer/Renderer.h
+++ b/viskores/rendering/anari-device/renderer/Renderer.h
@@ -1,0 +1,46 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#pragma once
+
+#include "../ViskoresTypes.h"
+#include "Object.h"
+#include "scene/World.h"
+
+namespace viskores_device
+{
+
+struct PixelSample
+{
+  float4 color;
+  float depth;
+  uint32_t primId{ ~0u };
+  uint32_t objId{ ~0u };
+  uint32_t instId{ ~0u };
+};
+
+struct Renderer : public Object
+{
+  Renderer(ViskoresDeviceGlobalState* s);
+  ~Renderer() override;
+  static Renderer* createInstance(std::string_view subtype, ViskoresDeviceGlobalState* d);
+  void commitParameters() override;
+  void finalize() override;
+
+  float4 background() const;
+
+private:
+  //float4 m_bgColor{float3(0.f), 1.f};
+  float4 m_bgColor{ 0.f, 0.f, 0.f, 1.f };
+};
+
+} // namespace viskores_device
+
+VISKORES_ANARI_TYPEFOR_SPECIALIZATION(viskores_device::Renderer*, ANARI_RENDERER);

--- a/viskores/rendering/anari-device/scene/Group.cpp
+++ b/viskores/rendering/anari-device/scene/Group.cpp
@@ -1,0 +1,117 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#include "Group.h"
+// std
+#include <iterator>
+
+namespace viskores_device
+{
+
+Group::Group(ViskoresDeviceGlobalState* s)
+  : Object(ANARI_GROUP, s)
+  , m_surfaceData(this)
+  , m_volumeData(this)
+{
+}
+
+Group::~Group() = default;
+
+bool Group::getProperty(const std::string_view& name,
+                        ANARIDataType type,
+                        void* ptr,
+                        uint64_t size,
+                        uint32_t flags)
+{
+  return Object::getProperty(name, type, ptr, size, flags);
+}
+
+void Group::commitParameters()
+{
+  m_surfaceData = getParamObject<ObjectArray>("surface");
+  m_volumeData = getParamObject<ObjectArray>("volume");
+}
+
+void Group::finalize()
+{
+  m_surfaces.clear();
+  m_volumes.clear();
+
+  if (m_surfaceData)
+  {
+    m_surfaceData->addChangeObserver(this);
+    std::transform(m_surfaceData->handlesBegin(),
+                   m_surfaceData->handlesEnd(),
+                   std::back_inserter(m_surfaces),
+                   [](auto* o) { return (Surface*)o; });
+  }
+
+  if (m_volumeData)
+  {
+    m_volumeData->addChangeObserver(this);
+    std::transform(m_volumeData->handlesBegin(),
+                   m_volumeData->handlesEnd(),
+                   std::back_inserter(m_volumes),
+                   [](auto* o) { return (Volume*)o; });
+  }
+}
+
+const std::vector<Surface*>& Group::surfaces() const
+{
+  return m_surfaces;
+}
+
+const std::vector<Volume*>& Group::volumes() const
+{
+  return m_volumes;
+}
+
+static inline float clampIt(const float& a, const range_t<float>& r)
+{
+  if (a < r.lower)
+    return r.lower;
+  if (a > r.upper)
+    return r.upper;
+  return a;
+}
+
+static inline float CLAMP(const float& a, const box1& b)
+{
+  if (a < b.lower)
+    return b.lower;
+  else if (a > b.upper)
+    return b.upper;
+
+  return a;
+}
+
+static inline float3 MIN(const float3& a, const float3& b)
+{
+  float3 res(std::min(a[0], b[0]), std::min(a[1], b[1]), std::min(a[2], b[2]));
+  return res;
+}
+static inline float3 MAX(const float3& a, const float3& b)
+{
+  float3 res(std::max(a[0], b[0]), std::max(a[1], b[1]), std::max(a[2], b[2]));
+  return res;
+}
+
+static inline float MINELEM(const float3& a)
+{
+  return std::min(a[0], std::min(a[1], a[2]));
+}
+static inline float MAXELEM(const float3& a)
+{
+  return std::max(a[0], std::max(a[1], a[2]));
+}
+
+} // namespace viskores_device
+
+VISKORES_ANARI_TYPEFOR_DEFINITION(viskores_device::Group*);

--- a/viskores/rendering/anari-device/scene/Group.h
+++ b/viskores/rendering/anari-device/scene/Group.h
@@ -1,0 +1,48 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#pragma once
+
+#include "array/ObjectArray.h"
+#include "light/Light.h"
+#include "surface/Surface.h"
+#include "volume/Volume.h"
+
+namespace viskores_device
+{
+
+struct Group : public Object
+{
+  Group(ViskoresDeviceGlobalState* s);
+  ~Group() override;
+
+  bool getProperty(const std::string_view& name,
+                   ANARIDataType type,
+                   void* ptr,
+                   uint64_t size,
+                   uint32_t flags) override;
+
+  void commitParameters() override;
+  void finalize() override;
+
+  const std::vector<Surface*>& surfaces() const;
+  const std::vector<Volume*>& volumes() const;
+
+private:
+  helium::ChangeObserverPtr<ObjectArray> m_surfaceData;
+  std::vector<Surface*> m_surfaces;
+
+  helium::ChangeObserverPtr<ObjectArray> m_volumeData;
+  std::vector<Volume*> m_volumes;
+};
+
+} // namespace viskores_device
+
+VISKORES_ANARI_TYPEFOR_SPECIALIZATION(viskores_device::Group*, ANARI_GROUP);

--- a/viskores/rendering/anari-device/scene/Instance.cpp
+++ b/viskores/rendering/anari-device/scene/Instance.cpp
@@ -1,0 +1,74 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#include "Instance.h"
+
+namespace viskores_device
+{
+
+Instance::Instance(ViskoresDeviceGlobalState* s)
+  : Object(ANARI_INSTANCE, s)
+{
+}
+
+Instance::~Instance() = default;
+
+void Instance::commitParameters()
+{
+  m_id = getParam<uint32_t>("id", ~0u);
+  m_xfm = getParam<mat4>("transform", mat4(linalg::identity));
+  m_group = getParamObject<Group>("group");
+  if (!m_group)
+    reportMessage(ANARI_SEVERITY_WARNING, "missing 'group' on ANARIInstance");
+}
+
+void Instance::finalize()
+{
+  m_xfmInvRot = linalg::inverse(extractRotation(m_xfm));
+}
+
+uint32_t Instance::id() const
+{
+  return m_id;
+}
+
+const mat4& Instance::xfm() const
+{
+  return m_xfm;
+}
+
+const mat3& Instance::xfmInvRot() const
+{
+  return m_xfmInvRot;
+}
+
+bool Instance::xfmIsIdentity() const
+{
+  return xfm() == mat4(linalg::identity);
+}
+
+const Group* Instance::group() const
+{
+  return m_group.ptr;
+}
+
+Group* Instance::group()
+{
+  return m_group.ptr;
+}
+
+bool Instance::isValid() const
+{
+  return m_group;
+}
+
+} // namespace viskores_device
+
+VISKORES_ANARI_TYPEFOR_DEFINITION(viskores_device::Instance*);

--- a/viskores/rendering/anari-device/scene/Instance.h
+++ b/viskores/rendering/anari-device/scene/Instance.h
@@ -1,0 +1,46 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#pragma once
+
+#include "Group.h"
+
+namespace viskores_device
+{
+
+struct Instance : public Object
+{
+  Instance(ViskoresDeviceGlobalState* s);
+  ~Instance() override;
+
+  void commitParameters() override;
+  void finalize() override;
+
+  uint32_t id() const;
+
+  const mat4& xfm() const;
+  const mat3& xfmInvRot() const;
+  bool xfmIsIdentity() const;
+
+  const Group* group() const;
+  Group* group();
+
+  bool isValid() const override;
+
+private:
+  uint32_t m_id{ ~0u };
+  mat4 m_xfm;
+  mat3 m_xfmInvRot;
+  helium::IntrusivePtr<Group> m_group;
+};
+
+} // namespace viskores_device
+
+VISKORES_ANARI_TYPEFOR_SPECIALIZATION(viskores_device::Instance*, ANARI_INSTANCE);

--- a/viskores/rendering/anari-device/scene/World.cpp
+++ b/viskores/rendering/anari-device/scene/World.cpp
@@ -1,0 +1,155 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#include "World.h"
+#include "surface/Surface.h"
+#include "volume/Volume.h"
+
+namespace viskores_device
+{
+
+World::World(ViskoresDeviceGlobalState* s)
+  : Object(ANARI_WORLD, s)
+  , m_zeroSurfaceData(this)
+  , m_zeroVolumeData(this)
+  , m_instanceData(this)
+{
+  m_zeroGroup = new Group(s);
+  m_zeroInstance = new Instance(s);
+  m_zeroInstance->setParamDirect("group", m_zeroGroup.ptr);
+
+  // never any public ref to these objects
+  m_zeroGroup->refDec(helium::RefType::PUBLIC);
+  m_zeroInstance->refDec(helium::RefType::PUBLIC);
+}
+
+World::~World() = default;
+
+bool World::getProperty(const std::string_view& name,
+                        ANARIDataType type,
+                        void* ptr,
+                        uint64_t size,
+                        uint32_t flags)
+{
+  if (name == "bounds" && type == ANARI_FLOAT32_BOX3)
+  {
+    viskores::Vec3f_32 anariBounds[] = { viskores::Vec3f_32(this->m_bounds.MinCorner()),
+                                         viskores::Vec3f_32(this->m_bounds.MaxCorner()) };
+    std::memcpy(ptr, &anariBounds, sizeof(anariBounds));
+    return true;
+  }
+  return Object::getProperty(name, type, ptr, size, flags);
+}
+
+void World::commitParameters()
+{
+  m_zeroSurfaceData = getParamObject<ObjectArray>("surface");
+  m_zeroVolumeData = getParamObject<ObjectArray>("volume");
+
+  m_addZeroInstance = m_zeroSurfaceData || m_zeroVolumeData;
+  if (m_addZeroInstance)
+  {
+    reportMessage(ANARI_SEVERITY_DEBUG, "viskores_device::World will add zero instance");
+  }
+
+  if (m_zeroSurfaceData)
+  {
+    reportMessage(ANARI_SEVERITY_DEBUG,
+                  "viskores_device::World found %zu surfaces in zero instance",
+                  m_zeroSurfaceData->size());
+    m_zeroGroup->setParamDirect("surface", getParamDirect("surface"));
+  }
+  else
+  {
+    m_zeroGroup->removeParam("surface");
+  }
+
+  if (m_zeroVolumeData)
+  {
+    reportMessage(ANARI_SEVERITY_DEBUG,
+                  "viskores_device::World found %zu volumes in zero instance",
+                  m_zeroVolumeData->size());
+    m_zeroGroup->setParamDirect("volume", getParamDirect("volume"));
+  }
+  else
+    m_zeroGroup->removeParam("volume");
+
+  m_zeroInstance->setParam("id", getParam<uint32_t>("id", ~0u));
+
+  m_zeroGroup->commitParameters();
+  m_zeroGroup->finalize();
+  m_zeroInstance->commitParameters();
+  m_zeroInstance->finalize();
+
+  m_instanceData = getParamObject<ObjectArray>("instance");
+}
+
+void World::finalize()
+{
+  m_instances.clear();
+
+  if (m_instanceData)
+  {
+    m_instanceData->removeAppendedHandles();
+    if (m_addZeroInstance)
+      m_instanceData->appendHandle(m_zeroInstance.ptr);
+    std::for_each(m_instanceData->handlesBegin(),
+                  m_instanceData->handlesEnd(),
+                  [&](auto* o)
+                  {
+                    if (o && o->isValid())
+                      m_instances.push_back((Instance*)o);
+                  });
+  }
+  else if (m_addZeroInstance)
+    m_instances.push_back(m_zeroInstance.ptr);
+
+  if (m_instanceData)
+    m_instanceData->addChangeObserver(this);
+  if (m_zeroSurfaceData)
+    m_zeroSurfaceData->addChangeObserver(this);
+
+  this->m_bounds = viskores::Bounds{};
+  for (auto&& instance : this->instances())
+  {
+    if (!instance->isValid())
+    {
+      reportMessage(ANARI_SEVERITY_DEBUG, "skip bounds check on invalid group");
+      continue;
+    }
+    for (auto&& surface : instance->group()->surfaces())
+    {
+      if (!surface || !surface->isValid())
+      {
+        reportMessage(ANARI_SEVERITY_DEBUG, "skip bounds check on invalid surface");
+        continue;
+      }
+      this->m_bounds.Include(surface->bounds());
+    }
+    for (auto&& volume : instance->group()->volumes())
+    {
+      if (!volume || !volume->isValid())
+      {
+        reportMessage(ANARI_SEVERITY_DEBUG, "skip bounds check on invalid volume");
+        continue;
+      }
+      this->m_bounds.Include(volume->bounds());
+    }
+  }
+}
+
+const std::vector<Instance*>& World::instances() const
+{
+  return m_instances;
+}
+
+} // namespace viskores_device
+
+VISKORES_ANARI_TYPEFOR_DEFINITION(viskores_device::World*);

--- a/viskores/rendering/anari-device/scene/World.h
+++ b/viskores/rendering/anari-device/scene/World.h
@@ -1,0 +1,64 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#pragma once
+
+#include "Instance.h"
+// Viskores
+#include <viskores/Bounds.h>
+
+namespace viskores_device
+{
+
+struct World : public Object
+{
+  World(ViskoresDeviceGlobalState* s);
+  ~World() override;
+
+  bool getProperty(const std::string_view& name,
+                   ANARIDataType type,
+                   void* ptr,
+                   uint64_t size,
+                   uint32_t flags) override;
+
+  void commitParameters() override;
+  void finalize() override;
+
+  const std::vector<Instance*>& instances() const;
+
+  const Instance* instanceFromRay(const Ray& ray) const { return this->instances()[ray.instID]; }
+  const Instance* instanceFromRay(const VolumeRay& ray) const
+  {
+    return this->instances()[ray.instID];
+  }
+  const Surface* surfaceFromRay(const Ray& ray) const
+  {
+    return instanceFromRay(ray)->group()->surfaces()[ray.geomID];
+  }
+
+  const viskores::Bounds& bounds() const { return this->m_bounds; }
+
+private:
+  helium::ChangeObserverPtr<ObjectArray> m_zeroSurfaceData;
+  helium::ChangeObserverPtr<ObjectArray> m_zeroVolumeData;
+
+  helium::ChangeObserverPtr<ObjectArray> m_instanceData;
+  std::vector<Instance*> m_instances;
+
+  bool m_addZeroInstance{ false };
+  helium::IntrusivePtr<Group> m_zeroGroup;
+  helium::IntrusivePtr<Instance> m_zeroInstance;
+
+  viskores::Bounds m_bounds;
+};
+
+} // namespace viskores_device
+
+VISKORES_ANARI_TYPEFOR_SPECIALIZATION(viskores_device::World*, ANARI_WORLD);

--- a/viskores/rendering/anari-device/scene/light/Light.cpp
+++ b/viskores/rendering/anari-device/scene/light/Light.cpp
@@ -1,0 +1,28 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#include "Light.h"
+
+namespace viskores_device
+{
+
+Light::Light(ViskoresDeviceGlobalState* s)
+  : Object(ANARI_LIGHT, s)
+{
+}
+
+Light* Light::createInstance(std::string_view /*subtype*/, ViskoresDeviceGlobalState* s)
+{
+  return (Light*)new UnknownObject(ANARI_LIGHT, s);
+}
+
+} // namespace viskores_device
+
+VISKORES_ANARI_TYPEFOR_DEFINITION(viskores_device::Light*);

--- a/viskores/rendering/anari-device/scene/light/Light.h
+++ b/viskores/rendering/anari-device/scene/light/Light.h
@@ -1,0 +1,26 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#pragma once
+
+#include "Object.h"
+
+namespace viskores_device
+{
+
+struct Light : public Object
+{
+  Light(ViskoresDeviceGlobalState* d);
+  static Light* createInstance(std::string_view subtype, ViskoresDeviceGlobalState* d);
+};
+
+} // namespace viskores_device
+
+VISKORES_ANARI_TYPEFOR_SPECIALIZATION(viskores_device::Light*, ANARI_LIGHT);

--- a/viskores/rendering/anari-device/scene/surface/Surface.cpp
+++ b/viskores/rendering/anari-device/scene/surface/Surface.cpp
@@ -1,0 +1,71 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#include "Surface.h"
+
+namespace viskores_device
+{
+
+Surface::Surface(ViskoresDeviceGlobalState* s)
+  : Object(ANARI_SURFACE, s)
+  , m_geometry(this)
+  , m_material(this)
+{
+}
+
+Surface::~Surface() = default;
+
+void Surface::commitParameters()
+{
+  m_id = getParam<uint32_t>("id", ~0u);
+  m_geometry = getParamObject<Geometry>("geometry");
+  m_material = getParamObject<Material>("material");
+}
+
+void Surface::finalize()
+{
+  if (!m_material)
+  {
+    reportMessage(ANARI_SEVERITY_WARNING, "missing 'material' on ANARISurface");
+    return;
+  }
+
+  if (!m_geometry)
+  {
+    reportMessage(ANARI_SEVERITY_WARNING, "missing 'geometry' on ANARISurface");
+    return;
+  }
+
+  this->m_actor = this->m_material->createActor(this->m_geometry->getDataSet());
+}
+
+const Geometry* Surface::geometry() const
+{
+  return m_geometry.get();
+}
+
+const Material* Surface::material() const
+{
+  return m_material.get();
+}
+
+viskores::Bounds Surface::bounds() const
+{
+  return this->geometry()->getDataSet().GetCoordinateSystem().GetBounds();
+}
+
+bool Surface::isValid() const
+{
+  return m_geometry && m_material && m_geometry->isValid() && m_material->isValid();
+}
+
+} // namespace viskores_device
+
+VISKORES_ANARI_TYPEFOR_DEFINITION(viskores_device::Surface*);

--- a/viskores/rendering/anari-device/scene/surface/Surface.h
+++ b/viskores/rendering/anari-device/scene/surface/Surface.h
@@ -1,0 +1,49 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#pragma once
+
+#include "geometry/Geometry.h"
+#include "material/Material.h"
+// Viskores
+#include <viskores/Bounds.h>
+
+namespace viskores_device
+{
+
+struct Surface : public Object
+{
+  Surface(ViskoresDeviceGlobalState* s);
+  ~Surface() override;
+
+  void commitParameters() override;
+  void finalize() override;
+
+  uint32_t id() const { return m_id; }
+  const Geometry* geometry() const;
+  const Material* material() const;
+
+  virtual viskores::rendering::Actor* actor() const { return this->m_actor.get(); }
+
+  viskores::Bounds bounds() const;
+
+  bool isValid() const override;
+
+private:
+  uint32_t m_id{ ~0u };
+  helium::ChangeObserverPtr<Geometry> m_geometry;
+  helium::ChangeObserverPtr<Material> m_material;
+
+  std::shared_ptr<viskores::rendering::Actor> m_actor;
+};
+
+} // namespace viskores_device
+
+VISKORES_ANARI_TYPEFOR_SPECIALIZATION(viskores_device::Surface*, ANARI_SURFACE);

--- a/viskores/rendering/anari-device/scene/surface/geometry/Geometry.cpp
+++ b/viskores/rendering/anari-device/scene/surface/geometry/Geometry.cpp
@@ -1,0 +1,128 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#include "Geometry.h"
+// subtypes
+#include "Sphere.h"
+#include "Triangle.h"
+
+#include "array/ArrayConversion.h"
+
+namespace viskores_device
+{
+
+Geometry::Geometry(ViskoresDeviceGlobalState* s)
+  : Object(ANARI_GEOMETRY, s)
+{
+  this->m_primitiveAttributes.setAttributes(
+    this, { "color", "attribute0", "attribute1", "attribute2", "attribute3" });
+  this->m_primitiveAttributes.setAnariAssociation("primitive");
+  this->m_primitiveAttributes.setViskoresAssociation(viskores::cont::Field::Association::Cells);
+}
+
+Geometry::~Geometry() = default;
+
+Geometry* Geometry::createInstance(std::string_view subtype, ViskoresDeviceGlobalState* s)
+{
+  // std::cout << "Creating geometry of type " << subtype << "\n";
+  if (subtype == "triangle")
+    return new Triangle(s);
+  else if (subtype == "sphere")
+    return new Sphere(s);
+  else
+    return new UnknownGeometry(s);
+}
+
+void Geometry::commitParameters()
+{
+  this->m_primitiveAttributes.commitParameters();
+}
+
+void Geometry::finalize()
+{
+  this->m_primitiveAttributes.setFields(this->m_dataSet);
+}
+
+void Geometry::FieldArrayParameters::setAttributes(Geometry* self,
+                                                   std::initializer_list<const char*>&& attributes)
+{
+  this->m_geometry = self;
+  for (auto&& attrib : attributes)
+  {
+    this->m_attributes.emplace(attrib, self);
+  }
+}
+
+void Geometry::FieldArrayParameters::setAnariAssociation(const std::string& association)
+{
+  this->m_anariAssociation = association;
+}
+
+void Geometry::FieldArrayParameters::setViskoresAssociation(
+  viskores::cont::Field::Association association)
+{
+  this->m_viskoresAssociation = association;
+}
+
+void Geometry::FieldArrayParameters::commitParameters()
+{
+  for (auto& iter : this->m_attributes)
+  {
+    iter.second =
+      this->m_geometry->getParamObject<Array1D>(this->m_anariAssociation + "." + iter.first);
+  }
+}
+
+void Geometry::FieldArrayParameters::setFields(viskores::cont::DataSet& dataSet)
+{
+  for (auto& iter : this->m_attributes)
+  {
+    if (iter.second)
+    {
+      dataSet.AddField(iter.first, this->m_viskoresAssociation, iter.second->dataAsViskoresArray());
+    }
+  }
+}
+
+helium::ChangeObserverPtr<Array1D>& Geometry::FieldArrayParameters::getParam(
+  const std::string& attribute)
+{
+  return this->m_attributes.find(attribute)->second;
+}
+
+const helium::ChangeObserverPtr<Array1D>& Geometry::FieldArrayParameters::getParam(
+  const std::string& attribute) const
+{
+  return this->m_attributes.find(attribute)->second;
+}
+
+UnknownGeometry::UnknownGeometry(ViskoresDeviceGlobalState* s)
+  : Geometry(s)
+{
+}
+
+void UnknownGeometry::commitParameters()
+{
+  // invalid
+}
+
+void UnknownGeometry::finalize()
+{
+  // invalid
+}
+
+bool UnknownGeometry::isValid() const
+{
+  return false;
+}
+
+} // namespace viskores_device
+
+VISKORES_ANARI_TYPEFOR_DEFINITION(viskores_device::Geometry*);

--- a/viskores/rendering/anari-device/scene/surface/geometry/Geometry.h
+++ b/viskores/rendering/anari-device/scene/surface/geometry/Geometry.h
@@ -1,0 +1,90 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#pragma once
+
+#include "Object.h"
+#include "array/Array1D.h"
+
+#include <viskores/cont/DataSet.h>
+#include <viskores/rendering/Actor.h>
+#include <viskores/rendering/MapperRayTracer.h>
+
+#include <map>
+
+namespace viskores_device
+{
+
+struct Geometry : public Object
+{
+  Geometry(ViskoresDeviceGlobalState* s);
+  ~Geometry() override;
+  static Geometry* createInstance(std::string_view subtype, ViskoresDeviceGlobalState* s);
+
+  const viskores::cont::DataSet& getDataSet() const { return this->m_dataSet; }
+  virtual const viskores::rendering::Mapper* mapper() const { return this->m_mapper.get(); }
+
+  // The commitParameters and finalize will load parameters common to all
+  // geometry objects and add them to `m_dataSet`.
+  void commitParameters() override;
+  void finalize() override;
+
+  // This struct helps manage a set of parameters providing arrays of data that
+  // will be attached to fields on a Viskores dataset created by this geometry.
+  // The fields are in the form `association.name` where `association` is the
+  // string used to describe what type of element each value is attached to
+  // (i.e., `vertex`, `primitive`) and `name` is how ANARI references the array
+  // (i.e., `color`, `attribute0`). The structure will register itself with the
+  // given `Geometry` object so that the geometry will be updated on data
+  // change. Use `commitParameters` to pull the arrays from the associated
+  // parameters (usually done in a `commitParameters` method of the geometry
+  // object). Use `setFields` to add these arrays as fields to a provided
+  // `viskores::cont::DataSet` (usually done in a `finalize` method of the
+  // geometry object).
+  class FieldArrayParameters
+  {
+    Geometry* m_geometry;
+    std::map<std::string, helium::ChangeObserverPtr<Array1D>> m_attributes;
+    std::string m_anariAssociation;
+    viskores::cont::Field::Association m_viskoresAssociation;
+
+  public:
+    void setAttributes(Geometry* self, std::initializer_list<const char*>&& attributes);
+    void setAnariAssociation(const std::string& association);
+    void setViskoresAssociation(viskores::cont::Field::Association association);
+
+    void commitParameters();
+    void setFields(viskores::cont::DataSet& dataSet);
+
+    // Gets a specific named parameter (perhaps because it is special). The
+    // string should be the same as that given in the list provided to
+    // `setAttributes`. It will not have the association part included in
+    // ANARI's name. This method only works after `commitParameters` is called.
+    helium::ChangeObserverPtr<Array1D>& getParam(const std::string& attribute);
+    const helium::ChangeObserverPtr<Array1D>& getParam(const std::string& attribute) const;
+  };
+
+protected:
+  viskores::cont::DataSet m_dataSet;
+  std::shared_ptr<viskores::rendering::Mapper> m_mapper;
+  FieldArrayParameters m_primitiveAttributes;
+};
+
+struct UnknownGeometry : public Geometry
+{
+  UnknownGeometry(ViskoresDeviceGlobalState* s);
+  void commitParameters() override;
+  void finalize() override;
+  bool isValid() const override;
+};
+
+} // namespace viskores_device
+
+VISKORES_ANARI_TYPEFOR_SPECIALIZATION(viskores_device::Geometry*, ANARI_GEOMETRY);

--- a/viskores/rendering/anari-device/scene/surface/geometry/Sphere.cpp
+++ b/viskores/rendering/anari-device/scene/surface/geometry/Sphere.cpp
@@ -1,0 +1,132 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#include "Sphere.h"
+
+#include <viskores/cont/ArrayCopy.h>
+#include <viskores/cont/ArrayHandleIndex.h>
+#include <viskores/cont/ArrayHandlePermutation.h>
+
+#include <numeric>
+
+namespace viskores_device
+{
+
+Sphere::Sphere(ViskoresDeviceGlobalState* s)
+  : Geometry(s)
+  , m_index(this)
+  , m_vertexPosition(this)
+  , m_vertexRadius(this)
+{
+}
+
+void Sphere::commitParameters()
+{
+  this->Geometry::commitParameters();
+
+  m_index = getParamObject<Array1D>("primitive.index");
+  m_vertexPosition = getParamObject<Array1D>("vertex.position");
+  m_vertexRadius = getParamObject<Array1D>("vertex.radius");
+}
+
+void Sphere::finalize()
+{
+  this->Geometry::finalize();
+
+  if (!m_vertexPosition)
+  {
+    reportMessage(ANARI_SEVERITY_WARNING,
+                  "missing required parameter 'vertex.position' on sphere geometry");
+    return;
+  }
+
+  m_globalRadius = getParam<float>("radius", 0.01f);
+  const auto numSpheres = m_index ? m_index->size() : m_vertexPosition->size();
+
+  this->m_dataSet = viskores::cont::DataSet{};
+
+  if (m_index)
+  {
+    this->SetupIndexBased();
+  }
+  else
+  {
+    this->m_dataSet.AddCoordinateSystem(
+      { "coords", this->m_vertexPosition->dataAsViskoresArray() });
+  }
+
+  auto pointMapper = std::make_shared<viskores::rendering::MapperPoint>();
+  pointMapper->SetUsePoints();
+
+  if (this->m_vertexRadius)
+  {
+    pointMapper->UseVariableRadius(true);
+    this->m_dataSet.AddPointField("data", this->m_vertexRadius->dataAsViskoresArray());
+  }
+  else
+  {
+    pointMapper->UseVariableRadius(false);
+    pointMapper->SetRadius(this->m_globalRadius);
+  }
+
+  this->m_mapper = pointMapper;
+
+  auto connIdx = viskores::cont::make_ArrayHandleIndex(numSpheres);
+  viskores::cont::ArrayHandle<viskores::Id> conn;
+  viskores::cont::ArrayCopy(connIdx, conn);
+
+  viskores::cont::CellSetSingleType<> cellSet;
+  cellSet.Fill(static_cast<viskores::Id>(numSpheres), viskores::CELL_SHAPE_VERTEX, 1, conn);
+  this->m_dataSet.SetCellSet(cellSet);
+}
+
+void Sphere::SetupIndexBased()
+{
+  viskores::cont::ArrayHandle<viskores::Id> indexArray;
+  viskores::cont::ArrayHandle<viskores::Vec3f> vertices;
+
+  auto viskoresArray = this->m_index->dataAsViskoresArray();
+  if (!viskoresArray.IsValueType<viskores::Id>())
+    viskores::cont::ArrayCopy(viskoresArray, indexArray);
+  else
+  {
+    indexArray = viskoresArray.AsArrayHandle<viskores::cont::ArrayHandle<viskores::Id>>();
+  }
+
+  auto positionArray = m_vertexPosition->dataAsViskoresArray();
+  if (!positionArray.IsValueType<viskores::Vec3f>())
+  {
+    viskores::cont::ArrayCopy(positionArray, vertices);
+  }
+  else
+  {
+    vertices = positionArray.AsArrayHandle<viskores::cont::ArrayHandle<viskores::Vec3f>>();
+  }
+
+  auto permuteArray = viskores::cont::make_ArrayHandlePermutation(indexArray, vertices);
+  this->m_dataSet.AddCoordinateSystem({ "coords", permuteArray });
+
+  // Now handle the radius.
+  if (this->m_vertexRadius)
+  {
+    viskores::cont::ArrayHandle<viskores::FloatDefault> radiusArray;
+    auto tmp = this->m_vertexRadius->dataAsViskoresArray();
+    if (!tmp.IsValueType<viskores::FloatDefault>())
+      viskores::cont::ArrayCopy(tmp, radiusArray);
+    else
+      radiusArray = tmp.AsArrayHandle<viskores::cont::ArrayHandle<viskores::FloatDefault>>();
+
+    auto permuteArray = viskores::cont::make_ArrayHandlePermutation(indexArray, radiusArray);
+
+    this->m_dataSet.AddPointField("data", permuteArray);
+  }
+}
+
+} // namespace viskores_device

--- a/viskores/rendering/anari-device/scene/surface/geometry/Sphere.h
+++ b/viskores/rendering/anari-device/scene/surface/geometry/Sphere.h
@@ -1,0 +1,50 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#pragma once
+
+#include "Geometry.h"
+#include "array/Array1D.h"
+
+// viskores
+#include <viskores/rendering/Actor.h>
+#include <viskores/rendering/MapperPoint.h>
+
+namespace viskores_device
+{
+
+struct Sphere : public Geometry
+{
+  Sphere(ViskoresDeviceGlobalState* s);
+
+  void commitParameters() override;
+  void finalize() override;
+
+  virtual viskores::rendering::Mapper* mapper() const override { return this->m_mapper.get(); }
+
+private:
+  void SetupIndexBased();
+
+  helium::ChangeObserverPtr<Array1D> m_index;
+  helium::ChangeObserverPtr<Array1D> m_vertexPosition;
+  // optional- radius per position
+  helium::ChangeObserverPtr<Array1D> m_vertexRadius;
+
+  std::shared_ptr<viskores::rendering::Mapper> m_mapper;
+  viskores::cont::ColorTable m_colorTable;
+
+  // TODO: Add these later.
+  // std::array<helium::IntrusivePtr<Array1D>, 5> m_vertexAttributes;
+  // std::vector<uint32_t> m_attributeIndex;
+
+  float m_globalRadius{ 0.f }; // fallback radius if m_vertexRadius not there.
+};
+
+} // namespace viskores_device

--- a/viskores/rendering/anari-device/scene/surface/geometry/Triangle.cpp
+++ b/viskores/rendering/anari-device/scene/surface/geometry/Triangle.cpp
@@ -1,0 +1,124 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#include "Triangle.h"
+// Viskores
+#include <viskores/CellShape.h>
+#include <viskores/cont/ArrayCopy.h>
+#include <viskores/cont/ArrayHandleRuntimeVec.h>
+#include <viskores/cont/CellSetSingleType.h>
+#include <viskores/cont/UnknownArrayHandle.h>
+// std
+#include <array>
+#include <numeric>
+
+namespace viskores_device
+{
+
+Triangle::Triangle(ViskoresDeviceGlobalState* s)
+  : Geometry(s)
+  , m_index(this)
+  , m_vertexColor(this)
+{
+  this->m_vertexAttributes.setAttributes(this,
+                                         { "position",
+                                           "normal",
+                                           "tangent",
+                                           "color",
+                                           "attribute0",
+                                           "attribute1",
+                                           "attribute2",
+                                           "attribute3" });
+  this->m_vertexAttributes.setAnariAssociation("vertex");
+  this->m_vertexAttributes.setViskoresAssociation(viskores::cont::Field::Association::Points);
+
+  this->m_faceVaryingAttributes.setAttributes(
+    this, { "normal", "tangent", "color", "attribute0", "attribute1", "attribute2", "attribute3" });
+  this->m_faceVaryingAttributes.setAnariAssociation("faceVarying");
+  this->m_faceVaryingAttributes.setViskoresAssociation(viskores::cont::Field::Association::Cells);
+}
+
+void Triangle::commitParameters()
+{
+  this->Geometry::commitParameters();
+
+  // Stashing these in a ChangeObserverPtr means that commit will be
+  // called again if the array contents change.
+  this->m_index = getParamObject<Array1D>("primitive.index");
+  this->m_vertexAttributes.commitParameters();
+  this->m_faceVaryingAttributes.commitParameters();
+
+  box1 range = { 0, 1 };
+  this->getParam("valueRange", ANARI_FLOAT32_BOX1, &range);
+  this->m_colorTable.RescaleToRange({ range.lower, range.upper });
+}
+
+void Triangle::finalize()
+{
+  this->Geometry::finalize();
+
+  helium::ChangeObserverPtr<Array1D>& positionArray = this->m_vertexAttributes.getParam("position");
+  if (!positionArray)
+  {
+    reportMessage(ANARI_SEVERITY_WARNING,
+                  "'triangle' geometry missing 'vertex.position' parameter");
+    return;
+  }
+
+  if (!this->m_index)
+  {
+    reportMessage(ANARI_SEVERITY_INFO, "generating 'triangle' index array");
+
+    Array1DMemoryDescriptor md;
+    md.appMemory = nullptr;
+    md.deleter = nullptr;
+    md.deleterPtr = nullptr;
+    md.elementType = ANARI_UINT32_VEC3;
+    md.numItems = positionArray->totalSize() / 3;
+
+    this->m_index = new Array1D(this->deviceState(), md);
+    this->m_index->refDec(helium::RefType::PUBLIC); // no public references
+
+    auto* begin = (uint32_t*)this->m_index->map();
+    auto* end = begin + this->m_index->totalSize() * 3;
+    std::iota(begin, end, 0);
+  }
+
+  // Reset data
+  this->m_dataSet = viskores::cont::DataSet{};
+  this->m_mapper = std::make_shared<viskores::rendering::MapperRayTracer>();
+
+  // Get the connection array.
+  // Note that ANARI provides the connection array as a series of triples
+  // whereas Viskores wants a flat array of indices. The easist way to do the
+  // conversion (while sharing pointers) is to use ArrayHandleRuntimeVec.
+  viskores::cont::ArrayHandleRuntimeVec<viskores::Id> connectionArray(3);
+  viskores::cont::ArrayCopyShallowIfPossible(this->m_index->dataAsViskoresArray(), connectionArray);
+
+  viskores::cont::CellSetSingleType<> cellSet;
+  cellSet.Fill(static_cast<viskores::Id>(positionArray->size()),
+               viskores::CELL_SHAPE_TRIANGLE,
+               3,
+               connectionArray.GetComponentsArray());
+  this->m_dataSet.SetCellSet(cellSet);
+
+  this->m_vertexAttributes.setFields(this->m_dataSet);
+  this->m_faceVaryingAttributes.setFields(this->m_dataSet);
+
+  // We have already checked that the position array exists.
+  this->m_dataSet.AddCoordinateSystem("position");
+}
+
+bool Triangle::isValid() const
+{
+  return this->m_vertexAttributes.getParam("position");
+}
+
+} // namespace viskores_device

--- a/viskores/rendering/anari-device/scene/surface/geometry/Triangle.h
+++ b/viskores/rendering/anari-device/scene/surface/geometry/Triangle.h
@@ -1,0 +1,42 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#pragma once
+
+#include "Geometry.h"
+// viskores
+#include <viskores/rendering/Actor.h>
+
+namespace viskores_device
+{
+
+struct Triangle : Geometry
+{
+  Triangle(ViskoresDeviceGlobalState* s);
+
+  void commitParameters() override;
+  void finalize() override;
+
+  virtual viskores::rendering::Mapper* mapper() const override { return this->m_mapper.get(); }
+
+  bool isValid() const override;
+
+private:
+  helium::ChangeObserverPtr<Array1D> m_index;
+  FieldArrayParameters m_vertexAttributes;
+  FieldArrayParameters m_faceVaryingAttributes;
+
+  std::shared_ptr<viskores::rendering::MapperRayTracer> m_mapper;
+
+  viskores::cont::ColorTable m_colorTable;
+  helium::ChangeObserverPtr<Array1D> m_vertexColor;
+};
+
+} // namespace viskores_device

--- a/viskores/rendering/anari-device/scene/surface/material/Material.cpp
+++ b/viskores/rendering/anari-device/scene/surface/material/Material.cpp
@@ -1,0 +1,82 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#include "Material.h"
+
+#include "MatteMaterial.h"
+
+namespace
+{
+
+struct UnknownMaterial : viskores_device::Material
+{
+  UnknownMaterial(viskores_device::ViskoresDeviceGlobalState* d);
+
+  void commitParameters() override;
+  void finalize() override;
+
+  bool isValid() const override;
+
+  std::shared_ptr<viskores::rendering::Actor> createActor(
+    const viskores::cont::DataSet& data) override;
+};
+
+UnknownMaterial::UnknownMaterial(viskores_device::ViskoresDeviceGlobalState* d)
+  : Material(d)
+{
+}
+
+void UnknownMaterial::commitParameters()
+{
+  // invalid
+}
+void UnknownMaterial::finalize()
+{
+  // invalid
+}
+
+bool UnknownMaterial::isValid() const
+{
+  return false;
+}
+
+std::shared_ptr<viskores::rendering::Actor> UnknownMaterial::createActor(
+  const viskores::cont::DataSet&)
+{
+  return nullptr;
+}
+
+} // anonymous namespace
+
+namespace viskores_device
+{
+
+Material::Material(ViskoresDeviceGlobalState* s)
+  : Object(ANARI_MATERIAL, s)
+{
+}
+
+Material::~Material() = default;
+
+Material* Material::createInstance(std::string_view subtype, ViskoresDeviceGlobalState* s)
+{
+  if (subtype == "matte")
+  {
+    return new MatteMaterial(s);
+  }
+  else
+  {
+    return new UnknownMaterial(s);
+  }
+}
+
+} // namespace viskores_device
+
+VISKORES_ANARI_TYPEFOR_DEFINITION(viskores_device::Material*);

--- a/viskores/rendering/anari-device/scene/surface/material/Material.h
+++ b/viskores/rendering/anari-device/scene/surface/material/Material.h
@@ -1,0 +1,33 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#pragma once
+
+#include "Object.h"
+#include "sampler/Sampler.h"
+
+#include <viskores/rendering/Actor.h>
+
+namespace viskores_device
+{
+
+struct Material : public Object
+{
+  Material(ViskoresDeviceGlobalState* s);
+  ~Material() override;
+  static Material* createInstance(std::string_view subtype, ViskoresDeviceGlobalState* s);
+
+  virtual std::shared_ptr<viskores::rendering::Actor> createActor(
+    const viskores::cont::DataSet& data) = 0;
+};
+
+} // namespace viskores_device
+
+VISKORES_ANARI_TYPEFOR_SPECIALIZATION(viskores_device::Material*, ANARI_MATERIAL);

--- a/viskores/rendering/anari-device/scene/surface/material/MatteMaterial.cpp
+++ b/viskores/rendering/anari-device/scene/surface/material/MatteMaterial.cpp
@@ -1,0 +1,79 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#include "MatteMaterial.h"
+
+#include <viskores/cont/ArrayHandleConstant.h>
+
+namespace viskores_device
+{
+
+MatteMaterial::MatteMaterial(ViskoresDeviceGlobalState* d)
+  : Material(d)
+  , m_sampler(this)
+{
+}
+
+void MatteMaterial::commitParameters()
+{
+  this->m_sampler = this->getParamObject<Sampler>("color");
+  this->m_colorAttribute = helium::attributeFromString(this->getParamString("color", "none"));
+  this->m_color = this->getParam("color", viskores::Vec3f_32{ 0.8, 0.8, 0.8 });
+  this->m_color = viskores::Min(viskores::Max(this->m_color, { 0.f, 0.f, 0.f }), { 1.f, 1.f, 1.f });
+  // TODO: Implement sampler
+
+  this->m_opacityAttribute = helium::attributeFromString(this->getParamString("color", "none"));
+  this->m_opacity = this->getParam("opacity", viskores::Float32{ 1.0f });
+  // TODO: Implement sampler
+
+  this->m_alphaMode = helium::alphaModeFromString(this->getParamString("alphaMode", "opaque"));
+
+  this->m_alphaCutoff = this->getParam("alphaCutoff", viskores::Float32{ 0.5f });
+}
+
+void MatteMaterial::finalize()
+{
+  // no-op
+}
+
+std::shared_ptr<viskores::rendering::Actor> MatteMaterial::createActor(
+  const viskores::cont::DataSet& data)
+{
+  std::shared_ptr<viskores::rendering::Actor> actor;
+  if (this->m_sampler && this->m_sampler->isValid())
+  {
+    actor = this->m_sampler->createActor(data);
+    if (!actor)
+    {
+      this->reportMessage(ANARI_SEVERITY_WARNING, "could not create actor for sampler");
+    }
+  }
+
+  if (!actor)
+  {
+    viskores::cont::ColorTable colorTable(viskores::ColorSpace::RGB);
+    viskores::cont::Field colorField;
+    // TODO: Implement sampling and attributes.
+    // This should be the fallback when other coloring is missing.
+    colorTable.AddPoint(0, this->color());
+    colorTable.AddPointAlpha(0, this->opacity());
+    colorField = viskores::cont::Field{ "data",
+                                        viskores::cont::Field::Association::Points,
+                                        viskores::cont::make_ArrayHandleConstant(
+                                          viskores::Float32{ 0.0f }, data.GetNumberOfPoints()) };
+
+    actor = std::make_shared<viskores::rendering::Actor>(
+      data.GetCellSet(), data.GetCoordinateSystem(), colorField, colorTable);
+  }
+
+  return actor;
+}
+
+} // namespace viskores_device

--- a/viskores/rendering/anari-device/scene/surface/material/MatteMaterial.h
+++ b/viskores/rendering/anari-device/scene/surface/material/MatteMaterial.h
@@ -1,0 +1,54 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#pragma once
+
+#include "Material.h"
+#include "sampler/Sampler.h"
+// helium
+#include <helium/utility/ChangeObserverPtr.h>
+
+namespace viskores_device
+{
+
+struct MatteMaterial : public Material
+{
+  MatteMaterial(ViskoresDeviceGlobalState* d);
+
+  void commitParameters() override;
+  void finalize() override;
+
+  std::shared_ptr<viskores::rendering::Actor> createActor(
+    const viskores::cont::DataSet& data) override;
+
+  Sampler* sampler() const { return this->m_sampler.get(); }
+
+  helium::Attribute colorAttribute() const { return this->m_colorAttribute; }
+  const viskores::Vec3f_32& color() const { return this->m_color; }
+
+  helium::Attribute opacityAttribute() const { return this->m_opacityAttribute; }
+  viskores::Float32 opacity() const { return this->m_opacity; }
+
+  helium::AlphaMode alphaMode() const { return this->m_alphaMode; }
+  viskores::Float32 alphaCutoff() const { return this->m_alphaCutoff; }
+
+private:
+  helium::ChangeObserverPtr<Sampler> m_sampler;
+  helium::Attribute m_colorAttribute;
+  viskores::Vec3f_32 m_color;
+
+  helium::Attribute m_opacityAttribute;
+  viskores::Float32 m_opacity;
+
+  helium::AlphaMode m_alphaMode;
+  viskores::Float32 m_alphaCutoff;
+};
+
+} // namespace viskores_device

--- a/viskores/rendering/anari-device/scene/surface/material/sampler/Image1DSampler.cpp
+++ b/viskores/rendering/anari-device/scene/surface/material/sampler/Image1DSampler.cpp
@@ -1,0 +1,200 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#include "Image1DSampler.h"
+// Viskores
+#include <viskores/TypeTraits.h>
+#include <viskores/cont/ArrayCopy.h>
+#include <viskores/cont/ArrayExtractComponent.h>
+#include <viskores/cont/ArrayHandleConstant.h>
+// std
+#include <limits>
+
+namespace
+{
+
+template <typename T>
+constexpr viskores::Float32 floatConvert(T anariValue, viskores::TypeTraitsRealTag)
+{
+  return static_cast<viskores::Float32>(anariValue);
+}
+template <typename T>
+constexpr viskores::Float32 floatConvert(T anariValue, viskores::TypeTraitsIntegerTag)
+{
+  return static_cast<viskores::Float32>(anariValue) /
+    static_cast<viskores::Float32>(std::numeric_limits<T>::max());
+}
+template <typename T>
+constexpr viskores::Float32 floatConvert(T anariValue)
+{
+  return floatConvert(anariValue, typename viskores::TypeTraits<T>::NumericTag{});
+}
+
+template <typename ComponentType>
+void captureColorTableType(const viskores::cont::UnknownArrayHandle& colorArray,
+                           viskores::cont::ColorTable& colorTable)
+{
+  const viskores::Id numValues = colorArray.GetNumberOfValues();
+  std::array<viskores::cont::ArrayHandleStride<ComponentType>, 4> colorChannelArrays;
+  std::array<typename viskores::cont::ArrayHandleStride<ComponentType>::ReadPortalType, 4>
+    colorChannelPortals;
+  for (viskores::IdComponent channel = 0; channel < 4; ++channel)
+  {
+    if (channel < colorArray.GetNumberOfComponentsFlat())
+    {
+      colorChannelArrays[channel] = colorArray.ExtractComponent<ComponentType>(channel);
+    }
+    else
+    {
+      colorChannelArrays[channel] = viskores::cont::ArrayExtractComponent(
+        viskores::cont::ArrayHandleConstant<ComponentType>(0, numValues), channel);
+    }
+    colorChannelPortals[channel] = colorChannelArrays[channel].ReadPortal();
+  }
+  viskores::Float32 sampleDelta = 1.0f / viskores::Float32(numValues - 1);
+  for (viskores::Id sample = 0; sample < numValues; ++sample)
+  {
+    viskores::Vec3f_32 color{ floatConvert(colorChannelPortals[0].Get(sample)),
+                              floatConvert(colorChannelPortals[1].Get(sample)),
+                              floatConvert(colorChannelPortals[2].Get(sample)) };
+    colorTable.AddPoint(sample * sampleDelta, color);
+    if (colorArray.GetNumberOfComponentsFlat() > 3)
+    {
+      viskores::Float32 alpha = floatConvert(colorChannelPortals[3].Get(sample));
+      colorTable.AddPointAlpha(sample * sampleDelta, alpha);
+    }
+  }
+}
+
+bool captureColorTable(const viskores::cont::UnknownArrayHandle& colorArray,
+                       viskores::cont::ColorTable& colorTable)
+{
+  if (colorArray.IsBaseComponentType<viskores::UInt8>())
+  {
+    captureColorTableType<viskores::UInt8>(colorArray, colorTable);
+    return true;
+  }
+  else if (colorArray.IsBaseComponentType<viskores::UInt16>())
+  {
+    captureColorTableType<viskores::UInt16>(colorArray, colorTable);
+    return true;
+  }
+  else if (colorArray.IsBaseComponentType<viskores::UInt32>())
+  {
+    captureColorTableType<viskores::UInt32>(colorArray, colorTable);
+    return true;
+  }
+  else if (colorArray.IsBaseComponentType<viskores::Float32>())
+  {
+    captureColorTableType<viskores::Float32>(colorArray, colorTable);
+    return true;
+  }
+  else
+  {
+    return false;
+  }
+}
+
+} // anonymous namespace
+namespace viskores_device
+{
+
+Image1DSampler::Image1DSampler(ViskoresDeviceGlobalState* d)
+  : Sampler(d)
+  , m_colorArray(this)
+{
+}
+
+void Image1DSampler::commitParameters()
+{
+  this->Sampler::commitParameters();
+
+  this->m_inAttribute = this->getParamString("inAttribute", "attribute0");
+
+  mat4 inTransform = this->getParam("inTransform", mat4(linalg::identity));
+  this->m_inTransform = toViskoresMatrix(inTransform);
+  float4 inOffset = this->getParam("inOffset", float4(0.f, 0.f, 0.f, 0.f));
+  this->m_inOffset = { inOffset[0], inOffset[1], inOffset[2], inOffset[3] };
+
+  this->m_colorArray = this->getParamObject<Array1D>("image");
+
+  this->m_wrapMode = helium::wrapModeFromString(this->getParamString("wrapMode", "clampToEdge"));
+  if (this->m_wrapMode == helium::WrapMode::DEFAULT)
+  {
+    this->m_wrapMode = helium::WrapMode::CLAMP_TO_EDGE;
+  }
+}
+
+void Image1DSampler::finalize()
+{
+  this->Sampler::finalize();
+
+  // TODO: Viskores' ColorTable is not the best place to put a texture
+  // because it just gets resampled. We will have to crack open the
+  // rendering components to implement something like that.
+  this->m_colorTable = viskores::cont::ColorTable{ viskores::ColorSpace::RGB };
+  bool colorTableFilled = false;
+  if (this->m_colorArray)
+  {
+    // TODO: This method does not properly handle vec2 nor SRGB.
+    colorTableFilled =
+      captureColorTable(this->m_colorArray->dataAsViskoresArray(), this->m_colorTable);
+    if (!colorTableFilled)
+    {
+      this->reportMessage(ANARI_SEVERITY_WARNING,
+                          "color array provided for image1D sampling has unrecognized type");
+    }
+  }
+
+  if (!colorTableFilled)
+  {
+    this->reportMessage(ANARI_SEVERITY_WARNING,
+                        "image1D sampling requested, but no color array given");
+    this->m_colorTable.AddPoint(0, { 1, 1, 1 });
+  }
+}
+
+std::shared_ptr<viskores::rendering::Actor> Image1DSampler::createActor(
+  const viskores::cont::DataSet& data)
+{
+  if (!data.HasField(this->inAttribute()))
+  {
+    this->reportMessage(
+      ANARI_SEVERITY_WARNING, "sampler attribute %s not found", this->inAttribute().c_str());
+    return nullptr;
+  }
+
+  viskores::cont::Field attribField = data.GetField(this->inAttribute());
+  viskores::cont::UnknownArrayHandle attribArray = attribField.GetData();
+  if (!attribArray.CanConvert<viskores::cont::ArrayHandle<viskores::Float32>>())
+  {
+    if (!attribArray.IsBaseComponentType<viskores::Float32>())
+    {
+      this->reportMessage(ANARI_SEVERITY_WARNING,
+                          "attribute array type not currently supported for image1D sampler.");
+      return nullptr;
+    }
+    this->reportMessage(ANARI_SEVERITY_PERFORMANCE_WARNING,
+                        "todo: handle vector attributes more efficiently");
+    viskores::cont::UnknownArrayHandle newArray;
+    viskores::cont::ArrayCopy(attribArray.ExtractComponent<viskores::Float32>(0), newArray);
+    attribArray = newArray;
+  }
+
+  auto actor = std::make_shared<viskores::rendering::Actor>(
+    data.GetCellSet(),
+    data.GetCoordinateSystem(),
+    viskores::cont::Field{ attribField.GetName(), attribField.GetAssociation(), attribArray },
+    this->colorTable());
+  actor->SetScalarRange({ 0, 1 });
+  return actor;
+}
+
+} // namespace viskores_device

--- a/viskores/rendering/anari-device/scene/surface/material/sampler/Image1DSampler.h
+++ b/viskores/rendering/anari-device/scene/surface/material/sampler/Image1DSampler.h
@@ -1,0 +1,53 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#pragma once
+
+#include "Sampler.h"
+
+#include "array/Array1D.h"
+// helium
+#include <helium/utility/ChangeObserverPtr.h>
+// viskores
+#include <viskores/cont/ColorTable.h>
+
+namespace viskores_device
+{
+
+struct Image1DSampler : public Sampler
+{
+  Image1DSampler(ViskoresDeviceGlobalState* d);
+
+  void commitParameters() override;
+  void finalize() override;
+
+  const Mat4f_32& inTransform() const { return this->m_inTransform; }
+  const viskores::Vec4f_32& inOffset() const { return this->m_inOffset; }
+
+  const std::string& inAttribute() const { return this->m_inAttribute; }
+
+  helium::WrapMode wrapMode() const { return this->m_wrapMode; }
+
+  const viskores::cont::ColorTable& colorTable() const { return this->m_colorTable; }
+
+  std::shared_ptr<viskores::rendering::Actor> createActor(
+    const viskores::cont::DataSet& data) override;
+
+private:
+  Mat4f_32 m_inTransform;
+  viskores::Vec4f_32 m_inOffset;
+  std::string m_inAttribute;
+  helium::ChangeObserverPtr<Array1D> m_colorArray;
+  helium::WrapMode m_wrapMode;
+
+  viskores::cont::ColorTable m_colorTable;
+};
+
+} // namespace viskores_device

--- a/viskores/rendering/anari-device/scene/surface/material/sampler/Sampler.cpp
+++ b/viskores/rendering/anari-device/scene/surface/material/sampler/Sampler.cpp
@@ -1,0 +1,93 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#include "Sampler.h"
+#include "Image1DSampler.h"
+namespace
+{
+
+struct UnknownSampler : viskores_device::Sampler
+{
+  UnknownSampler(viskores_device::ViskoresDeviceGlobalState* d);
+
+  void commitParameters() override;
+  void finalize() override;
+
+  bool isValid() const override;
+
+  std::shared_ptr<viskores::rendering::Actor> createActor(
+    const viskores::cont::DataSet& data) override;
+};
+
+UnknownSampler::UnknownSampler(viskores_device::ViskoresDeviceGlobalState* d)
+  : Sampler(d)
+{
+}
+
+void UnknownSampler::commitParameters()
+{
+  // invalid
+}
+void UnknownSampler::finalize()
+{
+  // invalid
+}
+
+bool UnknownSampler::isValid() const
+{
+  return false;
+}
+
+std::shared_ptr<viskores::rendering::Actor> UnknownSampler::createActor(
+  const viskores::cont::DataSet&)
+{
+  return nullptr;
+}
+
+} // anonymous namespace
+
+namespace viskores_device
+{
+
+Sampler::Sampler(ViskoresDeviceGlobalState* s)
+  : Object(ANARI_SAMPLER, s)
+{
+}
+
+Sampler::~Sampler() = default;
+
+Sampler* Sampler::createInstance(std::string_view subtype, ViskoresDeviceGlobalState* s)
+{
+  if (subtype == "image1D")
+  {
+    return new Image1DSampler(s);
+  }
+  else
+  {
+    return new UnknownSampler(s);
+  }
+}
+
+void Sampler::commitParameters()
+{
+  mat4 outTransform = this->getParam("outTransform", mat4(linalg::identity));
+  this->m_outTransform = toViskoresMatrix(outTransform);
+  float4 outOffset = this->getParam("outOffset", float4(0.f, 0.f, 0.f, 0.f));
+  this->m_outOffset = { outOffset[0], outOffset[1], outOffset[2], outOffset[3] };
+}
+
+void Sampler::finalize()
+{
+  // no-op
+}
+
+} // namespace viskores_device
+
+VISKORES_ANARI_TYPEFOR_DEFINITION(viskores_device::Sampler*);

--- a/viskores/rendering/anari-device/scene/surface/material/sampler/Sampler.h
+++ b/viskores/rendering/anari-device/scene/surface/material/sampler/Sampler.h
@@ -1,0 +1,45 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#pragma once
+
+#include "Object.h"
+
+#include <viskores/Matrix.h>
+#include <viskores/rendering/Actor.h>
+
+namespace viskores_device
+{
+
+struct Geometry;
+
+struct Sampler : public Object
+{
+  Sampler(ViskoresDeviceGlobalState* d);
+  virtual ~Sampler();
+  static Sampler* createInstance(std::string_view subtype, ViskoresDeviceGlobalState* d);
+
+  void commitParameters() override;
+  void finalize() override;
+
+  const Mat4f_32& outTransform() const { return this->m_outTransform; }
+  const viskores::Vec4f_32& outOffset() const { return this->m_outOffset; }
+
+  virtual std::shared_ptr<viskores::rendering::Actor> createActor(
+    const viskores::cont::DataSet& data) = 0;
+
+private:
+  Mat4f_32 m_outTransform;
+  viskores::Vec4f_32 m_outOffset;
+};
+
+} // namespace viskores_device
+
+VISKORES_ANARI_TYPEFOR_SPECIALIZATION(viskores_device::Sampler*, ANARI_SAMPLER);

--- a/viskores/rendering/anari-device/scene/volume/TransferFunction1D.cpp
+++ b/viskores/rendering/anari-device/scene/volume/TransferFunction1D.cpp
@@ -1,0 +1,286 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#include "TransferFunction1D.h"
+#include "array/ArrayConversion.h"
+// Viskores
+#include <viskores/cont/ArrayExtractComponent.h>
+#include <viskores/cont/ArrayHandleConstant.h>
+#include <viskores/cont/ArrayHandleStride.h>
+
+namespace
+{
+
+template <typename ComponentType>
+void FillColorTable(viskores::cont::ColorTable& table,
+                    const viskores::cont::UnknownArrayHandle& array)
+{
+  viskores::Id numValues = array.GetNumberOfValues();
+
+  std::array<viskores::cont::ArrayHandleStride<ComponentType>, 3> colorChannels;
+  colorChannels[0] = array.ExtractComponent<ComponentType>(0);
+  if (array.GetNumberOfComponentsFlat() > 1)
+  {
+    colorChannels[1] = array.ExtractComponent<ComponentType>(1);
+  }
+  else
+  {
+    colorChannels[1] = viskores::cont::ArrayExtractComponent(
+      viskores::cont::ArrayHandleConstant<ComponentType>(0, numValues), 0);
+  }
+  if (array.GetNumberOfComponentsFlat() > 2)
+  {
+    colorChannels[2] = array.ExtractComponent<ComponentType>(2);
+  }
+  else
+  {
+    colorChannels[2] = viskores::cont::ArrayExtractComponent(
+      viskores::cont::ArrayHandleConstant<ComponentType>(0, numValues), 0);
+  }
+
+  bool hasOpacity;
+  viskores::cont::ArrayHandleStride<ComponentType> alphaChannel;
+  if (array.GetNumberOfComponentsFlat() > 3)
+  {
+    alphaChannel = array.ExtractComponent<ComponentType>(3);
+    hasOpacity = true;
+  }
+  else
+  {
+    hasOpacity = false;
+  }
+
+  std::array<typename viskores::cont::ArrayHandleStride<ComponentType>::ReadPortalType, 3>
+    colorPortals;
+  std::transform(colorChannels.begin(),
+                 colorChannels.end(),
+                 colorPortals.begin(),
+                 [](auto array) { return array.ReadPortal(); });
+  typename viskores::cont::ArrayHandleStride<ComponentType>::ReadPortalType alphaPortal;
+  if (hasOpacity)
+  {
+    alphaPortal = alphaChannel.ReadPortal();
+  }
+  if (numValues > 1)
+  {
+    viskores::Float64 scale = 1.0 / (numValues - 1);
+    for (viskores::Id index = 0; index < numValues; ++index)
+    {
+      std::array<viskores::Float32, 3> color;
+      std::transform(colorPortals.begin(),
+                     colorPortals.end(),
+                     color.begin(),
+                     [index](auto portal)
+                     { return static_cast<viskores::Float32>(portal.Get(index)); });
+      table.AddPoint(index * scale, { color[0], color[1], color[2] });
+      if (hasOpacity)
+      {
+        table.AddPointAlpha(index * scale, static_cast<viskores::Float32>(alphaPortal.Get(index)));
+      }
+    }
+  }
+  else
+  {
+    // Special case: only one color given in array.
+    std::array<viskores::Float32, 3> color;
+    std::transform(colorPortals.begin(),
+                   colorPortals.end(),
+                   color.begin(),
+                   [](auto portal) { return static_cast<viskores::Float32>(portal.Get(0)); });
+    table.AddPoint(0, { color[0], color[1], color[2] });
+    table.AddPoint(1, { color[0], color[1], color[2] });
+    if (hasOpacity)
+    {
+      viskores::Float32 alpha = static_cast<viskores::Float32>(alphaPortal.Get(0));
+      table.AddPointAlpha(0, alpha);
+      table.AddPointAlpha(1, alpha);
+    }
+  }
+}
+
+} // namespace
+
+namespace viskores_device
+{
+
+TransferFunction1D::TransferFunction1D(ViskoresDeviceGlobalState* d)
+  : Volume(d)
+  , m_spatialField(this)
+  , m_colorArray(this)
+  , m_opacityArray(this)
+{
+}
+
+void TransferFunction1D::commitParameters()
+{
+  this->Volume::commitParameters();
+
+  this->m_spatialField = getParamObject<SpatialField>("value");
+
+  this->m_unitDistance = getParam("unitDistance", 1.0f);
+
+  this->m_colorArray = this->getParamObject<Array1D>("color");
+  this->m_color = { 1, 1, 1, 1 };
+  this->getParam("color", ANARI_FLOAT32_VEC4, &this->m_color);
+  this->getParam("color", ANARI_FLOAT32_VEC3, &this->m_color);
+
+  this->m_opacityArray = this->getParamObject<Array1D>("opacity");
+  this->m_alpha = 1.0f;
+  this->getParam("opacity", ANARI_FLOAT32, &this->m_alpha);
+
+  box1 range = { 0, 1 };
+  this->getParam("valueRange", ANARI_FLOAT32_BOX1, &range);
+  this->m_valueRange = { range.lower, range.upper };
+}
+
+void TransferFunction1D::finalize()
+{
+  Volume::finalize();
+
+  if (!this->m_spatialField)
+  {
+    reportMessage(ANARI_SEVERITY_WARNING, "'transferFunction1D' volume missing 'value' parameter");
+    return;
+  }
+
+  // Determine sample distance (which also affects colors).
+  viskores::cont::DataSet dataSet = this->m_spatialField->getDataSet();
+  viskores::Bounds bounds = dataSet.GetCoordinateSystem().GetBounds();
+  viskores::Float32 diagonalLength =
+    static_cast<viskores::Float32>(viskores::Magnitude(bounds.MaxCorner() - bounds.MinCorner()));
+  constexpr viskores::IdComponent numberOfSamples = 200;
+  viskores::Float32 sampleDistance =
+    static_cast<viskores::Float32>(diagonalLength / numberOfSamples);
+
+  // Reset and fill color table
+  this->m_colorTable = viskores::cont::ColorTable(viskores::ColorSpace::RGB);
+  bool colorsHaveAlpha = false;
+  if (this->m_colorArray)
+  {
+    // Convert to Viskores colors
+    viskores::cont::UnknownArrayHandle viskoresColors =
+      ANARIColorsToViskoresColors(this->m_colorArray->dataAsViskoresArray());
+    if (viskoresColors.GetNumberOfComponentsFlat() > 3)
+    {
+      colorsHaveAlpha = true;
+    }
+
+    // Copy colors into ColorTable
+    // NOTE: I am not at all convinced that this is a good idea. If we are
+    // getting an array, that probably means that the client has already sampled
+    // the colors to the desired level, and we should just use that array.
+    // Insetad, we are building peicewise linear segments and then resampling
+    // again.
+    if (viskoresColors.IsBaseComponentType<viskores::Float32>())
+    {
+      FillColorTable<viskores::Float32>(this->m_colorTable, viskoresColors);
+    }
+    else if (viskoresColors.IsBaseComponentType<viskores::Float64>())
+    {
+      FillColorTable<viskores::Float64>(this->m_colorTable, viskoresColors);
+    }
+    else
+    {
+      reportMessage(ANARI_SEVERITY_ERROR, "Unexpected type for color table data.");
+    }
+  }
+  else
+  {
+    this->m_colorTable.AddPoint(0, { m_color[0], m_color[1], m_color[2] });
+    this->m_colorTable.AddPoint(1, { m_color[0], m_color[1], m_color[2] });
+  }
+
+  if (m_opacityArray)
+  {
+    if (colorsHaveAlpha)
+    {
+      reportMessage(ANARI_SEVERITY_WARNING, "Alpha given in both color and opacity parameters.");
+    }
+    if (m_opacityArray->size() > 1)
+    {
+      viskores::Float64 scale = 1.0 / (m_opacityArray->size() - 1);
+      for (size_t index = 0; index < m_opacityArray->size(); ++index)
+      {
+        float opacity = *m_opacityArray->valueAt<float>(index);
+        this->m_colorTable.AddPointAlpha(index * scale, opacity);
+      }
+    }
+    else
+    {
+      float opacity = *m_opacityArray->valueAt<float>(0);
+      this->m_colorTable.AddPointAlpha(0, opacity);
+      this->m_colorTable.AddPointAlpha(1, opacity);
+    }
+  }
+  else if (!colorsHaveAlpha)
+  {
+    this->m_colorTable.AddPointAlpha(0, this->m_alpha);
+    this->m_colorTable.AddPointAlpha(1, this->m_alpha);
+  }
+
+  // The alpha channel provided by ANARI is actually meant to be interpreted as
+  // a transparency coefficient whereas the Viskores volume mapper uses the
+  // alpha channel as the opacity between two samples. The relationship between
+  // the two is:
+  //
+  // opacity = 1 - exp(-transparency * distance)
+  //
+  // Generally, the distance here will be the uniform sample distance used in
+  // the ray stepper. However, the units of the color distance might not be the
+  // same as the spatial units. This is given by ANARI's unit distance
+  // parameter, which can be used to convert the spatial units.
+  viskores::Float32 alphaSampleDistance = sampleDistance / this->m_unitDistance;
+  for (viskores::IdComponent pointId = 0; pointId < this->m_colorTable.GetNumberOfPointsAlpha();
+       ++pointId)
+  {
+    viskores::Vec4f_64 alphaPoint;
+    this->m_colorTable.GetPointAlpha(pointId, alphaPoint);
+    alphaPoint[1] = 1.0f - viskores::Exp(-alphaSampleDistance * alphaPoint[1]);
+    this->m_colorTable.UpdatePointAlpha(pointId, alphaPoint);
+  }
+
+  this->m_colorTable.RescaleToRange(this->m_valueRange);
+
+  this->m_actor = std::make_shared<viskores::rendering::Actor>(dataSet.GetCellSet(),
+                                                               dataSet.GetCoordinateSystem(),
+                                                               dataSet.GetField("data"),
+                                                               this->m_colorTable);
+  this->m_actor->SetScalarRange(this->m_colorTable.GetRange());
+  this->m_mapper = std::make_shared<viskores::rendering::MapperVolume>();
+  this->m_mapper->SetSampleDistance(sampleDistance);
+}
+
+const SpatialField* TransferFunction1D::spatialField() const
+{
+  return this->m_spatialField.get();
+}
+
+viskores::Bounds TransferFunction1D::bounds() const
+{
+  return isValid() ? this->m_spatialField->getDataSet().GetCoordinateSystem().GetBounds()
+                   : viskores::Bounds();
+}
+
+viskores::rendering::Actor* TransferFunction1D::actor() const
+{
+  return this->m_actor.get();
+}
+
+viskores::rendering::MapperVolume* TransferFunction1D::mapper() const
+{
+  return this->m_mapper.get();
+}
+
+bool TransferFunction1D::isValid() const
+{
+  return this->m_spatialField;
+}
+
+} // namespace viskores_device

--- a/viskores/rendering/anari-device/scene/volume/TransferFunction1D.h
+++ b/viskores/rendering/anari-device/scene/volume/TransferFunction1D.h
@@ -1,0 +1,54 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#pragma once
+
+#include "Volume.h"
+#include "array/Array1D.h"
+#include "spatial_field/SpatialField.h"
+// helium
+#include <helium/utility/ChangeObserverPtr.h>
+// Viskores
+#include <viskores/Range.h>
+#include <viskores/cont/ColorTable.h>
+#include <viskores/rendering/MapperVolume.h>
+
+namespace viskores_device
+{
+
+struct TransferFunction1D : public Volume
+{
+  TransferFunction1D(ViskoresDeviceGlobalState* d);
+
+  void commitParameters() override;
+  void finalize() override;
+
+  const SpatialField* spatialField() const;
+  viskores::Bounds bounds() const override;
+  viskores::rendering::Actor* actor() const override;
+  viskores::rendering::MapperVolume* mapper() const override;
+
+  bool isValid() const override;
+
+private:
+  helium::ChangeObserverPtr<SpatialField> m_spatialField;
+  viskores::Range m_valueRange;
+  helium::ChangeObserverPtr<Array1D> m_colorArray;
+  helium::ChangeObserverPtr<Array1D> m_opacityArray;
+  float4 m_color;
+  viskores::Float32 m_alpha;
+  viskores::Float32 m_unitDistance;
+  viskores::cont::ColorTable m_colorTable;
+
+  std::shared_ptr<viskores::rendering::Actor> m_actor;
+  std::shared_ptr<viskores::rendering::MapperVolume> m_mapper;
+};
+
+} // namespace viskores_device

--- a/viskores/rendering/anari-device/scene/volume/Volume.cpp
+++ b/viskores/rendering/anari-device/scene/volume/Volume.cpp
@@ -1,0 +1,69 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#include "Volume.h"
+#include "TransferFunction1D.h"
+
+namespace viskores_device
+{
+
+Volume::Volume(ViskoresDeviceGlobalState* s)
+  : Object(ANARI_VOLUME, s)
+{
+}
+
+Volume::~Volume() = default;
+
+Volume* Volume::createInstance(std::string_view subtype, ViskoresDeviceGlobalState* s)
+{
+  if (subtype == "transferFunction1D")
+    return new TransferFunction1D(s);
+  else
+    return new UnknownVolume(s);
+}
+
+void Volume::commitParameters()
+{
+  m_id = getParam<uint32_t>("id", ~0u);
+}
+
+void Volume::finalize()
+{
+  // no-op
+}
+
+UnknownVolume::UnknownVolume(ViskoresDeviceGlobalState* d)
+  : Volume(d)
+{
+}
+
+viskores::Bounds UnknownVolume::bounds() const
+{
+  return viskores::Bounds{};
+}
+
+viskores::rendering::Actor* UnknownVolume::actor() const
+{
+  return nullptr;
+}
+
+viskores::rendering::Mapper* UnknownVolume::mapper() const
+{
+  return nullptr;
+}
+
+bool UnknownVolume::isValid() const
+{
+  return false;
+}
+
+} // namespace viskores_device
+
+VISKORES_ANARI_TYPEFOR_DEFINITION(viskores_device::Volume*);

--- a/viskores/rendering/anari-device/scene/volume/Volume.h
+++ b/viskores/rendering/anari-device/scene/volume/Volume.h
@@ -1,0 +1,62 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#pragma once
+
+#include "Object.h"
+#include "ViskoresTypes.h"
+// Viskores
+#include <viskores/Bounds.h>
+#include <viskores/cont/DataSet.h>
+#include <viskores/rendering/Actor.h>
+#include <viskores/rendering/Mapper.h>
+
+namespace viskores_device
+{
+
+struct Volume : public Object
+{
+  Volume(ViskoresDeviceGlobalState* d);
+  virtual ~Volume();
+  static Volume* createInstance(std::string_view subtype, ViskoresDeviceGlobalState* d);
+
+  void commitParameters() override;
+  void finalize() override;
+
+  uint32_t id() const;
+
+  virtual viskores::Bounds bounds() const = 0;
+  virtual viskores::rendering::Actor* actor() const = 0;
+  virtual viskores::rendering::Mapper* mapper() const = 0;
+
+private:
+  uint32_t m_id{ ~0u };
+};
+
+struct UnknownVolume : public Volume
+{
+  UnknownVolume(ViskoresDeviceGlobalState* d);
+
+  viskores::Bounds bounds() const override;
+  viskores::rendering::Actor* actor() const override;
+  viskores::rendering::Mapper* mapper() const override;
+  bool isValid() const override;
+};
+
+// Inlined definitions ////////////////////////////////////////////////////////
+
+inline uint32_t Volume::id() const
+{
+  return m_id;
+}
+
+} // namespace viskores_device
+
+VISKORES_ANARI_TYPEFOR_SPECIALIZATION(viskores_device::Volume*, ANARI_VOLUME);

--- a/viskores/rendering/anari-device/scene/volume/spatial_field/SpatialField.cpp
+++ b/viskores/rendering/anari-device/scene/volume/spatial_field/SpatialField.cpp
@@ -1,0 +1,58 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#include "SpatialField.h"
+// Subtypes
+#include "StructuredRegularField.h"
+
+namespace viskores_device
+{
+
+SpatialField::SpatialField(ViskoresDeviceGlobalState* s)
+  : Object(ANARI_SPATIAL_FIELD, s)
+{
+}
+
+SpatialField::~SpatialField() = default;
+
+SpatialField* SpatialField::createInstance(std::string_view subtype, ViskoresDeviceGlobalState* s)
+{
+  if (subtype == "structuredRegular")
+  {
+    return new StructuredRegularField(s);
+  }
+  else
+  {
+    return new UnknownSpatialField(s);
+  }
+}
+
+UnknownSpatialField::UnknownSpatialField(ViskoresDeviceGlobalState* d)
+  : SpatialField(d)
+{
+}
+
+void UnknownSpatialField::commitParameters()
+{
+  // invalid
+}
+void UnknownSpatialField::finalize()
+{
+  // invalid
+}
+
+bool UnknownSpatialField::isValid() const
+{
+  return false;
+}
+
+} // namespace viskores_device
+
+VISKORES_ANARI_TYPEFOR_DEFINITION(viskores_device::SpatialField*);

--- a/viskores/rendering/anari-device/scene/volume/spatial_field/SpatialField.h
+++ b/viskores/rendering/anari-device/scene/volume/spatial_field/SpatialField.h
@@ -1,0 +1,44 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#pragma once
+
+#include "Object.h"
+// Viskores
+#include <viskores/cont/DataSet.h>
+
+namespace viskores_device
+{
+
+struct SpatialField : public Object
+{
+  SpatialField(ViskoresDeviceGlobalState* d);
+  virtual ~SpatialField();
+  static SpatialField* createInstance(std::string_view subtype, ViskoresDeviceGlobalState* d);
+
+  viskores::cont::DataSet getDataSet() const { return this->m_dataSet; }
+
+protected:
+  viskores::cont::DataSet m_dataSet;
+};
+
+struct UnknownSpatialField : public SpatialField
+{
+  UnknownSpatialField(ViskoresDeviceGlobalState* d);
+
+  void commitParameters() override;
+  void finalize() override;
+
+  bool isValid() const override;
+};
+
+} // namespace viskores_device
+
+VISKORES_ANARI_TYPEFOR_SPECIALIZATION(viskores_device::SpatialField*, ANARI_SPATIAL_FIELD);

--- a/viskores/rendering/anari-device/scene/volume/spatial_field/StructuredRegularField.cpp
+++ b/viskores/rendering/anari-device/scene/volume/spatial_field/StructuredRegularField.cpp
@@ -1,0 +1,60 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#include "StructuredRegularField.h"
+// Viskores
+#include <viskores/cont/ArrayCopy.h>
+#include <viskores/cont/DataSetBuilderUniform.h>
+
+namespace viskores_device
+{
+
+StructuredRegularField::StructuredRegularField(ViskoresDeviceGlobalState* d)
+  : SpatialField(d)
+  , m_dataArray(this)
+{
+}
+
+void StructuredRegularField::commitParameters()
+{
+  // Stashing these in a ChangeObserverPtr means that commit will be
+  // called again if the array contents change.
+  this->m_dataArray = getParamObject<Array3D>("data");
+
+  float3 origin = getParam("origin", float3{ 0, 0, 0 });
+  float3 spacing = getParam("spacing", float3{ 1, 1, 1 });
+  uint3 dimensions = this->m_dataArray->size();
+
+  this->m_dataSet = viskores::cont::DataSetBuilderUniform::Create(
+    viskores::Id3{ static_cast<viskores::Id>(dimensions[0]),
+                   static_cast<viskores::Id>(dimensions[1]),
+                   static_cast<viskores::Id>(dimensions[2]) },
+    viskores::Vec3f{ origin[0], origin[1], origin[2] },
+    viskores::Vec3f{ spacing[0], spacing[1], spacing[2] });
+}
+
+void StructuredRegularField::finalize()
+{
+  // Viskores volume render only supports float fields in volume rendering. Convert
+  // if necessary.
+  viskores::cont::UnknownArrayHandle viskoresArray = this->m_dataArray->dataAsViskoresArray();
+  if (!viskoresArray.IsValueType<viskores::Float32>() &&
+      !viskoresArray.IsValueType<viskores::Float64>())
+  {
+    viskores::cont::ArrayHandle<viskores::FloatDefault> castArray;
+    viskores::cont::ArrayCopy(viskoresArray, castArray);
+    viskoresArray = castArray;
+  }
+  this->m_dataSet.AddPointField("data", viskoresArray);
+
+  // this->m_dataSet.PrintSummary(std::cout);
+}
+
+} // namespace viskores_device

--- a/viskores/rendering/anari-device/scene/volume/spatial_field/StructuredRegularField.h
+++ b/viskores/rendering/anari-device/scene/volume/spatial_field/StructuredRegularField.h
@@ -1,0 +1,32 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#pragma once
+
+#include "SpatialField.h"
+#include "array/Array3D.h"
+// helium
+#include <helium/utility/ChangeObserverPtr.h>
+
+namespace viskores_device
+{
+
+struct StructuredRegularField : public SpatialField
+{
+  StructuredRegularField(ViskoresDeviceGlobalState* d);
+
+  void commitParameters() override;
+  void finalize() override;
+
+private:
+  helium::ChangeObserverPtr<Array3D> m_dataArray;
+};
+
+} // namespace viskores_device

--- a/viskores/rendering/anari-device/viskores.module
+++ b/viskores/rendering/anari-device/viskores.module
@@ -1,0 +1,10 @@
+NAME
+  anari_library_viskores
+GROUPS
+  ANARI
+DEPENDS
+  viskores_cont
+  viskores_worklet
+  viskores_source
+  viskores_rendering
+NO_TESTING

--- a/viskores/rendering/anari-device/viskores_device.json
+++ b/viskores/rendering/anari-device/viskores_device.json
@@ -1,0 +1,75 @@
+{
+  "info": {
+    "name": "VISKORES_DEVICE",
+    "type": "device",
+    "dependencies": [
+      "anari_core_1_0",
+      "anari_core_objects_base_1_0",
+      "khr_camera_orthographic",
+      "khr_camera_perspective",
+      "khr_geometry_triangle",
+      "khr_material_matte",
+      "khr_sampler_image1d",
+      "khr_volume_transfer_function1d"
+    ]
+  },
+  "objects": [
+    {
+      "type": "ANARI_DEVICE",
+      "parameters": [
+        {
+          "name": "allowInvalidMaterials",
+          "types": [
+            "ANARI_BOOL"
+          ],
+          "tags": [],
+          "default": true,
+          "description": "show surfaces with invalid materials"
+        },
+        {
+          "name": "invalidMaterialColor",
+          "types": [
+            "ANARI_FLOAT32_VEC4"
+          ],
+          "tags": [],
+          "default": [
+            1.0,
+            0.0,
+            1.0,
+            1.0
+          ],
+          "description": "color to identify surfaces with invalid materials"
+        }
+      ]
+    },
+    {
+      "type": "ANARI_RENDERER",
+      "name": "default",
+      "parameters": [
+        {
+          "name": "background",
+          "types": [
+            "ANARI_FLOAT32_VEC4"
+          ],
+          "tags": [],
+          "default": [
+            0.0,
+            0.0,
+            0.0,
+            1.0
+          ],
+          "description": "background color and alpha (RGBA)"
+        },
+        {
+          "name": "ambientRadiance",
+          "types": [
+            "ANARI_FLOAT32"
+          ],
+          "tags": [],
+          "default": 1.0,
+          "description": "ambient light intensity"
+        }
+      ]
+    }
+  ]
+}

--- a/viskores/rendering/anari-device/viskores_device_math.h
+++ b/viskores/rendering/anari-device/viskores_device_math.h
@@ -1,0 +1,43 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#pragma once
+
+// helium
+#include "helium/helium_math.h"
+// viskores
+#include <viskores/Matrix.h>
+#include <viskores/VectorAnalysis.h>
+#include <viskores/interop/anari/ViskoresANARITypes.h>
+
+namespace viskores_device
+{
+
+using namespace anari::math;
+using namespace helium::math;
+
+using Mat3f_32 = viskores::Matrix<viskores::Float32, 3, 3>;
+using Mat4f_32 = viskores::Matrix<viskores::Float32, 4, 4>;
+
+template <typename T, viskores::IdComponent NumRow, viskores::IdComponent NumCol>
+inline viskores::Matrix<T, NumRow, NumCol> toViskoresMatrix(mat<T, NumRow, NumCol>& anarimat)
+{
+  viskores::Matrix<T, NumRow, NumCol> viskoresmat;
+  for (viskores::IdComponent row = 0; row < NumRow; ++row)
+  {
+    for (viskores::IdComponent col = 0; col < NumCol; ++col)
+    {
+      viskoresmat[row][col] = anarimat[col][row];
+    }
+  }
+  return viskoresmat;
+}
+
+} // namespace viskores_device


### PR DESCRIPTION
Viskores now provides an ANARI device that can be used by applications that use
ANARI for rendering. The intention of this device is to provide a simple,
portable, accelerated ANARI device that will be available in HPC systems
regardless of vendor support. We hope this will help jumpstart the support of
ANARI for scientific visualization applications at HPC centers.

This device is still in its experimental phase. Although functional, it is
missing many features that applications will expect to be supported. The
inclusion of the device into Viskores in this early phase should help promote
development and simplify the integration of any changes necessary in the
rendering library.