### PR TITLE
Add FindCellId and FindAllCellIds to cell locators.

### DIFF
--- a/viskores/cont/CellLocatorBoundingIntervalHierarchy.h
+++ b/viskores/cont/CellLocatorBoundingIntervalHierarchy.h
@@ -35,6 +35,23 @@ namespace viskores
 namespace cont
 {
 
+namespace detail
+{
+
+VISKORES_DEPRECATED_SUPPRESS_BEGIN
+template <typename CellSetList>
+struct CellLocatorBoundingIntervalHierarchyExecList;
+
+template <typename... CellSetTypes>
+struct CellLocatorBoundingIntervalHierarchyExecList<viskores::List<CellSetTypes...>>
+{
+  using type =
+    viskores::List<viskores::exec::CellLocatorBoundingIntervalHierarchy<CellSetTypes>...>;
+};
+VISKORES_DEPRECATED_SUPPRESS_END
+
+} // namespace detail
+
 /// @brief A cell locator that performs a recursive division of space.
 ///
 /// `CellLocatorBoundingIntervalHierarchy` creates a search structure by recursively
@@ -54,8 +71,7 @@ public:
 
 
   using CellLocatorExecList =
-    viskores::ListTransform<SupportedCellSets,
-                            viskores::exec::CellLocatorBoundingIntervalHierarchy>;
+    typename detail::CellLocatorBoundingIntervalHierarchyExecList<SupportedCellSets>::type;
 
   using ExecObjType =
     viskores::ListApply<CellLocatorExecList, viskores::exec::CellLocatorMultiplexer>;

--- a/viskores/cont/testing/UnitTestCellLocatorGeneral.cxx
+++ b/viskores/cont/testing/UnitTestCellLocatorGeneral.cxx
@@ -17,7 +17,10 @@
 //============================================================================
 #include <viskores/cont/CellLocatorGeneral.h>
 
+#include <viskores/cont/Algorithm.h>
 #include <viskores/cont/ArrayHandle.h>
+#include <viskores/cont/ArrayHandleGroupVecVariable.h>
+#include <viskores/cont/ConvertNumComponentsToOffsets.h>
 #include <viskores/cont/DataSetBuilderRectilinear.h>
 #include <viskores/cont/DataSetBuilderUniform.h>
 #include <viskores/cont/Invoker.h>
@@ -203,6 +206,74 @@ public:
   }
 };
 
+class FindCellIdWorklet : public viskores::worklet::WorkletMapField
+{
+public:
+  using ControlSignature = void(FieldIn points, ExecObject locator, FieldOut cellIds);
+  using ExecutionSignature = void(_1, _2, _3);
+
+  template <typename LocatorType>
+  VISKORES_EXEC void operator()(const viskores::Vec3f& point,
+                                const LocatorType& locator,
+                                viskores::Id& cellId) const
+  {
+    viskores::ErrorCode status = locator.FindCellId(point, cellId);
+    if (status != viskores::ErrorCode::Success)
+      this->RaiseError(viskores::ErrorString(status));
+  }
+};
+
+class FindCellIdWorkletWithLastCell : public viskores::worklet::WorkletMapField
+{
+public:
+  using ControlSignature = void(FieldIn points,
+                                ExecObject locator,
+                                FieldOut cellIds,
+                                FieldInOut lastCell);
+  using ExecutionSignature = void(_1, _2, _3, _4);
+
+  template <typename LocatorType>
+  VISKORES_EXEC void operator()(const viskores::Vec3f& point,
+                                const LocatorType& locator,
+                                viskores::Id& cellId,
+                                typename LocatorType::LastCell& lastCell) const
+  {
+    viskores::ErrorCode status = locator.FindCellId(point, cellId, lastCell);
+    if (status != viskores::ErrorCode::Success)
+      this->RaiseError(viskores::ErrorString(status));
+  }
+};
+
+class CountAllCellsWorklet : public viskores::worklet::WorkletMapField
+{
+public:
+  using ControlSignature = void(FieldIn points, ExecObject locator, FieldOut count);
+  using ExecutionSignature = void(_1, _2, _3);
+
+  template <typename LocatorType>
+  VISKORES_EXEC void operator()(const viskores::Vec3f& point,
+                                const LocatorType& locator,
+                                viskores::Id& count) const
+  {
+    count = locator.CountAllCells(point);
+  }
+};
+
+class FindAllCellIdsWorklet : public viskores::worklet::WorkletMapField
+{
+public:
+  using ControlSignature = void(FieldIn points, ExecObject locator, FieldOut cellIds);
+  using ExecutionSignature = void(_1, _2, _3);
+
+  template <typename LocatorType, typename CellIdVecType>
+  VISKORES_EXEC void operator()(const viskores::Vec3f& point,
+                                const LocatorType& locator,
+                                CellIdVecType& cellIds) const
+  {
+    locator.FindAllCellIds(point, cellIds);
+  }
+};
+
 void TestLastCell(
   viskores::cont::CellLocatorGeneral& locator,
   viskores::Id numPoints,
@@ -229,6 +300,24 @@ void TestLastCell(
     VISKORES_TEST_ASSERT(test_equal(pcoordsPortal.Get(i), expPCoordsPortal.Get(i), 1e-3),
                          "Incorrect parameteric coordinates");
   }
+}
+
+void TestLastCellId(
+  viskores::cont::CellLocatorGeneral& locator,
+  viskores::Id numPoints,
+  viskores::cont::ArrayHandle<viskores::cont::CellLocatorGeneral::LastCell>& lastCell,
+  const viskores::cont::ArrayHandle<PointType>& points,
+  const viskores::cont::ArrayHandle<viskores::Id>& expCellIds)
+{
+  viskores::cont::ArrayHandle<viskores::Id> cellIds;
+
+  viskores::cont::Invoker invoker;
+  invoker(FindCellIdWorkletWithLastCell{}, points, locator, cellIds, lastCell);
+
+  auto cellIdPortal = cellIds.ReadPortal();
+  auto expCellIdsPortal = expCellIds.ReadPortal();
+  for (viskores::Id i = 0; i < numPoints; ++i)
+    VISKORES_TEST_ASSERT(cellIdPortal.Get(i) == expCellIdsPortal.Get(i), "Incorrect cell ids");
 }
 
 void TestWithDataSet(viskores::cont::CellLocatorGeneral& locator,
@@ -260,6 +349,12 @@ void TestWithDataSet(viskores::cont::CellLocatorGeneral& locator,
                          "Incorrect parameteric coordinates");
   }
 
+  viskores::cont::ArrayHandle<viskores::Id> cellIdsOnly;
+  invoker(FindCellIdWorklet{}, points, locator, cellIdsOnly);
+  auto cellIdsOnlyPortal = cellIdsOnly.ReadPortal();
+  for (viskores::Id i = 0; i < 64; ++i)
+    VISKORES_TEST_ASSERT(cellIdsOnlyPortal.Get(i) == expCellIdsPortal.Get(i), "Incorrect cell ids");
+
   //Test locator using lastCell
 
   //Test it with initialized.
@@ -269,6 +364,7 @@ void TestWithDataSet(viskores::cont::CellLocatorGeneral& locator,
 
   //Call it again using the lastCell just computed to validate.
   TestLastCell(locator, 64, lastCell, points, expCellIds, pcoords);
+  TestLastCellId(locator, 64, lastCell, points, expCellIds);
 
 
   //Test it with uninitialized array.
@@ -278,6 +374,21 @@ void TestWithDataSet(viskores::cont::CellLocatorGeneral& locator,
 
   //Call it again using the lastCell just computed to validate.
   TestLastCell(locator, 64, lastCell2, points, expCellIds, pcoords);
+  TestLastCellId(locator, 64, lastCell2, points, expCellIds);
+
+  viskores::cont::ArrayHandle<viskores::Id> cellCounts;
+  invoker(CountAllCellsWorklet{}, points, locator, cellCounts);
+
+  viskores::Id totalCells = viskores::cont::Algorithm::Reduce(cellCounts, viskores::Id(0));
+  viskores::cont::ArrayHandle<viskores::Id> allCellIds;
+  allCellIds.AllocateAndFill(totalCells, viskores::Id(-1));
+  auto offsets = viskores::cont::ConvertNumComponentsToOffsets(cellCounts);
+  auto allCellIdsVec = viskores::cont::make_ArrayHandleGroupVecVariable(allCellIds, offsets);
+  invoker(FindAllCellIdsWorklet{}, points, locator, allCellIdsVec);
+
+  auto allCellIdsPortal = allCellIds.ReadPortal();
+  for (viskores::Id i = 0; i < totalCells; ++i)
+    VISKORES_TEST_ASSERT(allCellIdsPortal.Get(i) == expCellIdsPortal.Get(i), "Incorrect cell ids");
 }
 
 void TestCellLocatorGeneral()

--- a/viskores/cont/testing/UnitTestCellLocatorRectilinearGrid.cxx
+++ b/viskores/cont/testing/UnitTestCellLocatorRectilinearGrid.cxx
@@ -114,13 +114,21 @@ public:
     // ExecutionWholeArrayConst. We need to get out the actual portal.
     viskores::Id calculated = CalculateCellId(pointIn, coordsPortal);
     viskores::ErrorCode status = locator.FindCell(pointIn, cellId, parametric);
+    viskores::Id cellIdOnly = -1;
+    viskores::ErrorCode statusId = locator.FindCellId(pointIn, cellIdOnly);
     if (status != viskores::ErrorCode::Success)
     {
       this->RaiseError(viskores::ErrorString(status));
       match = false;
       return;
     }
-    match = (calculated == cellId);
+    if (statusId != viskores::ErrorCode::Success)
+    {
+      this->RaiseError(viskores::ErrorString(statusId));
+      match = false;
+      return;
+    }
+    match = (calculated == cellId) && (cellId == cellIdOnly);
   }
 
 private:

--- a/viskores/cont/testing/UnitTestCellLocatorUniformGrid.cxx
+++ b/viskores/cont/testing/UnitTestCellLocatorUniformGrid.cxx
@@ -79,13 +79,22 @@ public:
   {
     viskores::Id calculated = CalculateCellId(pointIn);
     viskores::ErrorCode status = locator.FindCell(pointIn, cellId, parametric);
+    viskores::Id cellIdOnly = -1;
+    viskores::ErrorCode statusId = locator.FindCellId(pointIn, cellIdOnly);
     if ((status != viskores::ErrorCode::Success) && (status != viskores::ErrorCode::CellNotFound))
     {
       this->RaiseError(viskores::ErrorString(status));
       match = false;
       return;
     }
-    match = (calculated == cellId);
+    if ((statusId != viskores::ErrorCode::Success) &&
+        (statusId != viskores::ErrorCode::CellNotFound))
+    {
+      this->RaiseError(viskores::ErrorString(statusId));
+      match = false;
+      return;
+    }
+    match = (calculated == cellId) && (cellId == cellIdOnly);
   }
 
 private:

--- a/viskores/cont/testing/UnitTestCellLocatorUnstructured.cxx
+++ b/viskores/cont/testing/UnitTestCellLocatorUnstructured.cxx
@@ -222,6 +222,44 @@ public:
   }
 };
 
+class FindCellIdWorklet : public viskores::worklet::WorkletMapField
+{
+public:
+  using ControlSignature = void(FieldIn points, ExecObject locator, FieldOut cellIds);
+  using ExecutionSignature = void(_1, _2, _3);
+
+  template <typename LocatorType>
+  VISKORES_EXEC void operator()(const viskores::Vec3f& point,
+                                const LocatorType& locator,
+                                viskores::Id& cellId) const
+  {
+    viskores::ErrorCode status = locator.FindCellId(point, cellId);
+    if (status != viskores::ErrorCode::Success)
+      this->RaiseError(viskores::ErrorString(status));
+  }
+};
+
+class FindCellIdWorkletWithLastCell : public viskores::worklet::WorkletMapField
+{
+public:
+  using ControlSignature = void(FieldIn points,
+                                ExecObject locator,
+                                FieldOut cellIds,
+                                FieldInOut lastCell);
+  using ExecutionSignature = void(_1, _2, _3, _4);
+
+  template <typename LocatorType>
+  VISKORES_EXEC void operator()(const viskores::Vec3f& point,
+                                const LocatorType& locator,
+                                viskores::Id& cellId,
+                                typename LocatorType::LastCell& lastCell) const
+  {
+    viskores::ErrorCode status = locator.FindCellId(point, cellId, lastCell);
+    if (status != viskores::ErrorCode::Success)
+      this->RaiseError(viskores::ErrorString(status));
+  }
+};
+
 class CountAllCellsWorklet : public viskores::worklet::WorkletMapField
 {
 public:
@@ -256,6 +294,21 @@ public:
   }
 };
 
+class FindAllCellIdsWorklet : public viskores::worklet::WorkletMapField
+{
+public:
+  using ControlSignature = void(FieldIn points, ExecObject locator, FieldOut cellIds);
+  using ExecutionSignature = void(_1, _2, _3);
+
+  template <typename LocatorType, typename CellIdVecType>
+  VISKORES_EXEC void operator()(const viskores::Vec3f& point,
+                                const LocatorType& locator,
+                                CellIdVecType& cellIds) const
+  {
+    locator.FindAllCellIds(point, cellIds);
+  }
+};
+
 template <typename LocatorType>
 void TestLastCell(LocatorType& locator,
                   viskores::Id numPoints,
@@ -281,6 +334,26 @@ void TestLastCell(LocatorType& locator,
     VISKORES_TEST_ASSERT(cellIdPortal.Get(i) == expCellIdsPortal.Get(i), "Incorrect cell ids");
     VISKORES_TEST_ASSERT(test_equal(pcoordsPortal.Get(i), expPCoordsPortal.Get(i), 1e-3),
                          "Incorrect parameteric coordinates");
+  }
+}
+
+template <typename LocatorType>
+void TestLastCellId(LocatorType& locator,
+                    viskores::Id numPoints,
+                    viskores::cont::ArrayHandle<typename LocatorType::LastCell>& lastCell,
+                    const viskores::cont::ArrayHandle<PointType>& points,
+                    const viskores::cont::ArrayHandle<viskores::Id>& expCellIds)
+{
+  viskores::cont::ArrayHandle<viskores::Id> cellIds;
+
+  viskores::cont::Invoker invoker;
+  invoker(FindCellIdWorkletWithLastCell{}, points, locator, cellIds, lastCell);
+
+  auto cellIdPortal = cellIds.ReadPortal();
+  auto expCellIdsPortal = expCellIds.ReadPortal();
+  for (viskores::Id i = 0; i < numPoints; ++i)
+  {
+    VISKORES_TEST_ASSERT(cellIdPortal.Get(i) == expCellIdsPortal.Get(i), "Incorrect cell ids");
   }
 }
 
@@ -322,6 +395,14 @@ void TestCellLocator(LocatorType& locator,
                          "Incorrect parameteric coordinates");
   }
 
+  viskores::cont::ArrayHandle<viskores::Id> cellIdsOnly;
+  invoker(FindCellIdWorklet{}, points, locator, cellIdsOnly);
+  auto cellIdsOnlyPortal = cellIdsOnly.ReadPortal();
+  for (viskores::Id i = 0; i < numberOfPoints; ++i)
+  {
+    VISKORES_TEST_ASSERT(cellIdsOnlyPortal.Get(i) == expCellIdsPortal.Get(i), "Incorrect cell ids");
+  }
+
   //Test locator using lastCell
   //Test it with initialized.
   viskores::cont::ArrayHandle<typename LocatorType::LastCell> lastCell;
@@ -330,12 +411,14 @@ void TestCellLocator(LocatorType& locator,
 
   //Call it again using the lastCell just computed to validate.
   TestLastCell(locator, numberOfPoints, lastCell, points, expCellIds, pcoords);
+  TestLastCellId(locator, numberOfPoints, lastCell, points, expCellIds);
 
   //Test it with uninitialized array.
   viskores::cont::ArrayHandle<typename LocatorType::LastCell> lastCell2;
   lastCell2.Allocate(numberOfPoints);
 
   TestLastCell(locator, numberOfPoints, lastCell2, points, expCellIds, pcoords);
+  TestLastCellId(locator, numberOfPoints, lastCell2, points, expCellIds);
 
 
   //Test CountAllCells and FindAllCells. Should be identical to the tests above.
@@ -369,6 +452,19 @@ void TestCellLocator(LocatorType& locator,
     for (viskores::Id i = 0; i < numberOfFoundCells; ++i)
     {
       VISKORES_TEST_ASSERT(portal.Get(i) == expCellIds.ReadPortal().Get(i),
+                           "Found cell id out of range");
+    }
+
+    viskores::cont::ArrayHandle<viskores::Id> allCellIdsOnly;
+    allCellIdsOnly.AllocateAndFill(numberOfFoundCells, viskores::Id(-1));
+    auto cellIdsOnlyVec =
+      viskores::cont::make_ArrayHandleGroupVecVariable(allCellIdsOnly, cellOffsets);
+    invoker(FindAllCellIdsWorklet{}, points, locator, cellIdsOnlyVec);
+
+    auto portalIdsOnly = allCellIdsOnly.ReadPortal();
+    for (viskores::Id i = 0; i < numberOfFoundCells; ++i)
+    {
+      VISKORES_TEST_ASSERT(portalIdsOnly.Get(i) == expCellIds.ReadPortal().Get(i),
                            "Found cell id out of range");
     }
   }
@@ -463,10 +559,16 @@ void ValidateFindAllCells(LocatorType& locator,
     cellIds, viskores::cont::ConvertNumComponentsToOffsets(cellCounts));
   auto pCoordsVec = viskores::cont::make_ArrayHandleGroupVecVariable(
     pCoords, viskores::cont::ConvertNumComponentsToOffsets(cellCounts));
+  viskores::cont::ArrayHandle<viskores::Id> cellIdsOnly;
+  cellIdsOnly.AllocateAndFill(numberOfFoundCells, viskores::Id(-1));
+  auto cellIdsOnlyVec = viskores::cont::make_ArrayHandleGroupVecVariable(
+    cellIdsOnly, viskores::cont::ConvertNumComponentsToOffsets(cellCounts));
 
   invoker(FindAllCellsWorklet{}, pointsAH, locator, cellIdsVec, pCoordsVec);
+  invoker(FindAllCellIdsWorklet{}, pointsAH, locator, cellIdsOnlyVec);
 
   auto portal = cellIdsVec.ReadPortal();
+  auto portalIdsOnly = cellIdsOnlyVec.ReadPortal();
   for (viskores::Id i = 0; i < cellIdsVec.GetNumberOfValues(); i++)
   {
     viskores::IdComponent numComp = portal.Get(i).GetNumberOfComponents();
@@ -487,6 +589,21 @@ void ValidateFindAllCells(LocatorType& locator,
     {
       VISKORES_TEST_ASSERT(cells0[j] == cells1[j],
                            "Cell Ids do not match at index " + std::to_string(i));
+    }
+
+    VISKORES_TEST_ASSERT(portal.Get(i).GetNumberOfComponents() ==
+                           portalIdsOnly.Get(i).GetNumberOfComponents(),
+                         "FindAllCellIds returned the wrong number of cell ids");
+    std::vector<viskores::Id> cells2;
+    for (viskores::IdComponent j = 0; j < portalIdsOnly.Get(i).GetNumberOfComponents(); j++)
+      cells2.push_back(portalIdsOnly.Get(i)[j]);
+
+    std::sort(cells2.begin(), cells2.end());
+    for (std::size_t j = 0; j < cells1.size(); j++)
+    {
+      VISKORES_TEST_ASSERT(cells2[j] == cells1[j],
+                           "FindAllCellIds did not match expected ids at index " +
+                             std::to_string(i));
     }
   }
 }

--- a/viskores/exec/CellLocatorBoundingIntervalHierarchy.h
+++ b/viskores/exec/CellLocatorBoundingIntervalHierarchy.h
@@ -82,6 +82,25 @@ class VISKORES_ALWAYS_EXPORT CellLocatorBoundingIntervalHierarchy
     viskores::cont::ArrayHandle<viskores::exec::CellLocatorBoundingIntervalHierarchyNode>;
   using CellIdArrayHandle = viskores::cont::ArrayHandle<viskores::Id>;
 
+  struct IdOnlyParametricCoords
+  {
+    VISKORES_EXEC
+    explicit IdOnlyParametricCoords(viskores::IdComponent numberOfComponents)
+      : NumberOfComponents(numberOfComponents)
+      , Dummy()
+    {
+    }
+
+    VISKORES_EXEC
+    viskores::IdComponent GetNumberOfComponents() const { return this->NumberOfComponents; }
+
+    VISKORES_EXEC
+    viskores::Vec3f& operator[](viskores::IdComponent) { return this->Dummy; }
+
+    viskores::IdComponent NumberOfComponents;
+    viskores::Vec3f Dummy;
+  };
+
 public:
   VISKORES_CONT
   CellLocatorBoundingIntervalHierarchy(
@@ -104,6 +123,26 @@ public:
     viskores::Id CellId = -1;
     viskores::Id NodeIdx = -1;
   };
+
+  /// @brief Locate the id of the cell containing the provided point.
+  ///
+  /// This method returns the same cell id as `FindCell()` without requiring
+  /// the caller to provide parametric coordinates.
+  VISKORES_EXEC viskores::ErrorCode FindCellId(const viskores::Vec3f& point,
+                                               viskores::Id& cellId) const
+  {
+    viskores::Vec3f pCoords;
+    return this->FindCell(point, cellId, pCoords);
+  }
+
+  /// @copydoc viskores::exec::CellLocatorUniformGrid::FindCellId
+  VISKORES_EXEC viskores::ErrorCode FindCellId(const viskores::Vec3f& point,
+                                               viskores::Id& cellId,
+                                               LastCell& lastCell) const
+  {
+    viskores::Vec3f pCoords;
+    return this->FindCell(point, cellId, pCoords, lastCell);
+  }
 
   /// @copydoc viskores::exec::CellLocatorUniformGrid::FindCell
   VISKORES_EXEC viskores::ErrorCode FindCell(const viskores::Vec3f& point,
@@ -217,6 +256,36 @@ public:
 
     // More than n cells were found.
     //If the size of cellIdsVec is not big enough to hold the number found, return an error.
+    if (count > n)
+      return viskores::ErrorCode::InvalidNumberOfIndices;
+
+    return status;
+  }
+
+  /// @brief Locate all cell ids containing the provided point.
+  ///
+  /// This method returns the same cell ids as `FindAllCells()` without
+  /// requiring parametric coordinates.
+  ///
+  template <typename CellIdsType>
+  VISKORES_EXEC viskores::ErrorCode FindAllCellIds(const viskores::Vec3f& point,
+                                                   CellIdsType& cellIdsVec) const
+  {
+    viskores::IdComponent n = cellIdsVec.GetNumberOfComponents();
+    if (n == 0)
+      return viskores::ErrorCode::Success;
+
+    for (viskores::IdComponent i = 0; i < n; i++)
+      cellIdsVec[i] = -1;
+
+    IdOnlyParametricCoords pCoordsVec(n);
+    LastCell lastCell;
+    viskores::IdComponent count = 0;
+    auto status =
+      this->FindCellImpl(IterateMode::FindAll, point, cellIdsVec, pCoordsVec, lastCell, count);
+
+    // More than n cells were found.
+    // If cellIdsVec is not large enough to hold the number found, return an error.
     if (count > n)
       return viskores::ErrorCode::InvalidNumberOfIndices;
 

--- a/viskores/exec/CellLocatorMultiplexer.h
+++ b/viskores/exec/CellLocatorMultiplexer.h
@@ -58,6 +58,31 @@ struct FindCellFunctor
   }
 };
 
+struct FindCellIdFunctor
+{
+  template <typename Locator>
+  VISKORES_EXEC viskores::ErrorCode operator()(Locator&& locator,
+                                               const viskores::Vec3f& point,
+                                               viskores::Id& cellId) const
+  {
+    return locator.FindCellId(point, cellId);
+  }
+
+  template <typename Locator, typename LastCell>
+  VISKORES_EXEC viskores::ErrorCode operator()(Locator&& locator,
+                                               const viskores::Vec3f& point,
+                                               viskores::Id& cellId,
+                                               LastCell& lastCell) const
+  {
+    using ConcreteLastCell = typename std::decay_t<Locator>::LastCell;
+    if (!lastCell.template IsType<ConcreteLastCell>())
+    {
+      lastCell = ConcreteLastCell{};
+    }
+    return locator.FindCellId(point, cellId, lastCell.template Get<ConcreteLastCell>());
+  }
+};
+
 struct CountAllCellsFunctor
 {
   template <typename Locator>
@@ -77,6 +102,17 @@ struct FindAllCellsFunctor
                                                ParametricVecType& pCoords) const
   {
     return locator.FindAllCells(point, cellIds, pCoords);
+  }
+};
+
+struct FindAllCellIdsFunctor
+{
+  template <typename Locator, typename CellIdsType>
+  VISKORES_EXEC viskores::ErrorCode operator()(Locator&& locator,
+                                               const viskores::Vec3f& point,
+                                               CellIdsType& cellIds) const
+  {
+    return locator.FindAllCellIds(point, cellIds);
   }
 };
 
@@ -113,6 +149,27 @@ public:
     return this->Locators.CastAndCall(detail::FindCellFunctor{}, point, cellId, pCoords, lastCell);
   }
 
+  /// @brief Locate the id of the cell containing the provided point.
+  ///
+  /// This method returns the same cell id as `FindCell()` without requiring
+  /// the caller to provide parametric coordinates.
+  VISKORES_EXEC viskores::ErrorCode FindCellId(const viskores::Vec3f& point,
+                                               viskores::Id& cellId) const
+  {
+    return this->Locators.CastAndCall(detail::FindCellIdFunctor{}, point, cellId);
+  }
+
+  /// @brief Locate the id of the cell containing the provided point.
+  ///
+  /// This overload uses a `LastCell` cache that can accelerate successive
+  /// searches for nearby points.
+  VISKORES_EXEC viskores::ErrorCode FindCellId(const viskores::Vec3f& point,
+                                               viskores::Id& cellId,
+                                               LastCell& lastCell) const
+  {
+    return this->Locators.CastAndCall(detail::FindCellIdFunctor{}, point, cellId, lastCell);
+  }
+
   VISKORES_EXEC viskores::Id CountAllCells(const viskores::Vec3f& point) const
   {
     return this->Locators.CastAndCall(detail::CountAllCellsFunctor{}, point);
@@ -124,6 +181,17 @@ public:
                                                  ParametricVecType& pCoords) const
   {
     return this->Locators.CastAndCall(detail::FindAllCellsFunctor{}, point, cellIds, pCoords);
+  }
+
+  /// @brief Locate all cell ids containing the provided point.
+  ///
+  /// This method returns the same cell ids as `FindAllCells()` without
+  /// requiring parametric coordinates.
+  template <typename CellIdsType>
+  VISKORES_EXEC viskores::ErrorCode FindAllCellIds(const viskores::Vec3f& point,
+                                                   CellIdsType& cellIds) const
+  {
+    return this->Locators.CastAndCall(detail::FindAllCellIdsFunctor{}, point, cellIds);
   }
 };
 

--- a/viskores/exec/CellLocatorRectilinearGrid.h
+++ b/viskores/exec/CellLocatorRectilinearGrid.h
@@ -114,6 +114,25 @@ public:
     return inside;
   }
 
+  /// @brief Locate the id of the cell containing the provided point.
+  ///
+  /// This method returns the same cell id as `FindCell()` without requiring
+  /// the caller to provide parametric coordinates.
+  VISKORES_EXEC viskores::ErrorCode FindCellId(const viskores::Vec3f& point,
+                                               viskores::Id& cellId,
+                                               LastCell& lastCell) const
+  {
+    (void)lastCell;
+    return this->FindCellId(point, cellId);
+  }
+
+  /// @copydoc viskores::exec::CellLocatorUniformGrid::FindCellId
+  VISKORES_EXEC viskores::ErrorCode FindCellId(const viskores::Vec3f& point,
+                                               viskores::Id& cellId) const
+  {
+    return this->FindCellImpl(point, cellId, nullptr);
+  }
+
   /// @copydoc viskores::exec::CellLocatorUniformGrid::FindCell
   VISKORES_EXEC viskores::ErrorCode FindCell(const viskores::Vec3f& point,
                                              viskores::Id& cellId,
@@ -127,6 +146,79 @@ public:
   VISKORES_EXEC viskores::ErrorCode FindCell(const viskores::Vec3f& point,
                                              viskores::Id& cellId,
                                              viskores::Vec3f& parametric) const
+  {
+    return this->FindCellImpl(point, cellId, &parametric);
+  }
+
+  /// @copydoc viskores::exec::CellLocatorUniformGrid::CountAllCells
+  VISKORES_EXEC viskores::IdComponent CountAllCells(const viskores::Vec3f& point) const
+  {
+    viskores::Id cellId;
+    if (this->FindCellId(point, cellId) == viskores::ErrorCode::Success)
+      return 1;
+    return 0;
+  }
+
+  /// @copydoc viskores::exec::CellLocatorUniformGrid::FindAllCells
+  template <typename CellIdsType, typename ParametricCoordsVecType>
+  VISKORES_EXEC viskores::ErrorCode FindAllCells(const viskores::Vec3f& point,
+                                                 CellIdsType& cellIdVec,
+                                                 ParametricCoordsVecType& pCoordsVec) const
+  {
+    return this->FindAllCellsImpl(point, cellIdVec, pCoordsVec);
+  }
+
+  /// @brief Locate all cell ids containing the provided point.
+  ///
+  /// This method returns the same cell ids as `FindAllCells()` without
+  /// requiring parametric coordinates.
+  template <typename CellIdsType>
+  VISKORES_EXEC viskores::ErrorCode FindAllCellIds(const viskores::Vec3f& point,
+                                                   CellIdsType& cellIdVec) const
+  {
+    return this->FindAllCellsImpl(point, cellIdVec);
+  }
+
+private:
+  template <typename CellIdsType>
+  VISKORES_EXEC viskores::IdComponent InitializeAllCellIds(CellIdsType& cellIdVec) const
+  {
+    viskores::IdComponent n = cellIdVec.GetNumberOfComponents();
+    for (viskores::IdComponent i = 0; i < n; i++)
+      cellIdVec[i] = -1;
+    return n;
+  }
+
+  template <typename CellIdsType, typename ParametricCoordsVecType>
+  VISKORES_EXEC viskores::ErrorCode FindAllCellsImpl(const viskores::Vec3f& point,
+                                                     CellIdsType& cellIdVec,
+                                                     ParametricCoordsVecType& pCoordsVec) const
+  {
+    viskores::IdComponent n = this->InitializeAllCellIds(cellIdVec);
+    VISKORES_ASSERT(pCoordsVec.GetNumberOfComponents() == n);
+    if (n == 0)
+      return viskores::ErrorCode::Success;
+
+    return this->FindCell(point, cellIdVec[0], pCoordsVec[0]);
+  }
+
+  template <typename CellIdsType>
+  VISKORES_EXEC viskores::ErrorCode FindAllCellsImpl(const viskores::Vec3f& point,
+                                                     CellIdsType& cellIdVec) const
+  {
+    viskores::IdComponent n = this->InitializeAllCellIds(cellIdVec);
+    if (n == 0)
+      return viskores::ErrorCode::Success;
+
+    viskores::Id cellId = -1;
+    viskores::ErrorCode status = this->FindCellId(point, cellId);
+    cellIdVec[0] = cellId;
+    return status;
+  }
+
+  VISKORES_EXEC viskores::ErrorCode FindCellImpl(const viskores::Vec3f& point,
+                                                 viskores::Id& cellId,
+                                                 viskores::Vec3f* parametric) const
   {
     if (!this->IsInside(point))
     {
@@ -146,16 +238,15 @@ public:
       if (point[dim] == MaxPoint[dim])
       {
         logicalCell[dim] = this->PointDimensions[dim] - 2;
-        parametric[dim] = static_cast<viskores::FloatDefault>(1);
+        if (parametric != nullptr)
+          (*parametric)[dim] = static_cast<viskores::FloatDefault>(1);
         continue;
       }
 
       viskores::Id minIndex = 0;
       viskores::Id maxIndex = this->PointDimensions[dim] - 1;
-      viskores::FloatDefault minVal;
-      viskores::FloatDefault maxVal;
-      minVal = this->AxisPortals[dim].Get(minIndex);
-      maxVal = this->AxisPortals[dim].Get(maxIndex);
+      viskores::FloatDefault minVal = this->AxisPortals[dim].Get(minIndex);
+      viskores::FloatDefault maxVal = this->AxisPortals[dim].Get(maxIndex);
       while (maxIndex > minIndex + 1)
       {
         viskores::Id midIndex = (minIndex + maxIndex) / 2;
@@ -172,43 +263,14 @@ public:
         }
       }
       logicalCell[dim] = minIndex;
-      parametric[dim] = (point[dim] - minVal) / (maxVal - minVal);
+      if (parametric != nullptr)
+        (*parametric)[dim] = (point[dim] - minVal) / (maxVal - minVal);
     }
-    // Get the actual cellId, from the logical cell index of the cell
-    cellId = logicalCell[2] * this->PlaneSize + logicalCell[1] * this->RowSize + logicalCell[0];
 
+    cellId = logicalCell[2] * this->PlaneSize + logicalCell[1] * this->RowSize + logicalCell[0];
     return viskores::ErrorCode::Success;
   }
 
-  /// @copydoc viskores::exec::CellLocatorUniformGrid::CountAllCells
-  VISKORES_EXEC viskores::IdComponent CountAllCells(const viskores::Vec3f& point) const
-  {
-    viskores::Id cellId;
-    viskores::Vec3f pCoords;
-    if (this->FindCell(point, cellId, pCoords) == viskores::ErrorCode::Success)
-      return 1;
-    return 0;
-  }
-
-  /// @copydoc viskores::exec::CellLocatorUniformGrid::FindAllCells
-  template <typename CellIdsType, typename ParametricCoordsVecType>
-  VISKORES_EXEC viskores::ErrorCode FindAllCells(const viskores::Vec3f& point,
-                                                 CellIdsType& cellIdVec,
-                                                 ParametricCoordsVecType& pCoordsVec) const
-  {
-    viskores::IdComponent n = cellIdVec.GetNumberOfComponents();
-    VISKORES_ASSERT(pCoordsVec.GetNumberOfComponents() == n);
-
-    if (n == 0)
-      return viskores::ErrorCode::Success;
-
-    for (viskores::IdComponent i = 0; i < n; i++)
-      cellIdVec[i] = -1;
-
-    return this->FindCell(point, cellIdVec[0], pCoordsVec[0]);
-  }
-
-private:
   viskores::Id PlaneSize;
   viskores::Id RowSize;
 

--- a/viskores/exec/CellLocatorTwoLevel.h
+++ b/viskores/exec/CellLocatorTwoLevel.h
@@ -179,6 +179,26 @@ public:
     viskores::Id LeafIdx = -1;
   };
 
+  /// @brief Locate the id of the cell containing the provided point.
+  ///
+  /// This method returns the same cell id as `FindCell()` without requiring
+  /// the caller to provide parametric coordinates.
+  VISKORES_EXEC
+  viskores::ErrorCode FindCellId(const FloatVec3& point, viskores::Id& cellId) const
+  {
+    LastCell lastCell;
+    return this->FindCellImpl(point, cellId, lastCell, nullptr);
+  }
+
+  /// @copydoc viskores::exec::CellLocatorUniformGrid::FindCellId
+  VISKORES_EXEC
+  viskores::ErrorCode FindCellId(const FloatVec3& point,
+                                 viskores::Id& cellId,
+                                 LastCell& lastCell) const
+  {
+    return this->FindCellImpl(point, cellId, lastCell, nullptr);
+  }
+
   /// @copydoc viskores::exec::CellLocatorUniformGrid::FindCell
   VISKORES_EXEC
   viskores::ErrorCode FindCell(const FloatVec3& point,
@@ -186,7 +206,7 @@ public:
                                FloatVec3& pCoords) const
   {
     LastCell lastCell;
-    return this->FindCell(point, cellId, pCoords, lastCell);
+    return this->FindCellImpl(point, cellId, lastCell, &pCoords);
   }
 
   /// @copydoc viskores::exec::CellLocatorUniformGrid::FindCell
@@ -196,55 +216,16 @@ public:
                                FloatVec3& pCoords,
                                LastCell& lastCell) const
   {
-    viskores::Vec3f pc;
-    //See if point is inside the last cell.
-    if ((lastCell.CellId >= 0) && (lastCell.CellId < this->CellSet.GetNumberOfElements()) &&
-        this->PointInCell(point, lastCell.CellId, pc) == viskores::ErrorCode::Success)
-    {
-      pCoords = pc;
-      cellId = lastCell.CellId;
-      return viskores::ErrorCode::Success;
-    }
-
-    //See if it's in the last leaf.
-    if ((lastCell.LeafIdx >= 0) && (lastCell.LeafIdx < this->CellCount.GetNumberOfValues()) &&
-        this->PointInLeaf(point, lastCell.LeafIdx, cellId, pc) == viskores::ErrorCode::Success)
-    {
-      pCoords = pc;
-      lastCell.CellId = cellId;
-      return viskores::ErrorCode::Success;
-    }
-
-    //Call the full point search.
-    viskores::Vec<viskores::Id, 1> cellIdVec = { -1 };
-    viskores::Vec<viskores::Vec3f, 1> pCoordsVec;
-    auto nCells = this->IterateLeaves(point, IterateMode::FindOne, cellIdVec, pCoordsVec, lastCell);
-    if (nCells < 0)
-    {
-      cellId = -1;
-      return viskores::ErrorCode::InvalidNumberOfIndices;
-    }
-    else if (nCells == 0)
-    {
-      cellId = -1;
-      return viskores::ErrorCode::CellNotFound;
-    }
-    else
-    {
-      cellId = cellIdVec[0];
-      pCoords = pCoordsVec[0];
-      return viskores::ErrorCode::Success;
-    }
+    return this->FindCellImpl(point, cellId, lastCell, &pCoords);
   }
 
   /// @copydoc viskores::exec::CellLocatorUniformGrid::CountAllCells
   VISKORES_EXEC viskores::IdComponent CountAllCells(const viskores::Vec3f& point) const
   {
     viskores::Vec<viskores::Id, 1> cellIdVec = { -1 };
-    viskores::Vec<viskores::Vec3f, 1> pCoordsVec;
     LastCell lastCell;
 
-    return this->IterateLeaves(point, IterateMode::CountAll, cellIdVec, pCoordsVec, lastCell);
+    return this->IterateLeavesCellIds(point, IterateMode::CountAll, cellIdVec, lastCell);
   }
 
   /// @copydoc viskores::exec::CellLocatorUniformGrid::FindAllCells
@@ -253,26 +234,115 @@ public:
                                                  CellIdsType& cellIdVec,
                                                  ParametricCoordsVecType& pCoordsVec) const
   {
-    viskores::IdComponent n = cellIdVec.GetNumberOfComponents();
-    VISKORES_ASSERT(pCoordsVec.GetNumberOfComponents() == n);
+    return this->FindAllCellsImpl(point, cellIdVec, pCoordsVec);
+  }
 
+  /// @brief Locate all cell ids containing the provided point.
+  ///
+  /// This method returns the same cell ids as `FindAllCells()` without
+  /// requiring parametric coordinates.
+  template <typename CellIdsType>
+  VISKORES_EXEC viskores::ErrorCode FindAllCellIds(const viskores::Vec3f& point,
+                                                   CellIdsType& cellIdVec) const
+  {
+    return this->FindAllCellsImpl(point, cellIdVec);
+  }
+
+private:
+  VISKORES_EXEC viskores::ErrorCode FindCellImpl(const FloatVec3& point,
+                                                 viskores::Id& cellId,
+                                                 LastCell& lastCell,
+                                                 FloatVec3* pCoords) const
+  {
+    viskores::Vec3f pc;
+    if ((lastCell.CellId >= 0) && (lastCell.CellId < this->CellSet.GetNumberOfElements()) &&
+        this->PointInCell(point, lastCell.CellId, pc) == viskores::ErrorCode::Success)
+    {
+      cellId = lastCell.CellId;
+      if (pCoords != nullptr)
+        *pCoords = pc;
+      return viskores::ErrorCode::Success;
+    }
+
+    if ((lastCell.LeafIdx >= 0) && (lastCell.LeafIdx < this->CellCount.GetNumberOfValues()) &&
+        this->PointInLeaf(point, lastCell.LeafIdx, cellId, pc) == viskores::ErrorCode::Success)
+    {
+      lastCell.CellId = cellId;
+      if (pCoords != nullptr)
+        *pCoords = pc;
+      return viskores::ErrorCode::Success;
+    }
+
+    viskores::Vec<viskores::Id, 1> cellIdVec = { -1 };
+    viskores::IdComponent nCells = 0;
+    if (pCoords != nullptr)
+    {
+      viskores::Vec<viskores::Vec3f, 1> pCoordsVec;
+      nCells = this->IterateLeaves(point, IterateMode::FindOne, cellIdVec, pCoordsVec, lastCell);
+      if (nCells == 1)
+        *pCoords = pCoordsVec[0];
+    }
+    else
+    {
+      nCells = this->IterateLeavesCellIds(point, IterateMode::FindOne, cellIdVec, lastCell);
+    }
+
+    if (nCells == 0)
+    {
+      cellId = -1;
+      return viskores::ErrorCode::CellNotFound;
+    }
+
+    cellId = cellIdVec[0];
+    return viskores::ErrorCode::Success;
+  }
+
+  template <typename CellIdsType>
+  VISKORES_EXEC viskores::IdComponent InitializeAllCellIds(CellIdsType& cellIdVec) const
+  {
+    viskores::IdComponent n = cellIdVec.GetNumberOfComponents();
+    for (viskores::IdComponent i = 0; i < n; i++)
+      cellIdVec[i] = -1;
+    return n;
+  }
+
+  template <typename CellIdsType, typename ParametricCoordsVecType>
+  VISKORES_EXEC viskores::ErrorCode FindAllCellsImpl(const viskores::Vec3f& point,
+                                                     CellIdsType& cellIdVec,
+                                                     ParametricCoordsVecType& pCoordsVec) const
+  {
+    VISKORES_ASSERT(pCoordsVec.GetNumberOfComponents() == cellIdVec.GetNumberOfComponents());
+    auto writeHit =
+      WriteCellAndParametric<CellIdsType, ParametricCoordsVecType>{ cellIdVec, pCoordsVec };
+    return this->FindAllCellsImplCommon(point, cellIdVec, writeHit);
+  }
+
+  template <typename CellIdsType>
+  VISKORES_EXEC viskores::ErrorCode FindAllCellsImpl(const viskores::Vec3f& point,
+                                                     CellIdsType& cellIdVec) const
+  {
+    auto writeHit = WriteCellIdOnly<CellIdsType>{ cellIdVec };
+    return this->FindAllCellsImplCommon(point, cellIdVec, writeHit);
+  }
+
+  template <typename CellIdsType, typename WriteHitType>
+  VISKORES_EXEC viskores::ErrorCode FindAllCellsImplCommon(const viskores::Vec3f& point,
+                                                           CellIdsType& cellIdVec,
+                                                           WriteHitType& writeHit) const
+  {
+    viskores::IdComponent n = this->InitializeAllCellIds(cellIdVec);
     if (n == 0)
       return viskores::ErrorCode::Success;
 
-    for (viskores::IdComponent i = 0; i < n; i++)
-      cellIdVec[i] = -1;
-
     LastCell lastCell;
     viskores::IdComponent nCells =
-      this->IterateLeaves(point, IterateMode::FindAll, cellIdVec, pCoordsVec, lastCell);
+      this->IterateLeavesImpl(point, IterateMode::FindAll, cellIdVec, lastCell, writeHit);
     VISKORES_ASSERT(n == nCells);
     if (nCells == 0)
       return viskores::ErrorCode::CellNotFound;
 
     return viskores::ErrorCode::Success;
   }
-
-private:
   // Shared leaf traversal: modes are FindOne, CountAll, FindAll
   enum class IterateMode
   {
@@ -282,17 +352,43 @@ private:
   };
 
   template <typename CellIdVecType, typename ParametricCoordsVecType>
-  VISKORES_EXEC viskores::IdComponent IterateLeaves(const FloatVec3& point,
-                                                    const IterateMode& mode,
-                                                    CellIdVecType& cellIdVec,
-                                                    ParametricCoordsVecType& pCoordsVec,
-                                                    LastCell& lastCell) const
+  struct WriteCellAndParametric
+  {
+    CellIdVecType& CellIds;
+    ParametricCoordsVecType& ParametricCoords;
+
+    VISKORES_EXEC void operator()(viskores::IdComponent idx,
+                                  viskores::Id cellId,
+                                  const viskores::Vec3f& pc)
+    {
+      this->CellIds[idx] = cellId;
+      this->ParametricCoords[idx] = pc;
+    }
+  };
+
+  template <typename CellIdVecType>
+  struct WriteCellIdOnly
+  {
+    CellIdVecType& CellIds;
+
+    VISKORES_EXEC void operator()(viskores::IdComponent idx,
+                                  viskores::Id cellId,
+                                  const viskores::Vec3f&)
+    {
+      this->CellIds[idx] = cellId;
+    }
+  };
+
+  template <typename CellIdVecType, typename WriteHitType>
+  VISKORES_EXEC viskores::IdComponent IterateLeavesImpl(const FloatVec3& point,
+                                                        const IterateMode& mode,
+                                                        CellIdVecType& cellIdVec,
+                                                        LastCell& lastCell,
+                                                        WriteHitType& writeHit) const
   {
     using namespace viskores::internal::cl_uniform_bins;
 
     viskores::IdComponent n = cellIdVec.GetNumberOfComponents();
-    VISKORES_ASSERT(pCoordsVec.GetNumberOfComponents() == n);
-
     lastCell.CellId = -1;
     lastCell.LeafIdx = -1;
     viskores::IdComponent cellCnt = 0;
@@ -330,18 +426,40 @@ private:
           lastCell.CellId = cellId;
           lastCell.LeafIdx = leafIdx;
           if (mode != IterateMode::CountAll)
-          {
-            cellIdVec[cellCnt] = cellId;
-            pCoordsVec[cellCnt] = pc;
-          }
+            writeHit(cellCnt, cellId, pc);
+
           cellCnt++;
-          if (mode == IterateMode::FindOne)
+          if (mode == IterateMode::FindOne || (mode == IterateMode::FindAll && cellCnt == n))
             break;
         }
       }
     }
 
-    return static_cast<viskores::Id>(cellCnt);
+    return cellCnt;
+  }
+
+  template <typename CellIdVecType, typename ParametricCoordsVecType>
+  VISKORES_EXEC viskores::IdComponent IterateLeaves(const FloatVec3& point,
+                                                    const IterateMode& mode,
+                                                    CellIdVecType& cellIdVec,
+                                                    ParametricCoordsVecType& pCoordsVec,
+                                                    LastCell& lastCell) const
+  {
+    viskores::IdComponent n = cellIdVec.GetNumberOfComponents();
+    VISKORES_ASSERT(pCoordsVec.GetNumberOfComponents() == n);
+    auto writeHit =
+      WriteCellAndParametric<CellIdVecType, ParametricCoordsVecType>{ cellIdVec, pCoordsVec };
+    return this->IterateLeavesImpl(point, mode, cellIdVec, lastCell, writeHit);
+  }
+
+  template <typename CellIdVecType>
+  VISKORES_EXEC viskores::IdComponent IterateLeavesCellIds(const FloatVec3& point,
+                                                           const IterateMode& mode,
+                                                           CellIdVecType& cellIdVec,
+                                                           LastCell& lastCell) const
+  {
+    auto writeHit = WriteCellIdOnly<CellIdVecType>{ cellIdVec };
+    return this->IterateLeavesImpl(point, mode, cellIdVec, lastCell, writeHit);
   }
 
   VISKORES_EXEC viskores::ErrorCode PointInCell(const viskores::Vec3f& point,

--- a/viskores/exec/CellLocatorUniformBins.h
+++ b/viskores/exec/CellLocatorUniformBins.h
@@ -95,13 +95,30 @@ public:
     viskores::Id BinIdx = -1;
   };
 
+  /// @brief Locate the id of the cell containing the provided point.
+  ///
+  /// This method returns the same cell id as `FindCell()` without requiring
+  /// the caller to provide parametric coordinates.
+  VISKORES_EXEC viskores::ErrorCode FindCellId(const viskores::Vec3f& point,
+                                               viskores::Id& cellId) const
+  {
+    return this->FindCellImpl(point, cellId, nullptr, nullptr);
+  }
+
+  /// @copydoc viskores::exec::CellLocatorUniformGrid::FindCellId
+  VISKORES_EXEC viskores::ErrorCode FindCellId(const viskores::Vec3f& point,
+                                               viskores::Id& cellId,
+                                               LastCell& lastCell) const
+  {
+    return this->FindCellImpl(point, cellId, nullptr, &lastCell);
+  }
+
   /// @copydoc viskores::exec::CellLocatorUniformGrid::FindCell
   VISKORES_EXEC viskores::ErrorCode FindCell(const viskores::Vec3f& point,
                                              viskores::Id& cellId,
                                              viskores::Vec3f& pCoords) const
   {
-    LastCell lastCell;
-    return this->FindCell(point, cellId, pCoords, lastCell);
+    return this->FindCellImpl(point, cellId, &pCoords, nullptr);
   }
 
   /// @copydoc viskores::exec::CellLocatorUniformGrid::FindCell
@@ -110,50 +127,7 @@ public:
                                              viskores::Vec3f& pCoords,
                                              LastCell& lastCell) const
   {
-    viskores::Id binIdx = this->FindBinIdx(point);
-    if (binIdx == -1)
-    {
-      lastCell.CellId = -1;
-      lastCell.BinIdx = -1;
-      cellId = -1;
-      return viskores::ErrorCode::CellNotFound;
-    }
-    //See if the point is still in the same bin.
-    else if (binIdx == lastCell.BinIdx && this->LastCellValid(lastCell))
-    {
-      viskores::Vec3f pc;
-      //Check the last cell first.
-      if (this->PointInCell(point, lastCell.CellId, pc))
-      {
-        pCoords = pc;
-        cellId = lastCell.CellId;
-        return viskores::ErrorCode::Success;
-      }
-      //Otherwise, check cells in the bin, but skip lastCell.CellId
-      else if (this->PointInBin(point, lastCell.BinIdx, cellId, pc, lastCell.CellId))
-      {
-        pCoords = pc;
-        return viskores::ErrorCode::Success;
-      }
-    }
-
-    //if cell still not found, drop to the general find cell below.
-    //LastCell not initialized, or not in the same bin: do a full test.
-    //Since already computed the binIdx, re-use it.
-    viskores::Vec<viskores::Id, 1> cellIdVec = { -1 };
-    viskores::Vec<viskores::Vec3f, 1> pCoordsVec;
-    auto nCells = this->IterateBin(point, IterateMode::FindOne, cellIdVec, pCoordsVec, binIdx);
-    if (nCells == 1)
-    {
-      cellId = cellIdVec[0];
-      pCoords = pCoordsVec[0];
-      lastCell.BinIdx = binIdx;
-      lastCell.CellId = cellId;
-      return viskores::ErrorCode::Success;
-    }
-
-    cellId = -1;
-    return viskores::ErrorCode::CellNotFound;
+    return this->FindCellImpl(point, cellId, &pCoords, &lastCell);
   }
 
   /// @copydoc viskores::exec::CellLocatorUniformGrid::CountAllCells
@@ -163,9 +137,8 @@ public:
     if (binIdx == -1)
       return 0;
 
-    viskores::Vec<viskores::Vec3f, 1> pcVec;
     viskores::Vec<viskores::Id, 1> cellIdVec = { -1 };
-    return this->IterateBin(point, IterateMode::CountAll, cellIdVec, pcVec, binIdx);
+    return this->IterateBinCellIds(point, IterateMode::CountAll, cellIdVec, binIdx);
   }
 
   /// @copydoc viskores::exec::CellLocatorUniformGrid::FindAllCells
@@ -174,27 +147,18 @@ public:
                                                  CellIdsType& cellIdVec,
                                                  ParametricCoordsVecType& pCoordsVec) const
   {
-    viskores::IdComponent n = cellIdVec.GetNumberOfComponents();
-    if (n == 0)
-      return viskores::ErrorCode::Success;
+    return this->FindAllCellsImpl(point, cellIdVec, pCoordsVec);
+  }
 
-    for (viskores::IdComponent i = 0; i < n; i++)
-      cellIdVec[i] = -1;
-
-    VISKORES_ASSERT(n == pCoordsVec.GetNumberOfComponents());
-
-    viskores::Id binIdx = this->FindBinIdx(point);
-    if (binIdx == -1)
-      return viskores::ErrorCode::CellNotFound;
-
-    viskores::IdComponent cnt =
-      this->IterateBin(point, IterateMode::FindAll, cellIdVec, pCoordsVec, binIdx);
-    if (cnt < 0)
-      return viskores::ErrorCode::InvalidNumberOfIndices;
-    else if (cnt == 0)
-      return viskores::ErrorCode::CellNotFound;
-    else
-      return viskores::ErrorCode::Success;
+  /// @brief Locate all cell ids containing the provided point.
+  ///
+  /// This method returns the same cell ids as `FindAllCells()` without
+  /// requiring parametric coordinates.
+  template <typename CellIdsType>
+  VISKORES_EXEC viskores::ErrorCode FindAllCellIds(const viskores::Vec3f& point,
+                                                   CellIdsType& cellIdVec) const
+  {
+    return this->FindAllCellsImpl(point, cellIdVec);
   }
 
   VISKORES_DEPRECATED(1.6, "Locators are no longer pointers. Use . operator.")
@@ -228,6 +192,72 @@ private:
     return binIdx;
   }
 
+  VISKORES_EXEC viskores::ErrorCode FindCellImpl(const viskores::Vec3f& point,
+                                                 viskores::Id& cellId,
+                                                 viskores::Vec3f* pCoords,
+                                                 LastCell* lastCell) const
+  {
+    viskores::Id binIdx = this->FindBinIdx(point);
+    if (binIdx == -1)
+    {
+      if (lastCell != nullptr)
+      {
+        lastCell->CellId = -1;
+        lastCell->BinIdx = -1;
+      }
+      cellId = -1;
+      return viskores::ErrorCode::CellNotFound;
+    }
+
+    if ((lastCell != nullptr) && (binIdx == lastCell->BinIdx) && this->LastCellValid(*lastCell))
+    {
+      if (this->PointInCell(point, lastCell->CellId, pCoords))
+      {
+        cellId = lastCell->CellId;
+        return viskores::ErrorCode::Success;
+      }
+
+      if (this->PointInBin(point, lastCell->BinIdx, cellId, pCoords, lastCell->CellId))
+      {
+        lastCell->CellId = cellId;
+        return viskores::ErrorCode::Success;
+      }
+    }
+
+    viskores::Vec<viskores::Id, 1> cellIdVec = { -1 };
+    viskores::IdComponent nCells = 0;
+    if (pCoords != nullptr)
+    {
+      viskores::Vec<viskores::Vec3f, 1> pCoordsVec;
+      nCells = this->IterateBin(point, IterateMode::FindOne, cellIdVec, pCoordsVec, binIdx);
+      if (nCells == 1)
+        *pCoords = pCoordsVec[0];
+    }
+    else
+    {
+      nCells = this->IterateBinCellIds(point, IterateMode::FindOne, cellIdVec, binIdx);
+    }
+
+    if (nCells == 1)
+    {
+      cellId = cellIdVec[0];
+      if (lastCell != nullptr)
+      {
+        lastCell->BinIdx = binIdx;
+        lastCell->CellId = cellId;
+      }
+      return viskores::ErrorCode::Success;
+    }
+
+    if (lastCell != nullptr)
+    {
+      lastCell->CellId = -1;
+      lastCell->BinIdx = -1;
+    }
+    cellId = -1;
+    return viskores::ErrorCode::CellNotFound;
+  }
+
   VISKORES_EXEC bool LastCellValid(const LastCell& lastCell) const
   {
     return lastCell.BinIdx >= 0 && lastCell.BinIdx < this->CellIds.GetNumberOfValues() &&
@@ -246,6 +276,72 @@ private:
     return true;
   }
 
+  template <typename CellIdsType>
+  VISKORES_EXEC viskores::IdComponent InitializeAllCellIds(CellIdsType& cellIdVec) const
+  {
+    viskores::IdComponent n = cellIdVec.GetNumberOfComponents();
+    for (viskores::IdComponent i = 0; i < n; ++i)
+      cellIdVec[i] = -1;
+    return n;
+  }
+
+  template <typename CellIdVecType, typename ParametricCoordsVecType>
+  struct WriteCellAndParametric
+  {
+    CellIdVecType& CellIds;
+    ParametricCoordsVecType& ParametricCoords;
+
+    VISKORES_EXEC void operator()(viskores::IdComponent idx,
+                                  viskores::Id cellId,
+                                  const viskores::Vec3f& pc)
+    {
+      this->CellIds[idx] = cellId;
+      this->ParametricCoords[idx] = pc;
+    }
+  };
+
+  template <typename CellIdVecType>
+  struct WriteCellIdOnly
+  {
+    CellIdVecType& CellIds;
+
+    VISKORES_EXEC void operator()(viskores::IdComponent idx,
+                                  viskores::Id cellId,
+                                  const viskores::Vec3f&)
+    {
+      this->CellIds[idx] = cellId;
+    }
+  };
+
+  template <typename CellIdVecType, typename WriteHitType>
+  VISKORES_EXEC viskores::IdComponent IterateBinImpl(const viskores::Vec3f& point,
+                                                     const IterateMode& mode,
+                                                     CellIdVecType& cellIdVec,
+                                                     viskores::Id binIdx,
+                                                     WriteHitType& writeHit) const
+  {
+    viskores::IdComponent n = cellIdVec.GetNumberOfComponents();
+    auto binIds = this->CellIds.Get(binIdx);
+
+    viskores::Vec3f pc;
+    viskores::IdComponent cellCount = 0;
+    for (viskores::IdComponent i = 0; i < binIds.GetNumberOfComponents(); i++)
+    {
+      viskores::Id cid = binIds[i];
+      if (this->PointInCell(point, cid, &pc))
+      {
+        if (mode != IterateMode::CountAll)
+          writeHit(cellCount, cid, pc);
+
+        cellCount++;
+        if (mode == IterateMode::FindOne || (mode == IterateMode::FindAll && cellCount == n))
+          break;
+      }
+    }
+
+    return cellCount;
+  }
+
   template <typename CellIdVecType, typename ParametricCoordsVecType>
   VISKORES_EXEC viskores::IdComponent IterateBin(const viskores::Vec3f& point,
                                                  const IterateMode& mode,
@@ -255,28 +351,58 @@ private:
   {
     viskores::IdComponent n = cellIdVec.GetNumberOfComponents();
     VISKORES_ASSERT(pCoordsVec.GetNumberOfComponents() == n);
+    auto writeHit =
+      WriteCellAndParametric<CellIdVecType, ParametricCoordsVecType>{ cellIdVec, pCoordsVec };
+    return this->IterateBinImpl(point, mode, cellIdVec, binIdx, writeHit);
+  }
 
-    auto binIds = this->CellIds.Get(binIdx);
+  template <typename CellIdsType, typename ParametricCoordsVecType>
+  VISKORES_EXEC viskores::ErrorCode FindAllCellsImpl(const viskores::Vec3f& point,
+                                                     CellIdsType& cellIdVec,
+                                                     ParametricCoordsVecType& pCoordsVec) const
+  {
+    if (pCoordsVec.GetNumberOfComponents() != cellIdVec.GetNumberOfComponents())
+      return viskores::ErrorCode::InvalidNumberOfIndices;
 
-    viskores::Vec3f pc;
-    viskores::IdComponent cellCount = 0;
-    for (viskores::IdComponent i = 0; i < binIds.GetNumberOfComponents(); i++)
-    {
-      viskores::Id cid = binIds[i];
-      if (this->PointInCell(point, cid, pc))
-      {
-        if (mode != IterateMode::CountAll)
-        {
-          cellIdVec[cellCount] = cid;
-          pCoordsVec[cellCount] = pc;
-        }
-        cellCount++;
-        if (mode == IterateMode::FindOne || (mode == IterateMode::FindAll && cellCount == n))
-          break;
-      }
-    }
+    auto writeHit =
+      WriteCellAndParametric<CellIdsType, ParametricCoordsVecType>{ cellIdVec, pCoordsVec };
+    return this->FindAllCellsImplCommon(point, cellIdVec, writeHit);
+  }
 
-    return cellCount;
+  template <typename CellIdsType>
+  VISKORES_EXEC viskores::ErrorCode FindAllCellsImpl(const viskores::Vec3f& point,
+                                                     CellIdsType& cellIdVec) const
+  {
+    auto writeHit = WriteCellIdOnly<CellIdsType>{ cellIdVec };
+    return this->FindAllCellsImplCommon(point, cellIdVec, writeHit);
+  }
+
+  template <typename CellIdsType, typename WriteHitType>
+  VISKORES_EXEC viskores::ErrorCode FindAllCellsImplCommon(const viskores::Vec3f& point,
+                                                           CellIdsType& cellIdVec,
+                                                           WriteHitType& writeHit) const
+  {
+    viskores::IdComponent n = this->InitializeAllCellIds(cellIdVec);
+    if (n == 0)
+      return viskores::ErrorCode::Success;
+
+    viskores::Id binIdx = this->FindBinIdx(point);
+    if (binIdx == -1)
+      return viskores::ErrorCode::CellNotFound;
+
+    viskores::IdComponent count =
+      this->IterateBinImpl(point, IterateMode::FindAll, cellIdVec, binIdx, writeHit);
+    return (count > 0) ? viskores::ErrorCode::Success : viskores::ErrorCode::CellNotFound;
+  }
+
+  template <typename CellIdVecType>
+  VISKORES_EXEC viskores::IdComponent IterateBinCellIds(const viskores::Vec3f& point,
+                                                        const IterateMode& mode,
+                                                        CellIdVecType& cellIdVec,
+                                                        viskores::Id binIdx) const
+  {
+    auto writeHit = WriteCellIdOnly<CellIdVecType>{ cellIdVec };
+    return this->IterateBinImpl(point, mode, cellIdVec, binIdx, writeHit);
   }
 
   template <typename PointsVecType>
@@ -320,19 +446,16 @@ private:
   bool PointInBin(const viskores::Vec3f& point,
                   const viskores::Id& binIdx,
                   viskores::Id& cellId,
-                  viskores::Vec3f& pCoords,
+                  viskores::Vec3f* pCoords,
                   const viskores::Id& skipCellId = -1) const
   {
     auto binIds = this->CellIds.Get(binIdx);
-
-    viskores::Vec3f pc;
     for (viskores::IdComponent i = 0; i < binIds.GetNumberOfComponents(); i++)
     {
       viskores::Id cid = binIds[i];
-      if (cid != skipCellId && this->PointInCell(point, cid, pc))
+      if (cid != skipCellId && this->PointInCell(point, cid, pCoords))
       {
         cellId = cid;
-        pCoords = pc;
         return true;
       }
     }
@@ -343,7 +466,7 @@ private:
   VISKORES_EXEC
   bool PointInCell(const viskores::Vec3f& point,
                    const viskores::Id& cid,
-                   viskores::Vec3f& pCoords) const
+                   viskores::Vec3f* pCoords) const
   {
     auto indices = this->CellSet.GetIndices(cid);
     auto pts = viskores::make_VecFromPortalPermute(&indices, this->Coords);
@@ -352,7 +475,8 @@ private:
     auto status = this->PointInsideCell(point, this->CellSet.GetCellShape(cid), pts, pc, inside);
     if (status == viskores::ErrorCode::Success && inside)
     {
-      pCoords = pc;
+      if (pCoords != nullptr)
+        *pCoords = pc;
       return true;
     }
 

--- a/viskores/exec/CellLocatorUniformGrid.h
+++ b/viskores/exec/CellLocatorUniformGrid.h
@@ -81,6 +81,25 @@ public:
   {
   };
 
+  /// @brief Locate the id of the cell containing the provided point.
+  ///
+  /// This method returns the same cell id as `FindCell()` without requiring
+  /// the caller to provide parametric coordinates.
+  VISKORES_EXEC viskores::ErrorCode FindCellId(const viskores::Vec3f& point,
+                                               viskores::Id& cellId,
+                                               LastCell& lastCell) const
+  {
+    (void)lastCell;
+    return this->FindCellId(point, cellId);
+  }
+
+  /// @copydoc FindCellId
+  VISKORES_EXEC viskores::ErrorCode FindCellId(const viskores::Vec3f& point,
+                                               viskores::Id& cellId) const
+  {
+    return this->FindCellImpl(point, cellId, nullptr);
+  }
+
   /// @brief Locate the cell containing the provided point.
   ///
   /// Given the point coordinate `point`, this method determines which cell
@@ -112,26 +131,7 @@ public:
                                              viskores::Id& cellId,
                                              viskores::Vec3f& parametric) const
   {
-    if (!this->IsInside(point))
-    {
-      cellId = -1;
-      return viskores::ErrorCode::CellNotFound;
-    }
-    // Get the Cell Id from the point.
-    viskores::Id3 logicalCell(0, 0, 0);
-
-    viskores::Vec3f temp;
-    temp = point - this->Origin;
-    temp = temp * this->InvSpacing;
-
-    //make sure that if we border the upper edge, we sample the correct cell
-    logicalCell = viskores::Min(viskores::Id3(temp), this->MaxCellIds);
-
-    cellId =
-      (logicalCell[2] * this->CellDims[1] + logicalCell[1]) * this->CellDims[0] + logicalCell[0];
-    parametric = temp - logicalCell;
-
-    return viskores::ErrorCode::Success;
+    return this->FindCellImpl(point, cellId, &parametric);
   }
 
   /// @brief Count the cells containing the provided point.
@@ -141,8 +141,7 @@ public:
   VISKORES_EXEC viskores::IdComponent CountAllCells(const viskores::Vec3f& point) const
   {
     viskores::Id cellId;
-    viskores::Vec3f pCoords;
-    if (this->FindCell(point, cellId, pCoords) == viskores::ErrorCode::Success)
+    if (this->FindCellId(point, cellId) == viskores::ErrorCode::Success)
       return 1;
     return 0;
   }
@@ -174,7 +173,49 @@ public:
     return this->FindCell(point, cellIdVec[0], pCoordsVec[0]);
   }
 
+  /// @brief Locate all cell ids containing the provided point.
+  ///
+  /// This method returns the same cell ids as `FindAllCells()` without
+  /// requiring parametric coordinates.
+  template <typename CellIdsType>
+  VISKORES_EXEC viskores::ErrorCode FindAllCellIds(const viskores::Vec3f& point,
+                                                   CellIdsType& cellIdVec) const
+  {
+    viskores::IdComponent n = cellIdVec.GetNumberOfComponents();
+    if (n == 0)
+      return viskores::ErrorCode::Success;
+
+    for (viskores::IdComponent i = 0; i < n; i++)
+      cellIdVec[i] = -1;
+
+    viskores::Id cellId = -1;
+    viskores::ErrorCode status = this->FindCellId(point, cellId);
+    cellIdVec[0] = cellId;
+    return status;
+  }
+
 private:
+  VISKORES_EXEC viskores::ErrorCode FindCellImpl(const viskores::Vec3f& point,
+                                                 viskores::Id& cellId,
+                                                 viskores::Vec3f* parametric) const
+  {
+    if (!this->IsInside(point))
+    {
+      cellId = -1;
+      return viskores::ErrorCode::CellNotFound;
+    }
+
+    viskores::Vec3f temp = (point - this->Origin) * this->InvSpacing;
+    viskores::Id3 logicalCell = viskores::Min(viskores::Id3(temp), this->MaxCellIds);
+    cellId =
+      (logicalCell[2] * this->CellDims[1] + logicalCell[1]) * this->CellDims[0] + logicalCell[0];
+
+    if (parametric != nullptr)
+      *parametric = temp - logicalCell;
+
+    return viskores::ErrorCode::Success;
+  }
+
   viskores::Id3 CellDims;
   viskores::Id3 MaxCellIds;
   viskores::Vec3f Origin;

--- a/viskores/worklet/testing/UnitTestBoundingIntervalHierarchy.cxx
+++ b/viskores/worklet/testing/UnitTestBoundingIntervalHierarchy.cxx
@@ -62,8 +62,11 @@ struct BoundingIntervalHierarchyTester : public viskores::worklet::WorkletMapFie
   {
     viskores::Vec3f parametric;
     viskores::Id cellId = -1;
+    viskores::Id cellIdOnly = -1;
     bih.FindCell(point, cellId, parametric);
-    return (1 - static_cast<viskores::IdComponent>(expectedId == cellId));
+    bih.FindCellId(point, cellIdOnly);
+    return (1 -
+            static_cast<viskores::IdComponent>((expectedId == cellId) && (cellId == cellIdOnly)));
   }
 }; // struct BoundingIntervalHierarchyTester
 


### PR DESCRIPTION
Add cell-id-only locator APIs to cell locator classes.

Refactored CellLocatorTwoLevel and CellLocatorUniformBins to share common traversal logic via a single implementation plus writer policies (cellId+pcoords vs cellId-only), with behavior preserved.
