### PR TITLE
Improve the documentation of `ArrayHandleCounting`

### DIFF
--- a/docs/users-guide/fancy-array-handles.rst
+++ b/docs/users-guide/fancy-array-handles.rst
@@ -131,10 +131,11 @@ A :func:`viskores::cont::make_ArrayHandleIndex` convenience function is also ava
 The :class:`viskores::cont::ArrayHandleCounting` class provides a more general form of counting.
 :class:`viskores::cont::ArrayHandleCounting` is a templated class with a single template argument that is the type of value for each element in the array.
 The constructor for :class:`viskores::cont::ArrayHandleCounting` takes three arguments: the start value (used at index 0), the step from one value to the next, and the length of the array.
-The following example is a simple demonstration of the counting array handle.
 
 .. doxygenclass:: viskores::cont::ArrayHandleCounting
    :members:
+
+The following example is a simple demonstration of the counting array handle.
 
 .. load-example:: ArrayHandleCountingBasic
    :file: GuideExampleArrayHandleCounting.cxx

--- a/viskores/cont/ArrayHandleCounting.h
+++ b/viskores/cont/ArrayHandleCounting.h
@@ -133,9 +133,10 @@ struct Storage<
 
 } // namespace internal
 
-/// ArrayHandleCounting is a specialization of ArrayHandle. By default it
-/// contains a increment value, that is increment for each step between zero
-/// and the passed in length
+/// ArrayHandleCounting is a specialization of ArrayHandle. It is defined
+/// by a start, a step, and the length of the array. The value in the first
+/// index is the start value, and each subsequent value is incremented by
+/// the step.
 template <typename CountingValueType>
 class ArrayHandleCounting
   : public viskores::cont::ArrayHandle<CountingValueType, viskores::cont::StorageTagCounting>
@@ -146,6 +147,11 @@ public:
     (ArrayHandleCounting<CountingValueType>),
     (viskores::cont::ArrayHandle<CountingValueType, StorageTagCounting>));
 
+  /// Construct an `ArrayHandleCounting` with the provided `start`, `step`, and `length`.
+  ///
+  /// @param start The value of the first entry of the array (index 0).
+  /// @param step The amount each subsequent entry is incremented.
+  /// @param length The overall length of the array.
   VISKORES_CONT
   ArrayHandleCounting(CountingValueType start, CountingValueType step, viskores::Id length)
     : Superclass(internal::PortalToArrayHandleImplicitBuffers(


### PR DESCRIPTION
The modified doxygen comments are pulled into the user's guide to make the array's use more clear.