### PR TITLE
Fix compiler error with ambiguous type uint2

### DIFF
--- a/viskores/rendering/anari-device/frame/Frame.cpp
+++ b/viskores/rendering/anari-device/frame/Frame.cpp
@@ -157,7 +157,8 @@ void Frame::commitParameters()
   m_objIdType = getParam<anari::DataType>("channel.objectId", ANARI_UNKNOWN);
   m_instIdType = getParam<anari::DataType>("channel.instanceId", ANARI_UNKNOWN);
 
-  m_frameData.size = getParam<uint2>("size", uint2(10));
+  m_frameData.size =
+    getParam<std::array<unsigned int, 2>>("size", std::array<unsigned int, 2>{ 10, 10 });
 }
 
 void Frame::finalize()

--- a/viskores/rendering/anari-device/frame/Frame.h
+++ b/viskores/rendering/anari-device/frame/Frame.h
@@ -17,6 +17,7 @@
 #include "helium/BaseFrame.h"
 // std
 #include "../ViskoresTypes.h"
+#include <array>
 #include <future>
 #include <vector>
 
@@ -68,7 +69,7 @@ private:
   struct FrameData
   {
     int frameID{ 0 };
-    uint2 size;
+    std::array<unsigned int, 2> size;
   } m_frameData;
 
   anari::DataType m_colorType{ ANARI_UNKNOWN };


### PR DESCRIPTION
Replaces the custom uint2 type with std::array<unsigned int, 2> for the frame size parameter in FrameData and related code. This fixes a build error when building the ANARI device along with CUDA support.