### PR TITLE
Restrict workflow permissions to minimum required

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ on:
       - 'release**'
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -14,6 +14,9 @@ on:
       - 'release**'
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: doxygen-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -11,7 +11,9 @@ on:
   push:
   pull_request_target:
 
-permissions: write-all
+permissions:
+  contents: read
+  statuses: write
 
 jobs:
   generate_statuses:


### PR DESCRIPTION
Limiting the scope of the GITHUB_TOKEN via the [permissions](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions) attribute is best practice to prevent a leaked GITHUB_TOKEN from allowing repository write access.