### PR TITLE
add security policy file

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,28 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 1.x     | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+The Viskores team and community take security bugs in Viskores seriously.
+We appreciate your efforts to responsibly disclose your findings, and will make
+every effort to acknowledge your contributions.
+
+To report a security issue, please use the GitHub Security Advisory
+["Report a Vulnerability"](https://github.com/Viskores/viskores/security/advisories/new) tab.
+
+The Viskores team will send a response indicating the next steps in handling
+your report. After the initial reply to your report, the security team will
+keep you informed of the progress towards a fix and full announcement, and may
+ask for additional information or guidance.
+
+## Response Timeline
+
+You should receive an acknowledgement of your report within 6 business days.
+If the team requires more information, they will reach out through the advisory
+comments. The team aims to provide regular updates on the progress towards a fix
+and will notify you when the issue has been resolved.


### PR DESCRIPTION
fixes #247 

This PR add a Security policy file inspired by the one existing in the ADIOS2 project. This security policy filly complies with the OSSF best practices.