### PR TITLE
Fix problem with ANARI bounds update

### DIFF
--- a/viskores/rendering/anari-device/scene/World.cpp
+++ b/viskores/rendering/anari-device/scene/World.cpp
@@ -40,8 +40,9 @@ bool World::getProperty(const std::string_view& name,
 {
   if (name == "bounds" && type == ANARI_FLOAT32_BOX3)
   {
-    viskores::Vec3f_32 anariBounds[] = { viskores::Vec3f_32(this->m_bounds.MinCorner()),
-                                         viskores::Vec3f_32(this->m_bounds.MaxCorner()) };
+    viskores::Bounds bounds = this->bounds();
+    viskores::Vec3f_32 anariBounds[] = { viskores::Vec3f_32(bounds.MinCorner()),
+                                         viskores::Vec3f_32(bounds.MaxCorner()) };
     std::memcpy(ptr, &anariBounds, sizeof(anariBounds));
     return true;
   }
@@ -115,8 +116,15 @@ void World::finalize()
     m_instanceData->addChangeObserver(this);
   if (m_zeroSurfaceData)
     m_zeroSurfaceData->addChangeObserver(this);
+}
 
-  this->m_bounds = viskores::Bounds{};
+viskores::Bounds World::bounds() const
+{
+  // It would be better to compute the bounds in `finalize` once so that it can
+  // be reused. However, `finalize` is not refreshed if groups in the instance
+  // are updated (thus potentially changing the bounds) because the world object
+  // is not modified directly.
+  viskores::Bounds bounds;
   for (auto&& instance : this->instances())
   {
     if (!instance->isValid())
@@ -131,7 +139,7 @@ void World::finalize()
         reportMessage(ANARI_SEVERITY_DEBUG, "skip bounds check on invalid surface");
         continue;
       }
-      this->m_bounds.Include(surface->bounds());
+      bounds.Include(surface->bounds());
     }
     for (auto&& volume : instance->group()->volumes())
     {
@@ -140,9 +148,11 @@ void World::finalize()
         reportMessage(ANARI_SEVERITY_DEBUG, "skip bounds check on invalid volume");
         continue;
       }
-      this->m_bounds.Include(volume->bounds());
+      bounds.Include(volume->bounds());
     }
   }
+
+  return bounds;
 }
 
 const std::vector<Instance*>& World::instances() const

--- a/viskores/rendering/anari-device/scene/World.h
+++ b/viskores/rendering/anari-device/scene/World.h
@@ -43,7 +43,7 @@ struct World : public Object
     return instanceFromRay(ray)->group()->surfaces()[ray.geomID];
   }
 
-  const viskores::Bounds& bounds() const { return this->m_bounds; }
+  viskores::Bounds bounds() const;
 
 private:
   helium::ChangeObserverPtr<ObjectArray> m_zeroSurfaceData;
@@ -55,8 +55,6 @@ private:
   bool m_addZeroInstance{ false };
   helium::IntrusivePtr<Group> m_zeroGroup;
   helium::IntrusivePtr<Instance> m_zeroInstance;
-
-  viskores::Bounds m_bounds;
 };
 
 } // namespace viskores_device


### PR DESCRIPTION
When a world was used to render multiple frames with changing geometry, the rendering could be wrong because the bounds were not updated. The bounds were previously updated on the finalize call of the world. However, because the world object is not necessarily modified directly when the bounds of its instances change, the update may not happen.