### PR TITLE
Fix CMake for Kokkos-thrust (Backport #209 to Release 1.1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -275,7 +275,7 @@ cmake_dependent_option(
   Viskores_ENABLE_KOKKOS_THRUST
   "Enable Kokkos thrust support (only valid with CUDA and HIP)"
   ON
-  "Viskores_ENABLE_KOKKOS;Kokkos_ENABLE_CUDA OR Kokkos_ENABLE_HIP; NOT Kokkos_ENABLE_HIP AND CMAKE_VERSION VERSION_LESS 3.24"
+  "Viskores_ENABLE_KOKKOS;Kokkos_ENABLE_CUDA OR Kokkos_ENABLE_HIP; NOT Kokkos_ENABLE_HIP OR CMAKE_VERSION VERSION_GREATER_EQUAL 3.24"
   OFF
 )
 

--- a/viskores/cont/kokkos/internal/CMakeLists.txt
+++ b/viskores/cont/kokkos/internal/CMakeLists.txt
@@ -43,12 +43,9 @@ if (TARGET viskores_kokkos)
     set_source_files_properties(${sources} TARGET_DIRECTORY viskores_cont PROPERTIES LANGUAGE HIP)
     kokkos_compilation(SOURCE ${sources})
     if (Viskores_ENABLE_KOKKOS_THRUST)
-      # rocthrust does not wrap its compile defs/ops/dirs with $<$<COMPILE_LANGUAGE:HIP>.
-      # We need this workaround since we mix CXX and HIP source files in viskores_cont.
       target_link_libraries(viskores_cont
         PRIVATE
-          $<$<COMPILE_LANGUAGE:HIP>:roc::rocthrust>
-          $<LINK_ONLY:roc::rocthrust>
+          $<$<LINK_LANGUAGE:HIP>:roc::rocthrust>
       )
     endif()
   endif()


### PR DESCRIPTION
There was a mistake in an expression that caused hip support in thrust to never be selected. This has a high performance consequence.

There was also an error in how the rocthust library was linked. It was using an invalid generate expression when linking libraries.

Backport of #209