### PR TITLE
Support skipping tests

### DIFF
--- a/CMake/testing/ViskoresTestWrappers.cmake
+++ b/CMake/testing/ViskoresTestWrappers.cmake
@@ -341,7 +341,8 @@ viskores_unit_tests but not in its test dependencies. Add test dependencies to \
             LABELS "${upper_backend};${Viskores_UT_LABEL}"
             ${extra_args}
             RUN_SERIAL ${run_serial}
-            FAIL_REGULAR_EXPRESSION "runtime error")
+            FAIL_REGULAR_EXPRESSION "runtime error"
+            SKIP_RETURN_CODE 255)
         endif() # Viskores_ENABLE_MPI
         if ((NOT Viskores_ENABLE_MPI) OR Viskores_ENABLE_DIY_NOMPI)
           add_test(NAME ${tname}${upper_backend}_nompi
@@ -352,7 +353,8 @@ viskores_unit_tests but not in its test dependencies. Add test dependencies to \
             LABELS "${upper_backend};${Viskores_UT_LABEL}"
             ${extra_args}
             RUN_SERIAL ${run_serial}
-            FAIL_REGULAR_EXPRESSION "runtime error")
+            FAIL_REGULAR_EXPRESSION "runtime error"
+            SKIP_RETURN_CODE 255)
 
         endif() # Viskores_ENABLE_DIY_NOMPI
       else() # Viskores_UT_MPI
@@ -364,7 +366,8 @@ viskores_unit_tests but not in its test dependencies. Add test dependencies to \
             LABELS "${upper_backend};${Viskores_UT_LABEL}"
             ${extra_args}
             RUN_SERIAL ${run_serial}
-            FAIL_REGULAR_EXPRESSION "runtime error")
+            FAIL_REGULAR_EXPRESSION "runtime error"
+            SKIP_RETURN_CODE 255)
       endif() # Viskores_UT_MPI
     endforeach()
     unset(extra_args)

--- a/docs/changelog/test-skip.md
+++ b/docs/changelog/test-skip.md
@@ -1,0 +1,7 @@
+## Support skipping tests
+
+Viskores tests can now skip themselves. Sometimes it is not possible to
+determine whether a particular test is supported until the test is run and the
+system can be introspected. In this case, the test can now return by invoking
+the `VISKORES_TEST_SKIP`. In this case, the test will immediately end, and CTest
+will report that the test was skipped rather than pass or fail.

--- a/viskores/interop/anari/testing/UnitTestANARIMapperGlyphs.cxx
+++ b/viskores/interop/anari/testing/UnitTestANARIMapperGlyphs.cxx
@@ -38,6 +38,24 @@ void RenderTests()
 
   auto d = loadANARIDevice();
 
+  // Check for the KHR_GEOMETRY_CONE extension.
+
+  const char** extensions = nullptr;
+  anariGetProperty(d, d, "extension", ANARI_STRING_LIST, &extensions, sizeof(char**), ANARI_WAIT);
+  bool conesSupported = false;
+  for (int i = 0; extensions[i] != nullptr; ++i)
+  {
+    if (extensions[i] == std::string("KHR_GEOMETRY_CONE"))
+    {
+      conesSupported = true;
+      break;
+    }
+  }
+  if (!conesSupported)
+  {
+    VISKORES_TEST_SKIP("ANARI KHR_GEOMETRY_CONE extension not supported by ANARI device.");
+  }
+
   // Create Viskores datasets /////////////////////////////////////////////////////
 
   viskores::source::Tangle source;

--- a/viskores/testing/Testing.h
+++ b/viskores/testing/Testing.h
@@ -104,6 +104,14 @@
 #define VISKORES_TEST_FAIL(...) \
   ::viskores::testing::Testing::TestFail(__FILE__, __LINE__, __func__, __VA_ARGS__)
 
+/// \def VISKORES_TEST_SKIP(messages...)
+///
+/// Causes the test to quit with a code that is reported as skipped. Can be used when
+/// at runtime it is determined that the functionality is not supported.
+
+#define VISKORES_TEST_SKIP(...) \
+  ::viskores::testing::Testing::TestSkip(__FILE__, __LINE__, __func__, __VA_ARGS__)
+
 // We could, conceivably, use CUDA or Kokkos specific print statements here.
 // But we cannot use std::stringstream on device, so for now, we'll just accept
 // that on CUDA and Kokkos we print less actionable information.
@@ -407,14 +415,14 @@ struct InternalTryCellShape<viskores::NUMBER_OF_CELL_SHAPES>
 struct VISKORES_CONT_TESTING_EXPORT Testing
 {
 public:
-  class TestFailure
+  class TestException
   {
   public:
     template <typename... Ts>
-    VISKORES_CONT TestFailure(const std::string& file,
-                              viskores::Id line,
-                              const char* func,
-                              Ts&&... messages)
+    VISKORES_CONT TestException(const std::string& file,
+                                viskores::Id line,
+                                const char* func,
+                                Ts&&... messages)
       : File(file)
       , Line(line)
       , Func(func)
@@ -472,6 +480,32 @@ public:
     std::string Message;
   };
 
+  class TestFailure : public TestException
+  {
+  public:
+    template <typename... Ts>
+    VISKORES_CONT TestFailure(const std::string& file,
+                              viskores::Id line,
+                              const char* func,
+                              Ts&&... messages)
+      : TestException(file, line, func, messages...)
+    {
+    }
+  };
+
+  class TestSkipping : public TestException
+  {
+  public:
+    template <typename... Ts>
+    VISKORES_CONT TestSkipping(const std::string& file,
+                               viskores::Id line,
+                               const char* func,
+                               Ts&&... messages)
+      : TestException(file, line, func, messages...)
+    {
+    }
+  };
+
   template <typename... Ts>
   static VISKORES_CONT void Assert(const std::string& conditionString,
                                    const std::string& file,
@@ -518,6 +552,15 @@ public:
     throw TestFailure(file, line, func, std::forward<Ts>(messages)...);
   }
 
+  template <typename... Ts>
+  static VISKORES_CONT void TestSkip(const std::string& file,
+                                     viskores::Id line,
+                                     const char* func,
+                                     Ts&&... messages)
+  {
+    throw TestSkipping(file, line, func, std::forward<Ts>(messages)...);
+  }
+
   static VISKORES_CONT std::string GetTestDataBasePath();
 
   static VISKORES_CONT std::string DataPath(const std::string& filename);
@@ -542,6 +585,12 @@ public:
       std::cerr << "Error at " << error.GetFile() << ":" << error.GetLine() << ":"
                 << error.GetFunction() << "\n\t" << error.GetMessage() << "\n";
       return 1;
+    }
+    catch (viskores::testing::Testing::TestSkipping const& error)
+    {
+      std::cerr << "Skipping test at " << error.GetFile() << ":" << error.GetLine() << ":"
+                << error.GetFunction() << "\n\t" << error.GetMessage() << "\n";
+      return 255;
     }
     catch (viskores::cont::Error const& error)
     {


### PR DESCRIPTION
Viskores tests can now skip themselves. Sometimes it is not possible to determine whether a particular test is supported until the test is run and the system can be introspected. In this case, the test can now return by invoking the `VISKORES_TEST_SKIP` macro. In this case, the test will immediately end, and CTest will report that the test was skipped rather than pass or fail.