### PR TITLE
Fix the SetupForDevelopment.sh script

### DIFF
--- a/Utilities/SetupForDevelopment.sh
+++ b/Utilities/SetupForDevelopment.sh
@@ -15,6 +15,7 @@ git config rebase.stat true
 git config branch.main.rebase true
 
 # General aliases that could be global
-git config alias.pullall '!bash -c "git pull && git submodule update --init"' &&
+git config alias.pullall '!bash -c "git pull && git submodule update --init --recursive"' &&
 git config alias.prepush 'log --graph --stat origin/main..' &&
 git config alias.pull-main 'fetch origin main:main' &&
+true

--- a/docs/changelog/fix-setupfordevelopment-script.md
+++ b/docs/changelog/fix-setupfordevelopment-script.md
@@ -1,0 +1,16 @@
+## Fixed the SetupForDevelopment.sh script
+
+The [CONTRIBUTING.md] document instructs developers to run the
+`Utilities/SetupForDevelopment.sh` script. However, when you ran this script,
+you got an error:
+
+```bash
+$ ./Utilities/SetupForDevelopment.sh
+Setting up useful Git aliases...
+./Utilities/SetupForDevelopment.sh: line 22: syntax error: unexpected end of file
+```
+
+This error has been fixed, and the `SetupForDevelopment.sh` script now correctly
+sets up git aliases.
+
+[CONTRIBUTING.md]: https://github.com/Viskores/viskores/blob/main/CONTRIBUTING.md#setup


### PR DESCRIPTION
The CONTRIBUTING.md document instructs developers to run the `Utilities/SetupForDevelopment.sh` script. However, when you ran this script, you got an error:

```bash
$ ./Utilities/SetupForDevelopment.sh
Setting up useful Git aliases...
./Utilities/SetupForDevelopment.sh: line 22: syntax error: unexpected end of file
```

This error has been fixed, and the `SetupForDevelopment.sh` script now correctly sets up git aliases.

Also added the `--recursive` argument to the submodule update part of the pullall alias. This does not currently do anything as no submodule has submodules of its own. However, adding this argument does not hurt and it might be needed in the future if a submodule is eventually added with submodules of its own. Thus, to prevent developers having to update their setup, just add the argument for now.