### PR TITLE
Removed check of ascent default types

### DIFF
--- a/viskores/cont/CMakeLists.txt
+++ b/viskores/cont/CMakeLists.txt
@@ -250,11 +250,6 @@ viskores_option(Viskores_USE_DEFAULT_TYPES_FOR_ASCENT
   )
 if (Viskores_USE_DEFAULT_TYPES_FOR_ASCENT)
   set(Viskores_DEFAULT_TYPES_HEADER "internal/DefaultTypesAscent.h.in")
-  if (Viskores_USE_64BIT_IDS)
-    message(SEND_ERROR
-      "When Viskores_USE_DEFAULT_TYPES_FOR_ASCENT is ON, Viskores_USE_64BIT_IDS must be set to OFF"
-      )
-  endif()
   if (NOT Viskores_USE_DOUBLE_PRECISION)
     message(SEND_ERROR
       "When Viskores_USE_DEFAULT_TYPES_FOR_ASCENT is ON, Viskores_USE_DOUBLE_PRECISION must be set to ON"


### PR DESCRIPTION
I don't think this check is needed anymore.

I have a large dataset that required 64BIT_IDS. I disabled the check, enabled Viskores_USE_64BIT_IDS and Viskores_USE_DEFAULT_TYPES_FOR_ASCENT, and was able to compile Viskores/Ascent and visualize the data successfully. Before setting Viskores_USE_64BIT_IDS to ON, the IDs would overflow, but with it enabled everything works correctly.