### PR TITLE
Add configuration option for unified memory

### DIFF
--- a/docs/changelog/unified-memory-option.md
+++ b/docs/changelog/unified-memory-option.md
@@ -1,0 +1,10 @@
+## Add configuration option for unified memory
+
+A command line option for `--viskores-use-unified-memory` has been added. This
+command line option allows you to more easily select whether a device attempts
+to use unified memory or not (assuming that it supports that). The option can
+likewise be set with the `VISKORES_USE_UNIFIED_MEMORY` environment variable.
+
+Unified memory has also been turned off by default. This is because under at
+least some circumstances unified memory causes a performance degredation over
+explicit memory management.

--- a/docs/users-guide/initialization.rst
+++ b/docs/users-guide/initialization.rst
@@ -56,6 +56,11 @@ The following table lists the currently supported options.
      -
      - Selects the device to use when more than one device device of a given type is available.
        The device is specified with a numbered index.
+   * - ``--viskores-use-unified-memory``
+     - ``VISKORES_USE_UNIFIED_MEMORY``
+     - 0
+     - If set to 1, prefer using unified memory to transfer data between host and device.
+       When set to 0, prefer explicit host/device memory management.
 
 :func:`viskores::cont::Initialize` returns a :struct:`viskores::cont::InitializeResult` structure.
 This structure contains information about the supported arguments and options selected during initialization.

--- a/viskores/cont/RuntimeDeviceInformation.cxx
+++ b/viskores/cont/RuntimeDeviceInformation.cxx
@@ -120,6 +120,12 @@ public:
     throw viskores::cont::ErrorBadDevice("Tried to set the device instance on an invalid device");
   }
 
+  VISKORES_CONT virtual viskores::cont::internal::RuntimeDeviceConfigReturnCode SetUseUnifiedMemory(
+    const viskores::Id&) override final
+  {
+    throw viskores::cont::ErrorBadDevice("Tried to set use unified memory on an invalid device");
+  }
+
   VISKORES_CONT virtual viskores::cont::internal::RuntimeDeviceConfigReturnCode GetThreads(
     viskores::Id&) const override final
   {
@@ -130,6 +136,12 @@ public:
     viskores::Id&) const override final
   {
     throw viskores::cont::ErrorBadDevice("Tried to get the device instance on an invalid device");
+  }
+
+  VISKORES_CONT virtual viskores::cont::internal::RuntimeDeviceConfigReturnCode GetUseUnifiedMemory(
+    viskores::Id&) const override final
+  {
+    throw viskores::cont::ErrorBadDevice("Tried to get use unified memory on an invalid device");
   }
 
   VISKORES_CONT virtual viskores::cont::internal::RuntimeDeviceConfigReturnCode GetMaxThreads(
@@ -521,7 +533,7 @@ RuntimeDeviceInformation::GetRuntimeConfiguration(
   DeviceAdapterId device,
   const viskores::cont::internal::RuntimeDeviceConfigurationOptions& configOptions) const
 {
-  int placeholder;
+  int placeholder = 0;
   return this->GetRuntimeConfiguration(device, configOptions, placeholder, nullptr);
 }
 

--- a/viskores/cont/cuda/internal/RuntimeDeviceConfigurationCuda.h
+++ b/viskores/cont/cuda/internal/RuntimeDeviceConfigurationCuda.h
@@ -18,6 +18,7 @@
 #ifndef viskores_cont_cuda_internal_RuntimeDeviceConfigurationCuda_h
 #define viskores_cont_cuda_internal_RuntimeDeviceConfigurationCuda_h
 
+#include <viskores/cont/cuda/internal/CudaAllocator.h>
 #include <viskores/cont/cuda/internal/DeviceAdapterRuntimeDetectorCuda.h>
 #include <viskores/cont/cuda/internal/DeviceAdapterTagCuda.h>
 #include <viskores/cont/internal/RuntimeDeviceConfiguration.h>
@@ -75,8 +76,8 @@ public:
     return viskores::cont::DeviceAdapterTagCuda{};
   }
 
-  VISKORES_CONT virtual RuntimeDeviceConfigReturnCode SetDeviceInstance(
-    const viskores::Id& value) override final
+  VISKORES_CONT RuntimeDeviceConfigReturnCode
+  SetDeviceInstance(const viskores::Id& value) override final
   {
     if (value >= this->CudaDeviceCount)
     {
@@ -90,8 +91,8 @@ public:
     return RuntimeDeviceConfigReturnCode::SUCCESS;
   }
 
-  VISKORES_CONT virtual RuntimeDeviceConfigReturnCode GetDeviceInstance(
-    viskores::Id& value) const override final
+  VISKORES_CONT RuntimeDeviceConfigReturnCode
+  GetDeviceInstance(viskores::Id& value) const override final
   {
     int tmp;
     VISKORES_CUDA_CALL(cudaGetDevice(&tmp));
@@ -99,8 +100,28 @@ public:
     return RuntimeDeviceConfigReturnCode::SUCCESS;
   }
 
-  VISKORES_CONT virtual RuntimeDeviceConfigReturnCode GetMaxDevices(
-    viskores::Id& value) const override final
+  VISKORES_CONT RuntimeDeviceConfigReturnCode
+  SetUseUnifiedMemory(const viskores::Id& value) override final
+  {
+    if (value)
+    {
+      viskores::cont::cuda::internal::CudaAllocator::ForceManagedMemoryOn();
+    }
+    else
+    {
+      viskores::cont::cuda::internal::CudaAllocator::ForceManagedMemoryOff();
+    }
+  }
+
+  VISKORES_CONT RuntimeDeviceConfigReturnCode
+  GetUseUnifiedMemory(viskores::Id& value) const override final
+  {
+    value = viskores::cont::cuda::internal::CudaAllocator::UsingManagedMemory();
+    return RuntimeDeviceConfigReturnCode::SUCCESS;
+  }
+
+  VISKORES_CONT RuntimeDeviceConfigReturnCode
+  GetMaxDevices(viskores::Id& value) const override final
   {
     value = this->CudaDeviceCount;
     return RuntimeDeviceConfigReturnCode::SUCCESS;

--- a/viskores/cont/cuda/testing/UnitTestCudaRuntimeDeviceConfiguration.cu
+++ b/viskores/cont/cuda/testing/UnitTestCudaRuntimeDeviceConfiguration.cu
@@ -37,6 +37,7 @@ TestingRuntimeDeviceConfiguration<viskores::cont::DeviceAdapterTagCuda>::TestRun
   VISKORES_CUDA_CALL(cudaGetDeviceCount(&numDevices));
   viskores::Id selectedDevice = numDevices > 0 ? numDevices - 1 : 0;
   deviceOptions.ViskoresDeviceInstance.SetOption(selectedDevice);
+  deviceOptions.ViskoresUseUnifiedMemory.SetOption(1);
   auto& config =
     RuntimeDeviceInformation{}.GetRuntimeConfiguration(DeviceAdapterTagCuda(), deviceOptions);
   viskores::Id setDevice;
@@ -46,6 +47,13 @@ TestingRuntimeDeviceConfiguration<viskores::cont::DeviceAdapterTagCuda>::TestRun
   VISKORES_TEST_ASSERT(setDevice == selectedDevice,
                        "RTC's setDevice != selectedDevice cuda direct! " +
                          std::to_string(setDevice) + " != " + std::to_string(selectedDevice));
+  viskores::Id useUnifiedMemory;
+  VISKORES_TEST_ASSERT(config.GetUseUnifiedMemory(useUnifiedMemory) ==
+                         internal::RuntimeDeviceConfigReturnCode::SUCCESS,
+                       "Failed to get use unified memory");
+  VISKORES_TEST_ASSERT(useUnifiedMemory == 1,
+                       "RTC's useUnifiedMemory != 1 cuda direct! " + std::to_string(setDevice) +
+                         " != " + std::to_string(selectedDevice));
   viskores::Id maxDevices;
   VISKORES_TEST_ASSERT(config.GetMaxDevices(maxDevices) ==
                          internal::RuntimeDeviceConfigReturnCode::SUCCESS,

--- a/viskores/cont/internal/OptionParserArguments.h
+++ b/viskores/cont/internal/OptionParserArguments.h
@@ -44,7 +44,8 @@ enum OptionIndex
   // All RuntimeDeviceConfiguration specific options
   NUM_THREADS,
   NUMA_REGIONS,
-  DEVICE_INSTANCE
+  DEVICE_INSTANCE,
+  USE_UNIFIED_MEMORY
 };
 
 struct ViskoresArg : public option::Arg

--- a/viskores/cont/internal/RuntimeDeviceConfiguration.cxx
+++ b/viskores/cont/internal/RuntimeDeviceConfiguration.cxx
@@ -104,6 +104,11 @@ void RuntimeDeviceConfigurationBase::Initialize(
     [&](const viskores::Id& value) { return this->SetDeviceInstance(value); },
     "SetDeviceInstance",
     this->GetDevice().GetName());
+  InitializeOption(
+    configOptions.ViskoresUseUnifiedMemory,
+    [&](const viskores::Id& value) { return this->SetUseUnifiedMemory(value); },
+    "SetUseUnifiedMemory",
+    this->GetDevice().GetName());
   this->InitializeSubsystem();
 }
 
@@ -126,12 +131,24 @@ RuntimeDeviceConfigReturnCode RuntimeDeviceConfigurationBase::SetDeviceInstance(
   return RuntimeDeviceConfigReturnCode::INVALID_FOR_DEVICE;
 }
 
+RuntimeDeviceConfigReturnCode RuntimeDeviceConfigurationBase::SetUseUnifiedMemory(
+  const viskores::Id&)
+{
+  return RuntimeDeviceConfigReturnCode::INVALID_FOR_DEVICE;
+}
+
 RuntimeDeviceConfigReturnCode RuntimeDeviceConfigurationBase::GetThreads(viskores::Id&) const
 {
   return RuntimeDeviceConfigReturnCode::INVALID_FOR_DEVICE;
 }
 
 RuntimeDeviceConfigReturnCode RuntimeDeviceConfigurationBase::GetDeviceInstance(viskores::Id&) const
+{
+  return RuntimeDeviceConfigReturnCode::INVALID_FOR_DEVICE;
+}
+
+RuntimeDeviceConfigReturnCode RuntimeDeviceConfigurationBase::GetUseUnifiedMemory(
+  viskores::Id&) const
 {
   return RuntimeDeviceConfigReturnCode::INVALID_FOR_DEVICE;
 }

--- a/viskores/cont/internal/RuntimeDeviceConfiguration.h
+++ b/viskores/cont/internal/RuntimeDeviceConfiguration.h
@@ -63,11 +63,15 @@ public:
   /// support the particular set method.
   VISKORES_CONT virtual RuntimeDeviceConfigReturnCode SetThreads(const viskores::Id& value);
   VISKORES_CONT virtual RuntimeDeviceConfigReturnCode SetDeviceInstance(const viskores::Id& value);
+  VISKORES_CONT virtual RuntimeDeviceConfigReturnCode SetUseUnifiedMemory(
+    const viskores::Id& value);
 
   /// The following public methods are overriden in each individual device and store the
   /// values that were set via the above Set* methods for the given device.
   VISKORES_CONT virtual RuntimeDeviceConfigReturnCode GetThreads(viskores::Id& value) const;
   VISKORES_CONT virtual RuntimeDeviceConfigReturnCode GetDeviceInstance(viskores::Id& value) const;
+  VISKORES_CONT virtual RuntimeDeviceConfigReturnCode GetUseUnifiedMemory(
+    viskores::Id& value) const;
 
   /// The following public methods should be overriden as needed for each individual device
   /// as they describe various device parameters.

--- a/viskores/cont/internal/RuntimeDeviceConfigurationOptions.cxx
+++ b/viskores/cont/internal/RuntimeDeviceConfigurationOptions.cxx
@@ -54,6 +54,15 @@ void AppendOptionDescriptors(std::vector<option::Descriptor>& usage,
       option::ViskoresArg::Required,
       "  --viskores-device-instance <dev> \tSets the device instance to use when using "
       "kokkos/cuda" });
+  usage.push_back(
+    { useOptionIndex ? static_cast<uint32_t>(option::OptionIndex::USE_UNIFIED_MEMORY) : 3,
+      0,
+      "",
+      "viskores-use-unified-memory",
+      option::ViskoresArg::Required,
+      "  --viskores-use-unified-memory <flag> \tIf set to 1, prefer using unified memory to "
+      "transfer between host and device. When set to 0, prefer explicit host/device memory "
+      "management." });
 }
 } // anonymous namespace
 
@@ -62,6 +71,8 @@ RuntimeDeviceConfigurationOptions::RuntimeDeviceConfigurationOptions(const bool&
                        "VISKORES_NUM_THREADS")
   , ViskoresDeviceInstance(useOptionIndex ? option::OptionIndex::DEVICE_INSTANCE : 2,
                            "VISKORES_DEVICE_INSTANCE")
+  , ViskoresUseUnifiedMemory(useOptionIndex ? option::OptionIndex::USE_UNIFIED_MEMORY : 3,
+                             "VISKORES_USE_UNIFIED_MEMORY")
   , Initialized(false)
 {
 }
@@ -110,6 +121,7 @@ void RuntimeDeviceConfigurationOptions::Initialize(const option::Option* options
 {
   this->ViskoresNumThreads.Initialize(options);
   this->ViskoresDeviceInstance.Initialize(options);
+  this->ViskoresUseUnifiedMemory.Initialize(options);
   this->Initialized = true;
 }
 

--- a/viskores/cont/internal/RuntimeDeviceConfigurationOptions.h
+++ b/viskores/cont/internal/RuntimeDeviceConfigurationOptions.h
@@ -57,6 +57,7 @@ public:
 
   RuntimeDeviceOption ViskoresNumThreads;
   RuntimeDeviceOption ViskoresDeviceInstance;
+  RuntimeDeviceOption ViskoresUseUnifiedMemory;
 
 protected:
   /// Sets the option indices and environment varaible names for the viskores supported options.

--- a/viskores/cont/testing/TestingRuntimeDeviceConfiguration.h
+++ b/viskores/cont/testing/TestingRuntimeDeviceConfiguration.h
@@ -44,6 +44,7 @@ struct TestingRuntimeDeviceConfiguration
     internal::RuntimeDeviceConfigurationOptions runtimeDeviceOptions{};
     runtimeDeviceOptions.ViskoresNumThreads.SetOption(8);
     runtimeDeviceOptions.ViskoresDeviceInstance.SetOption(2);
+    runtimeDeviceOptions.ViskoresUseUnifiedMemory.SetOption(1);
     runtimeDeviceOptions.Initialize(nullptr);
     VISKORES_TEST_ASSERT(runtimeDeviceOptions.IsInitialized(),
                          "Failed to default initialize runtime config options.");

--- a/viskores/cont/testing/UnitTestRuntimeConfigurationOptions.cxx
+++ b/viskores/cont/testing/UnitTestRuntimeConfigurationOptions.cxx
@@ -201,6 +201,8 @@ void TestConfigOptionValues(const internal::RuntimeDeviceConfigurationOptions& c
   VISKORES_TEST_ASSERT(configOptions.ViskoresNumThreads.IsSet(), "num threads should be set");
   VISKORES_TEST_ASSERT(configOptions.ViskoresDeviceInstance.IsSet(),
                        "device instance should be set");
+  VISKORES_TEST_ASSERT(configOptions.ViskoresUseUnifiedMemory.IsSet(),
+                       "unified memory flag not set");
 
   VISKORES_TEST_ASSERT(configOptions.ViskoresNumThreads.GetValue() == 100,
                        "num threads should == 100");
@@ -224,8 +226,14 @@ void TestRuntimeDeviceConfigurationOptions()
 
     int argc;
     char** argv;
-    viskores::cont::testing::Testing::MakeArgs(
-      argc, argv, "--viskores-num-threads", "100", "--viskores-device-instance", "1");
+    viskores::cont::testing::Testing::MakeArgs(argc,
+                                               argv,
+                                               "--viskores-num-threads",
+                                               "100",
+                                               "--viskores-device-instance",
+                                               "1",
+                                               "--viskores-use-unified-memory",
+                                               "1");
     auto options = GetOptions(argc, argv, usage);
 
     VISKORES_TEST_ASSERT(!configOptions.IsInitialized(),
@@ -237,8 +245,14 @@ void TestRuntimeDeviceConfigurationOptions()
   {
     int argc;
     char** argv;
-    viskores::cont::testing::Testing::MakeArgs(
-      argc, argv, "--viskores-num-threads", "100", "--viskores-device-instance", "1");
+    viskores::cont::testing::Testing::MakeArgs(argc,
+                                               argv,
+                                               "--viskores-num-threads",
+                                               "100",
+                                               "--viskores-device-instance",
+                                               "1",
+                                               "--viskores-use-unified-memory",
+                                               "1");
     internal::RuntimeDeviceConfigurationOptions configOptions(argc, argv);
     TestConfigOptionValues(configOptions);
   }


### PR DESCRIPTION
A command line option for `--viskores-use-unified-memory` has been added. This command line option allows you to more easily select whether a device attempts to use unified memory or not (assuming that it supports that). The option can likewise be set with the `VISKORES_USE_UNIFIED_MEMORY` environment variable.

Unified memory has also been turned off by default. This is because under at least some circumstances unified memory causes a performance degredation over explicit memory management.