### PR TITLE
Fix array access for rectilinear splines

### DIFF
--- a/docs/changelog/spline-bounds.md
+++ b/docs/changelog/spline-bounds.md
@@ -1,0 +1,11 @@
+## Fix array access for rectilinear splines
+
+The rectilinear spline execution object needs to know the
+bounds of the coordinates. These were computed by loading
+the first and last items of the coordinate arrays. However,
+these arrays are on the device and the bounds are computed
+on the host. Thus, for devices with different memory spaces
+this could give bad values.
+
+Fix the problem by using the `GetBounds` method on the
+`CoordinateSystem` object, which will compute it correctly.

--- a/viskores/cont/SplineEvaluateRectilinearGrid.cxx
+++ b/viskores/cont/SplineEvaluateRectilinearGrid.cxx
@@ -36,8 +36,8 @@ viskores::exec::SplineEvaluateRectilinearGrid SplineEvaluateRectilinearGrid::Pre
   if (!this->DataSet.GetCoordinateSystem(0).GetData().IsType<RectCoordsType>())
     throw viskores::cont::ErrorBadType("Coordinates are not rectilinear type.");
 
-  RectCoordsType coords;
-  coords = this->DataSet.GetCoordinateSystem(0).GetData().template AsArrayHandle<RectCoordsType>();
+  viskores::cont::CoordinateSystem coordSystem = this->DataSet.GetCoordinateSystem();
+  RectCoordsType coords = coordSystem.GetData().template AsArrayHandle<RectCoordsType>();
   if (!viskores::cont::ArrayIsMonotonicIncreasing(coords.GetFirstArray()) ||
       !viskores::cont::ArrayIsMonotonicIncreasing(coords.GetSecondArray()) ||
       !viskores::cont::ArrayIsMonotonicIncreasing(coords.GetThirdArray()))
@@ -50,7 +50,8 @@ viskores::exec::SplineEvaluateRectilinearGrid SplineEvaluateRectilinearGrid::Pre
   viskores::cont::ArrayCopyShallowIfPossible(this->DataSet.GetField(this->FieldName).GetData(),
                                              fieldArray);
 
-  return viskores::exec::SplineEvaluateRectilinearGrid(coords, fieldArray, device, token);
+  return viskores::exec::SplineEvaluateRectilinearGrid(
+    coords, fieldArray, coordSystem.GetBounds(), device, token);
 }
 
 } //namespace cont

--- a/viskores/exec/SplineEvaluateRectilinearGrid.h
+++ b/viskores/exec/SplineEvaluateRectilinearGrid.h
@@ -41,9 +41,11 @@ public:
 
   VISKORES_CONT SplineEvaluateRectilinearGrid(const RectilinearType& rectCoords,
                                               const FieldType& field,
+                                              const viskores::Bounds& bounds,
                                               viskores::cont::DeviceAdapterId device,
                                               viskores::cont::Token& token)
-    : Field(field.PrepareForInput(device, token))
+    : Bounds(bounds)
+    , Field(field.PrepareForInput(device, token))
   {
     auto coordsExecPortal = rectCoords.PrepareForInput(device, token);
 
@@ -54,12 +56,6 @@ public:
     this->NumX = this->AxisPortals[0].GetNumberOfValues();
     this->NumY = this->AxisPortals[1].GetNumberOfValues();
     this->NumZ = this->AxisPortals[2].GetNumberOfValues();
-    this->Bounds = viskores::Bounds(this->AxisPortals[0].Get(0),
-                                    this->AxisPortals[0].Get(this->NumX - 1),
-                                    this->AxisPortals[1].Get(0),
-                                    this->AxisPortals[1].Get(this->NumY - 1),
-                                    this->AxisPortals[2].Get(0),
-                                    this->AxisPortals[2].Get(this->NumZ - 1));
   }
 
   VISKORES_EXEC viskores::ErrorCode Evaluate(const viskores::Vec3f& point,


### PR DESCRIPTION
The rectilinear spline execution object needs to know the bounds of the coordinates. These were computed by loading the first and last items of the coordinate arrays. However, these arrays are on the device and the bounds are computed on the host. Thus, for devices with different memory spaces this could give bad values.

Fix the problem by using the `GetBounds` method on the `CoordinateSystem` object, which will compute it correctly.