### PR TITLE
Make the raytracing camera self sufficient

### DIFF
--- a/benchmarking/BenchmarkRayTracing.cxx
+++ b/benchmarking/BenchmarkRayTracing.cxx
@@ -66,9 +66,8 @@ void BenchRayTracing(::benchmark::State& state)
   tracer.AddShapeIntersector(triIntersector);
 
   viskores::rendering::CanvasRayTracer canvas(1920, 1080);
-  viskores::rendering::raytracing::Camera rayCamera;
-  rayCamera.SetParameters(
-    camera, viskores::Int32(canvas.GetWidth()), viskores::Int32(canvas.GetHeight()));
+  viskores::rendering::raytracing::Camera rayCamera = camera.CreateRaytracingCamera(
+    viskores::Int32(canvas.GetWidth()), viskores::Int32(canvas.GetHeight()));
   viskores::rendering::raytracing::Ray<viskores::Float32> rays;
   rayCamera.CreateRays(rays, coords.GetBounds());
 

--- a/viskores/rendering/Camera.cxx
+++ b/viskores/rendering/Camera.cxx
@@ -23,88 +23,6 @@ namespace viskores
 namespace rendering
 {
 
-viskores::Matrix<viskores::Float32, 4, 4> Camera::Camera3DStruct::CreateViewMatrix() const
-{
-  return MatrixHelpers::ViewMatrix(this->Position, this->LookAt, this->ViewUp);
-}
-
-viskores::Matrix<viskores::Float32, 4, 4> Camera::Camera3DStruct::CreateProjectionMatrix(
-  viskores::Id width,
-  viskores::Id height,
-  viskores::Float32 nearPlane,
-  viskores::Float32 farPlane) const
-{
-  viskores::Matrix<viskores::Float32, 4, 4> matrix;
-  viskores::MatrixIdentity(matrix);
-
-  viskores::Float32 AspectRatio = viskores::Float32(width) / viskores::Float32(height);
-  viskores::Float32 fovRad = this->FieldOfView * viskores::Pi_180f();
-  fovRad = viskores::Tan(fovRad * 0.5f);
-  viskores::Float32 size = nearPlane * fovRad;
-  viskores::Float32 left = -size * AspectRatio;
-  viskores::Float32 right = size * AspectRatio;
-  viskores::Float32 bottom = -size;
-  viskores::Float32 top = size;
-
-  matrix(0, 0) = 2.f * nearPlane / (right - left);
-  matrix(1, 1) = 2.f * nearPlane / (top - bottom);
-  matrix(0, 2) = (right + left) / (right - left);
-  matrix(1, 2) = (top + bottom) / (top - bottom);
-  matrix(2, 2) = -(farPlane + nearPlane) / (farPlane - nearPlane);
-  matrix(3, 2) = -1.f;
-  matrix(2, 3) = -(2.f * farPlane * nearPlane) / (farPlane - nearPlane);
-  matrix(3, 3) = 0.f;
-
-  viskores::Matrix<viskores::Float32, 4, 4> T, Z;
-  T = viskores::Transform3DTranslate(this->XPan, this->YPan, 0.f);
-  Z = viskores::Transform3DScale(this->Zoom, this->Zoom, 1.f);
-  matrix = viskores::MatrixMultiply(Z, viskores::MatrixMultiply(T, matrix));
-  return matrix;
-}
-
-//---------------------------------------------------------------------------
-
-viskores::Matrix<viskores::Float32, 4, 4> Camera::Camera2DStruct::CreateViewMatrix() const
-{
-  viskores::Vec3f_32 lookAt(
-    (this->Left + this->Right) / 2.f, (this->Top + this->Bottom) / 2.f, 0.f);
-  viskores::Vec3f_32 position = lookAt;
-  position[2] = 1.f;
-  viskores::Vec3f_32 up(0, 1, 0);
-  viskores::Matrix<viskores::Float32, 4, 4> V = MatrixHelpers::ViewMatrix(position, lookAt, up);
-  viskores::Matrix<viskores::Float32, 4, 4> scaleMatrix =
-    MatrixHelpers::CreateScale(this->XScale, 1, 1);
-  V = viskores::MatrixMultiply(scaleMatrix, V);
-  return V;
-}
-
-viskores::Matrix<viskores::Float32, 4, 4> Camera::Camera2DStruct::CreateProjectionMatrix(
-  viskores::Float32 size,
-  viskores::Float32 znear,
-  viskores::Float32 zfar,
-  viskores::Float32 aspect) const
-{
-  viskores::Matrix<viskores::Float32, 4, 4> matrix(0.f);
-  viskores::Float32 left = -size / 2.f * aspect;
-  viskores::Float32 right = size / 2.f * aspect;
-  viskores::Float32 bottom = -size / 2.f;
-  viskores::Float32 top = size / 2.f;
-
-  matrix(0, 0) = 2.f / (right - left);
-  matrix(1, 1) = 2.f / (top - bottom);
-  matrix(2, 2) = -2.f / (zfar - znear);
-  matrix(0, 3) = -(right + left) / (right - left);
-  matrix(1, 3) = -(top + bottom) / (top - bottom);
-  matrix(2, 3) = -(zfar + znear) / (zfar - znear);
-  matrix(3, 3) = 1.f;
-
-  viskores::Matrix<viskores::Float32, 4, 4> T, Z;
-  T = viskores::Transform3DTranslate(this->XPan, this->YPan, 0.f);
-  Z = viskores::Transform3DScale(this->Zoom, this->Zoom, 1.f);
-  matrix = viskores::MatrixMultiply(Z, viskores::MatrixMultiply(T, matrix));
-  return matrix;
-}
-
 //---------------------------------------------------------------------------
 
 viskores::Matrix<viskores::Float32, 4, 4> Camera::CreateViewMatrix() const
@@ -443,5 +361,27 @@ void Camera::Print() const
     std::cout << vm[3][0] << " " << vm[3][1] << " " << vm[3][2] << " " << vm[3][3] << std::endl;
   }
 }
+
+viskores::rendering::raytracing::Camera Camera::CreateRaytracingCamera(viskores::Int32 width,
+                                                                       viskores::Int32 height) const
+{
+  viskores::rendering::raytracing::Camera rayCamera;
+  rayCamera.SetUp(this->GetViewUp());
+  rayCamera.SetLookAt(this->GetLookAt());
+  rayCamera.SetPosition(this->GetPosition());
+  rayCamera.SetPan(this->GetPan());
+  rayCamera.SetZoom(this->GetZoom());
+  rayCamera.SetClippingRange(this->NearPlane, this->FarPlane);
+  rayCamera.SetFieldOfView(this->GetFieldOfView());
+  rayCamera.SetHeight(height);
+  rayCamera.SetWidth(width);
+  rayCamera.SetIsOrthogonalProjection(this->GetMode() == Mode::TwoD);
+  rayCamera.SetCamera3D(this->Camera3D);
+  rayCamera.SetCamera2D(this->Camera2D);
+  rayCamera.SetViewport(
+    this->ViewportLeft, this->ViewportRight, this->ViewportBottom, this->ViewportTop);
+  return rayCamera;
+}
+
 }
 } // namespace viskores::rendering

--- a/viskores/rendering/Camera.h
+++ b/viskores/rendering/Camera.h
@@ -22,11 +22,11 @@
 
 #include <viskores/Bounds.h>
 #include <viskores/Math.h>
-#include <viskores/Matrix.h>
 #include <viskores/Range.h>
 #include <viskores/Transform3D.h>
 #include <viskores/VectorAnalysis.h>
 #include <viskores/rendering/MatrixHelpers.h>
+#include <viskores/rendering/raytracing/Camera.h>
 
 namespace viskores
 {
@@ -44,72 +44,6 @@ namespace rendering
 /// place the camera anywhere in 3D space.
 class VISKORES_RENDERING_EXPORT Camera
 {
-  struct Camera3DStruct
-  {
-  public:
-    VISKORES_CONT
-    Camera3DStruct()
-      : LookAt(0.0f, 0.0f, 0.0f)
-      , Position(0.0f, 0.0f, 1.0f)
-      , ViewUp(0.0f, 1.0f, 0.0f)
-      , FieldOfView(60.0f)
-      , XPan(0.0f)
-      , YPan(0.0f)
-      , Zoom(1.0f)
-    {
-    }
-
-    viskores::Matrix<viskores::Float32, 4, 4> CreateViewMatrix() const;
-
-    viskores::Matrix<viskores::Float32, 4, 4> CreateProjectionMatrix(
-      viskores::Id width,
-      viskores::Id height,
-      viskores::Float32 nearPlane,
-      viskores::Float32 farPlane) const;
-
-    viskores::Vec3f_32 LookAt;
-    viskores::Vec3f_32 Position;
-    viskores::Vec3f_32 ViewUp;
-    viskores::Float32 FieldOfView;
-    viskores::Float32 XPan;
-    viskores::Float32 YPan;
-    viskores::Float32 Zoom;
-  };
-
-  struct VISKORES_RENDERING_EXPORT Camera2DStruct
-  {
-  public:
-    VISKORES_CONT
-    Camera2DStruct()
-      : Left(-1.0f)
-      , Right(1.0f)
-      , Bottom(-1.0f)
-      , Top(1.0f)
-      , XScale(1.0f)
-      , XPan(0.0f)
-      , YPan(0.0f)
-      , Zoom(1.0f)
-    {
-    }
-
-    viskores::Matrix<viskores::Float32, 4, 4> CreateViewMatrix() const;
-
-    viskores::Matrix<viskores::Float32, 4, 4> CreateProjectionMatrix(
-      viskores::Float32 size,
-      viskores::Float32 znear,
-      viskores::Float32 zfar,
-      viskores::Float32 aspect) const;
-
-    viskores::Float32 Left;
-    viskores::Float32 Right;
-    viskores::Float32 Bottom;
-    viskores::Float32 Top;
-    viskores::Float32 XScale;
-    viskores::Float32 XPan;
-    viskores::Float32 YPan;
-    viskores::Float32 Zoom;
-  };
-
 public:
   enum struct Mode
   {
@@ -612,10 +546,13 @@ public:
   VISKORES_CONT
   void Print() const;
 
+  viskores::rendering::raytracing::Camera CreateRaytracingCamera(viskores::Int32 width,
+                                                                 viskores::Int32 height) const;
+
 private:
   Mode ModeType;
-  Camera3DStruct Camera3D;
-  Camera2DStruct Camera2D;
+  viskores::rendering::raytracing::Camera3DStruct Camera3D;
+  viskores::rendering::raytracing::Camera2DStruct Camera2D;
 
   viskores::Float32 NearPlane;
   viskores::Float32 FarPlane;

--- a/viskores/rendering/ConnectivityProxy.cxx
+++ b/viskores/rendering/ConnectivityProxy.cxx
@@ -237,13 +237,13 @@ public:
     {
       throw viskores::cont::ErrorBadValue("Conn Proxy: null canvas");
     }
-    viskores::rendering::raytracing::Camera rayCamera;
-    rayCamera.SetParameters(
-      camera, (viskores::Int32)canvas->GetWidth(), (viskores::Int32)canvas->GetHeight());
+    viskores::rendering::raytracing::Camera rayCamera = camera.CreateRaytracingCamera(
+      (viskores::Int32)canvas->GetWidth(), (viskores::Int32)canvas->GetHeight());
     viskores::rendering::raytracing::Ray<viskores::Float32> rays;
     rayCamera.CreateRays(rays, this->Dataset.GetCoordinateSystem(this->CoordinateName).GetBounds());
     rays.Buffers.at(0).InitConst(0.f);
-    raytracing::RayOperations::MapCanvasToRays(rays, camera, *canvas);
+    raytracing::RayOperations::MapCanvasToRays(
+      rays, camera.CreateRaytracingCamera(canvas->GetWidth(), canvas->GetHeight()), *canvas);
 
     if (this->Mode == RenderMode::Volume)
     {

--- a/viskores/rendering/MapperCylinder.cxx
+++ b/viskores/rendering/MapperCylinder.cxx
@@ -194,12 +194,12 @@ void MapperCylinder::RenderCellsImpl(const viskores::cont::UnknownCellSet& cells
   viskores::Int32 width = (viskores::Int32)this->Internals->Canvas->GetWidth();
   viskores::Int32 height = (viskores::Int32)this->Internals->Canvas->GetHeight();
 
-  this->Internals->RayCamera.SetParameters(camera, width, height);
+  this->Internals->RayCamera = camera.CreateRaytracingCamera(width, height);
 
   this->Internals->RayCamera.CreateRays(this->Internals->Rays, shapeBounds);
   this->Internals->Rays.Buffers.at(0).InitConst(0.f);
   raytracing::RayOperations::MapCanvasToRays(
-    this->Internals->Rays, camera, *this->Internals->Canvas);
+    this->Internals->Rays, camera.CreateRaytracingCamera(width, height), *this->Internals->Canvas);
 
   this->Internals->Tracer.SetField(scalarField, scalarRange);
   this->Internals->Tracer.GetCamera() = this->Internals->RayCamera;

--- a/viskores/rendering/MapperGlyphScalar.cxx
+++ b/viskores/rendering/MapperGlyphScalar.cxx
@@ -476,14 +476,14 @@ void MapperGlyphScalar::RenderCellsImpl(
     viskores::Int32 width = (viskores::Int32)this->Canvas->GetWidth();
     viskores::Int32 height = (viskores::Int32)this->Canvas->GetHeight();
 
-    viskores::rendering::raytracing::Camera RayCamera;
+    viskores::rendering::raytracing::Camera RayCamera =
+      camera.CreateRaytracingCamera(width, height);
     viskores::rendering::raytracing::Ray<viskores::Float32> Rays;
-
-    RayCamera.SetParameters(camera, width, height);
 
     RayCamera.CreateRays(Rays, shapeBounds);
     Rays.Buffers.at(0).InitConst(0.f);
-    raytracing::RayOperations::MapCanvasToRays(Rays, camera, *this->Canvas);
+    raytracing::RayOperations::MapCanvasToRays(
+      Rays, camera.CreateRaytracingCamera(width, height), *this->Canvas);
 
     tracer.SetField(processedField, scalarRange);
     tracer.GetCamera() = RayCamera;

--- a/viskores/rendering/MapperGlyphVector.cxx
+++ b/viskores/rendering/MapperGlyphVector.cxx
@@ -147,14 +147,13 @@ void MapperGlyphVector::RenderCellsImpl(
   viskores::Int32 width = (viskores::Int32)this->Canvas->GetWidth();
   viskores::Int32 height = (viskores::Int32)this->Canvas->GetHeight();
 
-  viskores::rendering::raytracing::Camera RayCamera;
+  viskores::rendering::raytracing::Camera RayCamera = camera.CreateRaytracingCamera(width, height);
   viskores::rendering::raytracing::Ray<viskores::Float32> Rays;
-
-  RayCamera.SetParameters(camera, width, height);
 
   RayCamera.CreateRays(Rays, shapeBounds);
   Rays.Buffers.at(0).InitConst(0.f);
-  raytracing::RayOperations::MapCanvasToRays(Rays, camera, *this->Canvas);
+  raytracing::RayOperations::MapCanvasToRays(
+    Rays, camera.CreateRaytracingCamera(width, height), *this->Canvas);
 
   auto magnitudeField = glyphExtractor.GetMagnitudeField();
   auto magnitudeFieldRange = magnitudeField.GetRange().ReadPortal().Get(0);

--- a/viskores/rendering/MapperPoint.cxx
+++ b/viskores/rendering/MapperPoint.cxx
@@ -225,12 +225,12 @@ void MapperPoint::RenderCellsImpl(const viskores::cont::UnknownCellSet& cellset,
   viskores::Int32 width = (viskores::Int32)this->Internals->Canvas->GetWidth();
   viskores::Int32 height = (viskores::Int32)this->Internals->Canvas->GetHeight();
 
-  this->Internals->RayCamera.SetParameters(camera, width, height);
+  this->Internals->RayCamera = camera.CreateRaytracingCamera(width, height);
 
   this->Internals->RayCamera.CreateRays(this->Internals->Rays, shapeBounds);
   this->Internals->Rays.Buffers.at(0).InitConst(0.f);
   raytracing::RayOperations::MapCanvasToRays(
-    this->Internals->Rays, camera, *this->Internals->Canvas);
+    this->Internals->Rays, camera.CreateRaytracingCamera(width, height), *this->Internals->Canvas);
 
   this->Internals->Tracer.SetField(scalarField, scalarRange);
   this->Internals->Tracer.GetCamera() = this->Internals->RayCamera;

--- a/viskores/rendering/MapperQuad.cxx
+++ b/viskores/rendering/MapperQuad.cxx
@@ -113,12 +113,12 @@ void MapperQuad::RenderCellsImpl(const viskores::cont::UnknownCellSet& cellset,
   viskores::Int32 width = (viskores::Int32)this->Internals->Canvas->GetWidth();
   viskores::Int32 height = (viskores::Int32)this->Internals->Canvas->GetHeight();
 
-  this->Internals->RayCamera.SetParameters(camera, width, height);
+  this->Internals->RayCamera = camera.CreateRaytracingCamera(width, height);
 
   this->Internals->RayCamera.CreateRays(this->Internals->Rays, shapeBounds);
   this->Internals->Rays.Buffers.at(0).InitConst(0.f);
   raytracing::RayOperations::MapCanvasToRays(
-    this->Internals->Rays, camera, *this->Internals->Canvas);
+    this->Internals->Rays, camera.CreateRaytracingCamera(width, height), *this->Internals->Canvas);
 
   this->Internals->Tracer.GetCamera() = this->Internals->RayCamera;
   this->Internals->Tracer.SetField(scalarField, scalarRange);

--- a/viskores/rendering/MapperRayTracer.cxx
+++ b/viskores/rendering/MapperRayTracer.cxx
@@ -122,13 +122,13 @@ void MapperRayTracer::RenderCellsImpl(const viskores::cont::UnknownCellSet& cell
   viskores::Int32 width = (viskores::Int32)this->Internals->Canvas->GetWidth();
   viskores::Int32 height = (viskores::Int32)this->Internals->Canvas->GetHeight();
 
-  this->Internals->RayCamera.SetParameters(camera, width, height);
+  this->Internals->RayCamera = camera.CreateRaytracingCamera(width, height);
 
   this->Internals->RayCamera.CreateRays(this->Internals->Rays, shapeBounds);
   this->Internals->Tracer.GetCamera() = this->Internals->RayCamera;
   this->Internals->Rays.Buffers.at(0).InitConst(0.f);
   raytracing::RayOperations::MapCanvasToRays(
-    this->Internals->Rays, camera, *this->Internals->Canvas);
+    this->Internals->Rays, camera.CreateRaytracingCamera(width, height), *this->Internals->Canvas);
 
   this->Internals->Tracer.SetField(scalarField, scalarRange);
 

--- a/viskores/rendering/MapperVolume.cxx
+++ b/viskores/rendering/MapperVolume.cxx
@@ -106,15 +106,16 @@ void MapperVolume::RenderCellsImpl(const viskores::cont::UnknownCellSet& cellset
 
     viskores::rendering::raytracing::VolumeRendererStructured tracer;
 
-    viskores::rendering::raytracing::Camera rayCamera;
     viskores::Int32 width = (viskores::Int32)this->Internals->Canvas->GetWidth();
     viskores::Int32 height = (viskores::Int32)this->Internals->Canvas->GetHeight();
-    rayCamera.SetParameters(camera, width, height);
+    viskores::rendering::raytracing::Camera rayCamera =
+      camera.CreateRaytracingCamera(width, height);
 
     viskores::rendering::raytracing::Ray<viskores::Float32> rays;
     rayCamera.CreateRays(rays, coords.GetBounds());
     rays.Buffers.at(0).InitConst(0.f);
-    raytracing::RayOperations::MapCanvasToRays(rays, camera, *this->Internals->Canvas);
+    raytracing::RayOperations::MapCanvasToRays(
+      rays, camera.CreateRaytracingCamera(width, height), *this->Internals->Canvas);
 
 
     if (this->Internals->SampleDistance != DEFAULT_SAMPLE_DISTANCE)

--- a/viskores/rendering/ScalarRenderer.cxx
+++ b/viskores/rendering/ScalarRenderer.cxx
@@ -111,8 +111,8 @@ ScalarRenderer::Result ScalarRenderer::Render(const viskores::rendering::Camera&
   timer.Start();
 
   // Create rays
-  viskores::rendering::raytracing::Camera cam;
-  cam.SetParameters(camera, this->Internals->Width, this->Internals->Height);
+  viskores::rendering::raytracing::Camera cam =
+    camera.CreateRaytracingCamera(this->Internals->Width, this->Internals->Height);
 
   // FIXME: rays are created with an unused Buffers.at(0), that ChannelBuffer
   //  also has wrong number of channels, thus allocates memory that is wasted.

--- a/viskores/rendering/anari-device/scene/surface/geometry/Sphere.cpp
+++ b/viskores/rendering/anari-device/scene/surface/geometry/Sphere.cpp
@@ -155,8 +155,7 @@ void Sphere::render(viskores::rendering::Canvas& canvas,
   viskores::Int32 width = (viskores::Int32)canvas.GetWidth();
   viskores::Int32 height = (viskores::Int32)canvas.GetHeight();
 
-  viskores::rendering::raytracing::Camera rayCamera;
-  rayCamera.SetParameters(camera, width, height);
+  viskores::rendering::raytracing::Camera rayCamera = camera.CreateRaytracingCamera(width, height);
 
   viskores::rendering::raytracing::Ray<viskores::Float32> rays;
   viskores::rendering::CanvasRayTracer* canvasRT =
@@ -165,7 +164,8 @@ void Sphere::render(viskores::rendering::Canvas& canvas,
 
   rayCamera.CreateRays(rays, shapeBounds);
   rays.Buffers.at(0).InitConst(0.f);
-  viskores::rendering::raytracing::RayOperations::MapCanvasToRays(rays, camera, *canvasRT);
+  viskores::rendering::raytracing::RayOperations::MapCanvasToRays(
+    rays, camera.CreateRaytracingCamera(width, height), *canvasRT);
 
   tracer.SetField(field, scalarRange);
   tracer.GetCamera() = rayCamera;

--- a/viskores/rendering/anari-device/scene/surface/geometry/Triangle.cpp
+++ b/viskores/rendering/anari-device/scene/surface/geometry/Triangle.cpp
@@ -150,8 +150,7 @@ void Triangle::render(viskores::rendering::Canvas& canvas,
   viskores::Int32 width = (viskores::Int32)canvas.GetWidth();
   viskores::Int32 height = (viskores::Int32)canvas.GetHeight();
 
-  viskores::rendering::raytracing::Camera rayCamera;
-  rayCamera.SetParameters(camera, width, height);
+  viskores::rendering::raytracing::Camera rayCamera = camera.CreateRaytracingCamera(width, height);
 
   viskores::rendering::raytracing::Ray<viskores::Float32> rays;
   viskores::rendering::CanvasRayTracer* canvasRT =
@@ -161,7 +160,8 @@ void Triangle::render(viskores::rendering::Canvas& canvas,
   rayCamera.CreateRays(rays, shapeBounds);
   tracer.GetCamera() = rayCamera;
   rays.Buffers.at(0).InitConst(0.f);
-  viskores::rendering::raytracing::RayOperations::MapCanvasToRays(rays, camera, *canvasRT);
+  viskores::rendering::raytracing::RayOperations::MapCanvasToRays(
+    rays, camera.CreateRaytracingCamera(width, height), *canvasRT);
 
   tracer.SetField(field, scalarRange);
 

--- a/viskores/rendering/anari-device/scene/volume/TransferFunction1D.cpp
+++ b/viskores/rendering/anari-device/scene/volume/TransferFunction1D.cpp
@@ -305,15 +305,15 @@ void TransferFunction1D::render(viskores::rendering::Canvas& canvas,
 
   viskores::rendering::raytracing::VolumeRendererStructured tracer;
 
-  viskores::rendering::raytracing::Camera rayCamera;
   viskores::Int32 width = (viskores::Int32)canvas.GetWidth();
   viskores::Int32 height = (viskores::Int32)canvas.GetHeight();
-  rayCamera.SetParameters(camera, width, height);
+  viskores::rendering::raytracing::Camera rayCamera = camera.CreateRaytracingCamera(width, height);
 
   viskores::rendering::raytracing::Ray<viskores::Float32> rays;
   rayCamera.CreateRays(rays, coords.GetBounds());
   rays.Buffers.at(0).InitConst(0.f);
-  viskores::rendering::raytracing::RayOperations::MapCanvasToRays(rays, camera, *canvasRT);
+  viskores::rendering::raytracing::RayOperations::MapCanvasToRays(
+    rays, camera.CreateRaytracingCamera(width, height), *canvasRT);
 
   tracer.SetSampleDistance(this->m_sampleDistance);
 

--- a/viskores/rendering/raytracing/Camera.cxx
+++ b/viskores/rendering/raytracing/Camera.cxx
@@ -54,7 +54,6 @@ public:
   VISKORES_CONT
   PixelData(viskores::Int32 width,
             viskores::Int32 height,
-            viskores::Float32 fovX,
             viskores::Float32 fovY,
             viskores::Vec3f_32 look,
             viskores::Vec3f_32 up,
@@ -72,8 +71,8 @@ public:
     , Origin(origin)
     , BoundingBox(boundingBox)
   {
-    viskores::Float32 thx = tanf((fovX * viskores::Pi_180f()) * .5f);
     viskores::Float32 thy = tanf((fovY * viskores::Pi_180f()) * .5f);
+    viskores::Float32 thx = (thy * width) / height;
     viskores::Vec3f_32 ru = viskores::Cross(look, up);
     viskores::Normalize(ru);
 
@@ -171,7 +170,6 @@ public:
   VISKORES_CONT_EXPORT
   PerspectiveRayGenJitter(viskores::Int32 width,
                           viskores::Int32 height,
-                          viskores::Float32 fovX,
                           viskores::Float32 fovY,
                           viskores::Vec3f_32 look,
                           viskores::Vec3f_32 up,
@@ -180,8 +178,8 @@ public:
     : w(width)
     , h(height)
   {
-    viskores::Float32 thx = tanf((fovX * 3.1415926f / 180.f) * .5f);
     viskores::Float32 thy = tanf((fovY * 3.1415926f / 180.f) * .5f);
+    viskores::Float32 thx = (thy * width) / height;
     viskores::Vec3f_32 ru = viskores::Cross(up, look);
     viskores::Normalize(ru);
 
@@ -247,26 +245,23 @@ public:
   viskores::Vec3f_32 StartOffset;
 
   VISKORES_CONT
-  Ortho2DRayGen(viskores::Int32 width,
-                viskores::Int32 height,
-                viskores::Float32 viskoresNotUsed(_zoom),
-                viskores::Int32 subsetWidth,
-                viskores::Int32 minx,
-                viskores::Int32 miny,
-                const viskores::rendering::Camera& camera)
-    : w(width)
-    , h(height)
-    , Minx(minx)
-    , Miny(miny)
-    , SubsetWidth(subsetWidth)
+  Ortho2DRayGen(const viskores::rendering::raytracing::Camera& camera)
+    : w(camera.GetWidth())
+    , h(camera.GetHeight())
+    , Minx(camera.GetSubsetMinX())
+    , Miny(camera.GetSubsetMinY())
+    , SubsetWidth(camera.GetSubsetWidth())
   {
-    viskores::Float32 left, right, bottom, top;
-    camera.GetViewRange2D(left, right, bottom, top);
+    auto& camera2d = camera.GetCamera2D();
+    viskores::Float32 left = camera2d.Left;
+    viskores::Float32 right = camera2d.Right;
+    viskores::Float32 bottom = camera2d.Bottom;
+    viskores::Float32 top = camera2d.Top;
 
     viskores::Float32 vl, vr, vb, vt;
-    camera.GetRealViewport(width, height, vl, vr, vb, vt);
-    viskores::Float32 _w = static_cast<viskores::Float32>(width) * (vr - vl) / 2.f;
-    viskores::Float32 _h = static_cast<viskores::Float32>(height) * (vt - vb) / 2.f;
+    camera.GetViewport(vl, vr, vb, vt);
+    viskores::Float32 _w = static_cast<viskores::Float32>(this->w) * (vr - vl) / 2.f;
+    viskores::Float32 _h = static_cast<viskores::Float32>(this->h) * (vt - vb) / 2.f;
     viskores::Vec2f_32 minPoint(left, bottom);
     viskores::Vec2f_32 maxPoint(right, top);
 
@@ -345,7 +340,6 @@ public:
   VISKORES_CONT
   PerspectiveRayGen(viskores::Int32 width,
                     viskores::Int32 height,
-                    viskores::Float32 fovX,
                     viskores::Float32 fovY,
                     viskores::Vec3f_32 look,
                     viskores::Vec3f_32 up,
@@ -363,8 +357,8 @@ public:
     , Miny(miny)
     , SubsetWidth(subsetWidth)
   {
-    viskores::Float32 thx = tanf((fovX * viskores::Pi_180f()) * .5f);
     viskores::Float32 thy = tanf((fovY * viskores::Pi_180f()) * .5f);
+    viskores::Float32 thx = (thy * width) / height;
 
     viskores::Vec3f_32 ru = viskores::Cross(look, up);
     viskores::Normalize(ru);
@@ -425,51 +419,88 @@ public:
 
 }; // class perspective ray gen
 
-bool Camera::operator==(const Camera& other) const
+//---------------------------------------------------------------------------
+
+viskores::Matrix<viskores::Float32, 4, 4> Camera3DStruct::CreateViewMatrix() const
 {
-  if (this->Height != other.Height)
-    return false;
-  if (this->Width != other.Width)
-    return false;
-  if (this->SubsetWidth != other.SubsetWidth)
-    return false;
-  if (this->SubsetHeight != other.SubsetHeight)
-    return false;
-  if (this->SubsetMinX != other.SubsetMinX)
-    return false;
-  if (this->SubsetMinY != other.SubsetMinY)
-    return false;
-  if (this->FovY != other.FovY)
-    return false;
-  if (this->FovX != other.FovX)
-    return false;
-  if (this->Zoom != other.Zoom)
-    return false;
-  if (this->Look != other.Look)
-    return false;
-  if (this->LookAt != other.LookAt)
-    return false;
-  if (this->Up != other.Up)
-    return false;
-  if (this->Position != other.Position)
-    return false;
-  return true;
+  return MatrixHelpers::ViewMatrix(this->Position, this->LookAt, this->ViewUp);
 }
 
-VISKORES_CONT
-void Camera::SetParameters(const viskores::rendering::Camera& camera,
-                           viskores::Int32 width,
-                           viskores::Int32 height)
+viskores::Matrix<viskores::Float32, 4, 4> Camera3DStruct::CreateProjectionMatrix(
+  viskores::Id width,
+  viskores::Id height,
+  viskores::Float32 nearPlane,
+  viskores::Float32 farPlane) const
 {
-  this->SetUp(camera.GetViewUp());
-  this->SetLookAt(camera.GetLookAt());
-  this->SetPosition(camera.GetPosition());
-  this->SetPan(camera.GetPan());
-  this->SetZoom(camera.GetZoom());
-  this->SetFieldOfView(camera.GetFieldOfView());
-  this->SetHeight(height);
-  this->SetWidth(width);
-  this->CameraView = camera;
+  viskores::Matrix<viskores::Float32, 4, 4> matrix;
+  viskores::MatrixIdentity(matrix);
+
+  viskores::Float32 AspectRatio = viskores::Float32(width) / viskores::Float32(height);
+  viskores::Float32 fovRad = this->FieldOfView * viskores::Pi_180f();
+  fovRad = viskores::Tan(fovRad * 0.5f);
+  viskores::Float32 size = nearPlane * fovRad;
+  viskores::Float32 left = -size * AspectRatio;
+  viskores::Float32 right = size * AspectRatio;
+  viskores::Float32 bottom = -size;
+  viskores::Float32 top = size;
+
+  matrix(0, 0) = 2.f * nearPlane / (right - left);
+  matrix(1, 1) = 2.f * nearPlane / (top - bottom);
+  matrix(0, 2) = (right + left) / (right - left);
+  matrix(1, 2) = (top + bottom) / (top - bottom);
+  matrix(2, 2) = -(farPlane + nearPlane) / (farPlane - nearPlane);
+  matrix(3, 2) = -1.f;
+  matrix(2, 3) = -(2.f * farPlane * nearPlane) / (farPlane - nearPlane);
+  matrix(3, 3) = 0.f;
+
+  viskores::Matrix<viskores::Float32, 4, 4> T, Z;
+  T = viskores::Transform3DTranslate(this->XPan, this->YPan, 0.f);
+  Z = viskores::Transform3DScale(this->Zoom, this->Zoom, 1.f);
+  matrix = viskores::MatrixMultiply(Z, viskores::MatrixMultiply(T, matrix));
+  return matrix;
+}
+
+//---------------------------------------------------------------------------
+
+viskores::Matrix<viskores::Float32, 4, 4> Camera2DStruct::CreateViewMatrix() const
+{
+  viskores::Vec3f_32 lookAt(
+    (this->Left + this->Right) / 2.f, (this->Top + this->Bottom) / 2.f, 0.f);
+  viskores::Vec3f_32 position = lookAt;
+  position[2] = 1.f;
+  viskores::Vec3f_32 up(0, 1, 0);
+  viskores::Matrix<viskores::Float32, 4, 4> V = MatrixHelpers::ViewMatrix(position, lookAt, up);
+  viskores::Matrix<viskores::Float32, 4, 4> scaleMatrix =
+    MatrixHelpers::CreateScale(this->XScale, 1, 1);
+  V = viskores::MatrixMultiply(scaleMatrix, V);
+  return V;
+}
+
+viskores::Matrix<viskores::Float32, 4, 4> Camera2DStruct::CreateProjectionMatrix(
+  viskores::Float32 size,
+  viskores::Float32 znear,
+  viskores::Float32 zfar,
+  viskores::Float32 aspect) const
+{
+  viskores::Matrix<viskores::Float32, 4, 4> matrix(0.f);
+  viskores::Float32 left = -size / 2.f * aspect;
+  viskores::Float32 right = size / 2.f * aspect;
+  viskores::Float32 bottom = -size / 2.f;
+  viskores::Float32 top = size / 2.f;
+
+  matrix(0, 0) = 2.f / (right - left);
+  matrix(1, 1) = 2.f / (top - bottom);
+  matrix(2, 2) = -2.f / (zfar - znear);
+  matrix(0, 3) = -(right + left) / (right - left);
+  matrix(1, 3) = -(top + bottom) / (top - bottom);
+  matrix(2, 3) = -(zfar + znear) / (zfar - znear);
+  matrix(3, 3) = 1.f;
+
+  viskores::Matrix<viskores::Float32, 4, 4> T, Z;
+  T = viskores::Transform3DTranslate(this->XPan, this->YPan, 0.f);
+  Z = viskores::Transform3DScale(this->Zoom, this->Zoom, 1.f);
+  matrix = viskores::MatrixMultiply(Z, viskores::MatrixMultiply(T, matrix));
+  return matrix;
 }
 
 VISKORES_CONT
@@ -482,7 +513,7 @@ void Camera::SetHeight(const viskores::Int32& height)
   if (Height != height)
   {
     this->Height = height;
-    this->SetFieldOfView(this->FovY);
+    this->IsViewDirty = true;
   }
 }
 
@@ -502,7 +533,7 @@ void Camera::SetWidth(const viskores::Int32& width)
   if (this->Width != width)
   {
     this->Width = width;
-    this->SetFieldOfView(this->FovY);
+    this->IsViewDirty = true;
   }
 }
 
@@ -524,6 +555,16 @@ viskores::Int32 Camera::GetSubsetHeight() const
   return this->SubsetHeight;
 }
 
+VISKORES_CONT viskores::Int32 Camera::GetSubsetMinX() const
+{
+  return this->SubsetMinX;
+}
+
+VISKORES_CONT viskores::Int32 Camera::GetSubsetMinY() const
+{
+  return this->SubsetMinY;
+}
+
 VISKORES_CONT
 void Camera::SetZoom(const viskores::Float32& zoom)
 {
@@ -531,17 +572,25 @@ void Camera::SetZoom(const viskores::Float32& zoom)
   {
     throw viskores::cont::ErrorBadValue("Camera zoom must be greater than zero.");
   }
-  if (this->Zoom != zoom)
+  if ((this->Camera3D.Zoom != zoom) || (this->Camera3D.Zoom != zoom))
   {
     this->IsViewDirty = true;
-    this->Zoom = zoom;
+    this->Camera3D.Zoom = zoom;
+    this->Camera2D.Zoom = zoom;
   }
 }
 
 VISKORES_CONT
 viskores::Float32 Camera::GetZoom() const
 {
-  return this->Zoom;
+  if (this->IsOrthogonalProjection)
+  {
+    return this->Camera2D.Zoom;
+  }
+  else
+  {
+    return this->Camera2D.Zoom;
+  }
 }
 
 VISKORES_CONT
@@ -549,66 +598,33 @@ void Camera::SetFieldOfView(const viskores::Float32& degrees)
 {
   if (degrees <= 0)
   {
-    throw viskores::cont::ErrorBadValue("Camera feild of view must be greater than zero.");
+    throw viskores::cont::ErrorBadValue("Camera field of view must be greater than zero.");
   }
   if (degrees > 180)
   {
-    throw viskores::cont::ErrorBadValue("Camera feild of view must be less than 180.");
+    throw viskores::cont::ErrorBadValue("Camera field of view must be less than 180.");
   }
 
-  viskores::Float32 newFOVY = degrees;
-  viskores::Float32 newFOVX;
-
-  if (this->Width != this->Height)
+  if (this->Camera3D.FieldOfView != degrees)
   {
-    viskores::Float32 fovyRad = newFOVY * viskores::Pi_180f();
-
-    // Use the tan function to find the distance from the center of the image to the top (or
-    // bottom). (Actually, we are finding the ratio of this distance to the near plane distance,
-    // but since we scale everything by the near plane distance, we can use this ratio as a scaled
-    // proxy of the distances we need.)
-    viskores::Float32 verticalDistance = viskores::Tan(0.5f * fovyRad);
-
-    // Scale the vertical distance by the aspect ratio to get the horizontal distance.
-    viskores::Float32 aspectRatio =
-      viskores::Float32(this->Width) / viskores::Float32(this->Height);
-    viskores::Float32 horizontalDistance = aspectRatio * verticalDistance;
-
-    // Now use the arctan function to get the proper field of view in the x direction.
-    viskores::Float32 fovxRad = 2.0f * viskores::ATan(horizontalDistance);
-    newFOVX = fovxRad / viskores::Pi_180f();
-  }
-  else
-  {
-    newFOVX = newFOVY;
-  }
-
-  if (newFOVX != this->FovX)
-  {
+    this->Camera3D.FieldOfView = degrees;
     this->IsViewDirty = true;
   }
-  if (newFOVY != this->FovY)
-  {
-    this->IsViewDirty = true;
-  }
-  this->FovX = newFOVX;
-  this->FovY = newFOVY;
-  this->CameraView.SetFieldOfView(this->FovY);
 }
 
 VISKORES_CONT
 viskores::Float32 Camera::GetFieldOfView() const
 {
-  return this->FovY;
+  return this->Camera3D.FieldOfView;
 }
 
 VISKORES_CONT
 void Camera::SetUp(const viskores::Vec3f_32& up)
 {
-  if (this->Up != up)
+  if (this->Camera3D.ViewUp != up)
   {
-    this->Up = up;
-    viskores::Normalize(this->Up);
+    this->Camera3D.ViewUp = up;
+    viskores::Normalize(this->Camera3D.ViewUp);
     this->IsViewDirty = true;
   }
 }
@@ -616,15 +632,15 @@ void Camera::SetUp(const viskores::Vec3f_32& up)
 VISKORES_CONT
 viskores::Vec3f_32 Camera::GetUp() const
 {
-  return this->Up;
+  return this->Camera3D.ViewUp;
 }
 
 VISKORES_CONT
 void Camera::SetLookAt(const viskores::Vec3f_32& lookAt)
 {
-  if (this->LookAt != lookAt)
+  if (this->Camera3D.LookAt != lookAt)
   {
-    this->LookAt = lookAt;
+    this->Camera3D.LookAt = lookAt;
     this->IsViewDirty = true;
   }
 }
@@ -632,15 +648,15 @@ void Camera::SetLookAt(const viskores::Vec3f_32& lookAt)
 VISKORES_CONT
 viskores::Vec3f_32 Camera::GetLookAt() const
 {
-  return this->LookAt;
+  return this->Camera3D.LookAt;
 }
 
 VISKORES_CONT
 void Camera::SetPosition(const viskores::Vec3f_32& position)
 {
-  if (this->Position != position)
+  if (this->Camera3D.Position != position)
   {
-    this->Position = position;
+    this->Camera3D.Position = position;
     this->IsViewDirty = true;
   }
 }
@@ -648,7 +664,13 @@ void Camera::SetPosition(const viskores::Vec3f_32& position)
 VISKORES_CONT
 viskores::Vec3f_32 Camera::GetPosition() const
 {
-  return this->Position;
+  return this->Camera3D.Position;
+}
+
+VISKORES_CONT viskores::Matrix<viskores::Float32, 4, 4>& Camera::GetViewProjectionMatrix() const
+{
+  this->UpdateViewProjectionMatrix();
+  return this->ViewProjectionMat;
 }
 
 VISKORES_CONT
@@ -670,8 +692,8 @@ void Camera::GetPixelData(const viskores::cont::CoordinateSystem& coords,
   viskores::Bounds boundingBox = coords.GetBounds();
   this->FindSubset(boundingBox);
   //Reset the camera look vector
-  this->Look = this->LookAt - this->Position;
-  viskores::Normalize(this->Look);
+  this->LookDirection = this->Camera3D.LookAt - this->Camera3D.Position;
+  viskores::Normalize(this->LookDirection);
   const int size = this->SubsetWidth * this->SubsetHeight;
   viskores::cont::ArrayHandle<viskores::Float32> dists;
   viskores::cont::ArrayHandle<viskores::Int32> hits;
@@ -681,15 +703,14 @@ void Camera::GetPixelData(const viskores::cont::CoordinateSystem& coords,
   //Create the ray direction
   viskores::worklet::DispatcherMapField<PixelData>(PixelData(this->Width,
                                                              this->Height,
-                                                             this->FovX,
-                                                             this->FovY,
-                                                             this->Look,
-                                                             this->Up,
-                                                             this->Zoom,
+                                                             this->Camera3D.FieldOfView,
+                                                             this->LookDirection,
+                                                             this->Camera3D.ViewUp,
+                                                             this->Camera3D.Zoom,
                                                              this->SubsetWidth,
                                                              this->SubsetMinX,
                                                              this->SubsetMinY,
-                                                             this->Position,
+                                                             this->Camera3D.Position,
                                                              boundingBox))
     .Invoke(hits, dists); //X Y Z
   activePixels = viskores::cont::Algorithm::Reduce(hits, viskores::Int32(0));
@@ -717,8 +738,7 @@ VISKORES_CONT void Camera::CreateRaysImpl(Ray<Precision>& rays, const viskores::
   createTimer.Start();
   logger->OpenLogEntry("ray_camera");
 
-  bool ortho = this->CameraView.GetMode() == viskores::rendering::Camera::Mode::TwoD;
-  this->UpdateDimensions(rays, boundingBox, ortho);
+  this->UpdateDimensions(rays, boundingBox);
   this->WriteSettingsToLog();
 
   viskores::cont::Timer timer;
@@ -742,19 +762,13 @@ VISKORES_CONT void Camera::CreateRaysImpl(Ray<Precision>& rays, const viskores::
   timer.Start();
 
   //Reset the camera look vector
-  this->Look = this->LookAt - this->Position;
-  viskores::Normalize(this->Look);
+  this->LookDirection = this->Camera3D.LookAt - this->Camera3D.Position;
+  viskores::Normalize(this->LookDirection);
 
   viskores::cont::Invoker invoke;
-  if (ortho)
+  if (this->IsOrthogonalProjection)
   {
-    invoke(Ortho2DRayGen{ this->Width,
-                          this->Height,
-                          this->Zoom,
-                          this->SubsetWidth,
-                          this->SubsetMinX,
-                          this->SubsetMinY,
-                          this->CameraView },
+    invoke(Ortho2DRayGen{ *this },
            rays.DirX,
            rays.DirY,
            rays.DirZ,
@@ -768,13 +782,12 @@ VISKORES_CONT void Camera::CreateRaysImpl(Ray<Precision>& rays, const viskores::
     //Create the ray direction
     invoke(PerspectiveRayGen{ this->Width,
                               this->Height,
-                              this->FovX,
-                              this->FovY,
-                              this->Look,
-                              this->Up,
-                              this->XPan,
-                              this->YPan,
-                              this->Zoom,
+                              this->Camera3D.FieldOfView,
+                              this->LookDirection,
+                              this->Camera3D.ViewUp,
+                              this->Camera3D.XPan,
+                              this->Camera3D.YPan,
+                              this->Camera3D.Zoom,
                               this->SubsetWidth,
                               this->SubsetMinX,
                               this->SubsetMinY },
@@ -784,13 +797,13 @@ VISKORES_CONT void Camera::CreateRaysImpl(Ray<Precision>& rays, const viskores::
            rays.PixelIdx);
 
     //Set the origin of the ray back to the camera position
-    viskores::cont::ArrayHandleConstant<Precision> posX(this->Position[0], rays.NumRays);
+    viskores::cont::ArrayHandleConstant<Precision> posX(this->Camera3D.Position[0], rays.NumRays);
     viskores::cont::Algorithm::Copy(posX, rays.OriginX);
 
-    viskores::cont::ArrayHandleConstant<Precision> posY(this->Position[1], rays.NumRays);
+    viskores::cont::ArrayHandleConstant<Precision> posY(this->Camera3D.Position[1], rays.NumRays);
     viskores::cont::Algorithm::Copy(posY, rays.OriginY);
 
-    viskores::cont::ArrayHandleConstant<Precision> posZ(this->Position[2], rays.NumRays);
+    viskores::cont::ArrayHandleConstant<Precision> posZ(this->Camera3D.Position[2], rays.NumRays);
     viskores::cont::Algorithm::Copy(posZ, rays.OriginZ);
   }
 
@@ -803,9 +816,7 @@ VISKORES_CONT void Camera::CreateRaysImpl(Ray<Precision>& rays, const viskores::
 VISKORES_CONT
 void Camera::FindSubset(const viskores::Bounds& bounds)
 {
-  this->ViewProjectionMat =
-    viskores::MatrixMultiply(this->CameraView.CreateProjectionMatrix(this->Width, this->Height),
-                             this->CameraView.CreateViewMatrix());
+  this->UpdateViewProjectionMatrix();
   viskores::Float32 x[2], y[2], z[2];
   x[0] = static_cast<viskores::Float32>(bounds.X.Min);
   x[1] = static_cast<viskores::Float32>(bounds.X.Max);
@@ -814,8 +825,9 @@ void Camera::FindSubset(const viskores::Bounds& bounds)
   z[0] = static_cast<viskores::Float32>(bounds.Z.Min);
   z[1] = static_cast<viskores::Float32>(bounds.Z.Max);
   //Inise the data bounds
-  if (this->Position[0] >= x[0] && this->Position[0] <= x[1] && this->Position[1] >= y[0] &&
-      this->Position[1] <= y[1] && this->Position[2] >= z[0] && this->Position[2] <= z[1])
+  if (this->Camera3D.Position[0] >= x[0] && this->Camera3D.Position[0] <= x[1] &&
+      this->Camera3D.Position[1] >= y[0] && this->Camera3D.Position[1] <= y[1] &&
+      this->Camera3D.Position[2] >= z[0] && this->Camera3D.Position[2] <= z[1])
   {
     this->SubsetWidth = this->Width;
     this->SubsetHeight = this->Height;
@@ -899,38 +911,27 @@ void Camera::FindSubset(const viskores::Bounds& bounds)
 
 template <typename Precision>
 VISKORES_CONT void Camera::UpdateDimensions(Ray<Precision>& rays,
-                                            const viskores::Bounds& boundingBox,
-                                            bool ortho2D)
+                                            const viskores::Bounds& boundingBox)
 {
   // If bounds have been provided, only cast rays that could hit the data
   bool imageSubsetModeOn = boundingBox.IsNonEmpty();
 
   //Find the pixel footprint
-  if (imageSubsetModeOn && !ortho2D)
+  if (imageSubsetModeOn && !this->IsOrthogonalProjection)
   {
-    //Create a transform matrix using the rendering::camera class
-    this->CameraView.SetFieldOfView(this->GetFieldOfView());
-    this->CameraView.SetLookAt(this->GetLookAt());
-    this->CameraView.SetPosition(this->GetPosition());
-    this->CameraView.SetViewUp(this->GetUp());
-
     // Note:
     // Use clipping range provided, the subsetting does take into consideration
     // the near and far clipping planes.
-
-    //Update our ViewProjection matrix
-    this->ViewProjectionMat =
-      viskores::MatrixMultiply(this->CameraView.CreateProjectionMatrix(this->Width, this->Height),
-                               this->CameraView.CreateViewMatrix());
+    this->UpdateViewProjectionMatrix();
     this->FindSubset(boundingBox);
   }
-  else if (ortho2D)
+  else if (this->IsOrthogonalProjection)
   {
     // 2D rendering has a viewport that represents the area of the canvas where the image
     // is drawn. Thus, we have to create rays corresponding to that region of the
     // canvas, so annotations are correctly rendered
     viskores::Float32 vl, vr, vb, vt;
-    this->CameraView.GetRealViewport(this->GetWidth(), this->GetHeight(), vl, vr, vb, vt);
+    this->GetViewport(vl, vr, vb, vt);
     viskores::Float32 _x = static_cast<viskores::Float32>(this->GetWidth()) * (1.f + vl) / 2.f;
     viskores::Float32 _y = static_cast<viskores::Float32>(this->GetHeight()) * (1.f + vb) / 2.f;
     viskores::Float32 _w = static_cast<viskores::Float32>(this->GetWidth()) * (vr - vl) / 2.f;
@@ -957,6 +958,30 @@ VISKORES_CONT void Camera::UpdateDimensions(Ray<Precision>& rays,
   }
 }
 
+void Camera::UpdateViewProjectionMatrix() const
+{
+  viskores::Matrix<viskores::Float32, 4, 4> projection;
+  viskores::Matrix<viskores::Float32, 4, 4> modelview;
+  if (this->IsOrthogonalProjection)
+  {
+    viskores::Float32 size = viskores::Abs(this->Camera2D.Top - this->Camera2D.Bottom);
+    viskores::Float32 aspect =
+      (static_cast<viskores::Float32>(this->Width) * (this->ViewportRight - this->ViewportLeft)) /
+      (static_cast<viskores::Float32>(this->Height) * (this->ViewportTop - this->ViewportBottom));
+    projection =
+      this->Camera2D.CreateProjectionMatrix(size, this->NearPlane, this->FarPlane, aspect);
+
+    modelview = this->Camera2D.CreateViewMatrix();
+  }
+  else
+  {
+    projection = this->Camera3D.CreateProjectionMatrix(
+      this->Width, this->Height, this->NearPlane, this->FarPlane);
+    modelview = this->Camera3D.CreateViewMatrix();
+  }
+  this->ViewProjectionMat = viskores::MatrixMultiply(projection, modelview);
+}
+
 void Camera::CreateDebugRay(viskores::Vec2i_32 pixel, Ray<viskores::Float64>& rays)
 {
   CreateDebugRayImp(pixel, rays);
@@ -973,9 +998,9 @@ void Camera::CreateDebugRayImp(viskores::Vec2i_32 pixel, Ray<Precision>& rays)
   RayOperations::Resize(rays, 1);
   viskores::Int32 pixelIndex = this->Width * (this->Height - pixel[1]) + pixel[0];
   rays.PixelIdx.WritePortal().Set(0, pixelIndex);
-  rays.OriginX.WritePortal().Set(0, this->Position[0]);
-  rays.OriginY.WritePortal().Set(0, this->Position[1]);
-  rays.OriginZ.WritePortal().Set(0, this->Position[2]);
+  rays.OriginX.WritePortal().Set(0, this->Camera3D.Position[0]);
+  rays.OriginY.WritePortal().Set(0, this->Camera3D.Position[1]);
+  rays.OriginZ.WritePortal().Set(0, this->Camera3D.Position[2]);
 
 
   viskores::Float32 infinity;
@@ -985,20 +1010,21 @@ void Camera::CreateDebugRayImp(viskores::Vec2i_32 pixel, Ray<Precision>& rays)
   rays.MinDistance.WritePortal().Set(0, 0.f);
   rays.HitIdx.WritePortal().Set(0, -2);
 
-  viskores::Float32 thx = tanf((this->FovX * viskores::Pi_180f()) * .5f);
-  viskores::Float32 thy = tanf((this->FovY * viskores::Pi_180f()) * .5f);
-  viskores::Vec3f_32 ru = viskores::Cross(this->Look, this->Up);
+
+  viskores::Float32 thy = tanf((this->Camera3D.FieldOfView * viskores::Pi_180f()) * .5f);
+  viskores::Float32 thx = (thy * this->Width) / this->Height;
+  viskores::Vec3f_32 ru = viskores::Cross(this->LookDirection, this->Camera3D.ViewUp);
   viskores::Normalize(ru);
 
-  viskores::Vec3f_32 rv = viskores::Cross(ru, this->Look);
+  viskores::Vec3f_32 rv = viskores::Cross(ru, this->LookDirection);
   viskores::Vec3f_32 delta_x, delta_y;
   viskores::Normalize(rv);
   delta_x = ru * (2 * thx / (float)this->Width);
   delta_y = rv * (2 * thy / (float)this->Height);
 
-  if (this->Zoom > 0)
+  if (this->Camera3D.Zoom > 0)
   {
-    viskores::Float32 _zoom = this->Zoom;
+    viskores::Float32 _zoom = this->Camera3D.Zoom;
     delta_x[0] = delta_x[0] / _zoom;
     delta_x[1] = delta_x[1] / _zoom;
     delta_x[2] = delta_x[2] / _zoom;
@@ -1006,7 +1032,7 @@ void Camera::CreateDebugRayImp(viskores::Vec2i_32 pixel, Ray<Precision>& rays)
     delta_y[1] = delta_y[1] / _zoom;
     delta_y[2] = delta_y[2] / _zoom;
   }
-  viskores::Vec3f_32 nlook = this->Look;
+  viskores::Vec3f_32 nlook = this->LookDirection;
   viskores::Normalize(nlook);
 
   viskores::Vec<Precision, 3> ray_dir;
@@ -1029,20 +1055,19 @@ void Camera::CreateDebugRayImp(viskores::Vec2i_32 pixel, Ray<Precision>& rays)
 void Camera::WriteSettingsToLog()
 {
   Logger* logger = Logger::GetInstance();
-  logger->AddLogData("position_x", Position[0]);
-  logger->AddLogData("position_y", Position[1]);
-  logger->AddLogData("position_z", Position[2]);
+  logger->AddLogData("position_x", this->Camera3D.Position[0]);
+  logger->AddLogData("position_y", this->Camera3D.Position[1]);
+  logger->AddLogData("position_z", this->Camera3D.Position[2]);
 
-  logger->AddLogData("lookat_x", LookAt[0]);
-  logger->AddLogData("lookat_y", LookAt[1]);
-  logger->AddLogData("lookat_z", LookAt[2]);
+  logger->AddLogData("lookat_x", this->Camera3D.LookAt[0]);
+  logger->AddLogData("lookat_y", this->Camera3D.LookAt[1]);
+  logger->AddLogData("lookat_z", this->Camera3D.LookAt[2]);
 
-  logger->AddLogData("up_x", Up[0]);
-  logger->AddLogData("up_y", Up[1]);
-  logger->AddLogData("up_z", Up[2]);
+  logger->AddLogData("up_x", this->Camera3D.ViewUp[0]);
+  logger->AddLogData("up_y", this->Camera3D.ViewUp[1]);
+  logger->AddLogData("up_z", this->Camera3D.ViewUp[2]);
 
-  logger->AddLogData("fov_x", FovX);
-  logger->AddLogData("fov_y", FovY);
+  logger->AddLogData("fov_y", this->Camera3D.FieldOfView);
   logger->AddLogData("width", Width);
   logger->AddLogData("height", Height);
   logger->AddLogData("subset_height", SubsetHeight);
@@ -1054,16 +1079,16 @@ std::string Camera::ToString()
 {
   std::stringstream sstream;
   sstream << "------------------------------------------------------------\n";
-  sstream << "Position : [" << this->Position[0] << ",";
-  sstream << this->Position[1] << ",";
-  sstream << this->Position[2] << "]\n";
-  sstream << "LookAt   : [" << this->LookAt[0] << ",";
-  sstream << this->LookAt[1] << ",";
-  sstream << this->LookAt[2] << "]\n";
-  sstream << "FOV_X    : " << this->FovX << "\n";
-  sstream << "Up       : [" << this->Up[0] << ",";
-  sstream << this->Up[1] << ",";
-  sstream << this->Up[2] << "]\n";
+  sstream << "Position : [" << this->Camera3D.Position[0] << ",";
+  sstream << this->Camera3D.Position[1] << ",";
+  sstream << this->Camera3D.Position[2] << "]\n";
+  sstream << "LookAt   : [" << this->Camera3D.LookAt[0] << ",";
+  sstream << this->Camera3D.LookAt[1] << ",";
+  sstream << this->Camera3D.LookAt[2] << "]\n";
+  sstream << "FOV_X    : " << this->Camera3D.FieldOfView << "\n";
+  sstream << "Up       : [" << this->Camera3D.ViewUp[0] << ",";
+  sstream << this->Camera3D.ViewUp[1] << ",";
+  sstream << this->Camera3D.ViewUp[2] << "]\n";
   sstream << "Width    : " << this->Width << "\n";
   sstream << "Height   : " << this->Height << "\n";
   sstream << "------------------------------------------------------------\n";

--- a/viskores/rendering/raytracing/Camera.h
+++ b/viskores/rendering/raytracing/Camera.h
@@ -18,8 +18,8 @@
 #ifndef viskores_rendering_raytracing_Camera_h
 #define viskores_rendering_raytracing_Camera_h
 
+#include <viskores/Matrix.h>
 #include <viskores/cont/CoordinateSystem.h>
-#include <viskores/rendering/Camera.h>
 #include <viskores/rendering/raytracing/Ray.h>
 
 namespace viskores
@@ -28,6 +28,71 @@ namespace rendering
 {
 namespace raytracing
 {
+
+struct Camera3DStruct
+{
+public:
+  VISKORES_CONT
+  Camera3DStruct()
+    : LookAt(0.0f, 0.0f, 0.0f)
+    , Position(0.0f, 0.0f, 1.0f)
+    , ViewUp(0.0f, 1.0f, 0.0f)
+    , FieldOfView(60.0f)
+    , XPan(0.0f)
+    , YPan(0.0f)
+    , Zoom(1.0f)
+  {
+  }
+
+  viskores::Matrix<viskores::Float32, 4, 4> CreateViewMatrix() const;
+
+  viskores::Matrix<viskores::Float32, 4, 4> CreateProjectionMatrix(
+    viskores::Id width,
+    viskores::Id height,
+    viskores::Float32 nearPlane,
+    viskores::Float32 farPlane) const;
+
+  viskores::Vec3f_32 LookAt;
+  viskores::Vec3f_32 Position;
+  viskores::Vec3f_32 ViewUp;
+  viskores::Float32 FieldOfView;
+  viskores::Float32 XPan;
+  viskores::Float32 YPan;
+  viskores::Float32 Zoom;
+};
+
+struct VISKORES_RENDERING_EXPORT Camera2DStruct
+{
+public:
+  VISKORES_CONT
+  Camera2DStruct()
+    : Left(-1.0f)
+    , Right(1.0f)
+    , Bottom(-1.0f)
+    , Top(1.0f)
+    , XScale(1.0f)
+    , XPan(0.0f)
+    , YPan(0.0f)
+    , Zoom(1.0f)
+  {
+  }
+
+  viskores::Matrix<viskores::Float32, 4, 4> CreateViewMatrix() const;
+
+  viskores::Matrix<viskores::Float32, 4, 4> CreateProjectionMatrix(viskores::Float32 size,
+                                                                   viskores::Float32 znear,
+                                                                   viskores::Float32 zfar,
+                                                                   viskores::Float32 aspect) const;
+
+  viskores::Float32 Left;
+  viskores::Float32 Right;
+  viskores::Float32 Bottom;
+  viskores::Float32 Top;
+  viskores::Float32 XScale;
+  viskores::Float32 XPan;
+  viskores::Float32 YPan;
+  viskores::Float32 Zoom;
+};
 
 class VISKORES_RENDERING_EXPORT Camera
 {
@@ -38,28 +103,24 @@ private:
   viskores::Int32 SubsetHeight = 500;
   viskores::Int32 SubsetMinX = 0;
   viskores::Int32 SubsetMinY = 0;
-  viskores::Float32 FovX = 30.f;
-  viskores::Float32 FovY = 30.f;
-  viskores::Float32 XPan = 0.f;
-  viskores::Float32 YPan = 0.f;
-  viskores::Float32 Zoom = 1.f;
   bool IsViewDirty = true;
 
-  viskores::Vec3f_32 Look{ 0.f, 0.f, -1.f };
-  viskores::Vec3f_32 Up{ 0.f, 1.f, 0.f };
-  viskores::Vec3f_32 LookAt{ 0.f, 0.f, -1.f };
-  viskores::Vec3f_32 Position{ 0.f, 0.f, 0.f };
-  viskores::rendering::Camera CameraView;
-  viskores::Matrix<viskores::Float32, 4, 4> ViewProjectionMat;
+  bool IsOrthogonalProjection = false;
+  Camera3DStruct Camera3D;
+  Camera2DStruct Camera2D;
+  viskores::Float32 ViewportLeft = -1.0f;
+  viskores::Float32 ViewportRight = 1.0f;
+  viskores::Float32 ViewportBottom = -1.0f;
+  viskores::Float32 ViewportTop = 1.0f;
+
+  viskores::Vec3f_32 LookDirection{ 0.f, 0.f, -1.f };
+  viskores::Float32 NearPlane = 0.01f;
+  viskores::Float32 FarPlane = 1000.0f;
+  mutable viskores::Matrix<viskores::Float32, 4, 4> ViewProjectionMat;
 
 public:
   VISKORES_CONT
   std::string ToString();
-
-  VISKORES_CONT
-  void SetParameters(const viskores::rendering::Camera& camera,
-                     viskores::Int32 width,
-                     viskores::Int32 height);
 
   VISKORES_CONT
   void SetHeight(const viskores::Int32& height);
@@ -79,11 +140,16 @@ public:
   VISKORES_CONT
   viskores::Int32 GetSubsetHeight() const;
 
+  VISKORES_CONT viskores::Int32 GetSubsetMinX() const;
+  VISKORES_CONT viskores::Int32 GetSubsetMinY() const;
+
   VISKORES_CONT
   void SetPan(const viskores::Float32& xpan, const viskores::Float32& ypan)
   {
-    this->XPan = xpan;
-    this->YPan = ypan;
+    this->Camera3D.XPan = xpan;
+    this->Camera3D.YPan = ypan;
+    this->Camera2D.XPan = xpan;
+    this->Camera2D.YPan = ypan;
   }
 
   VISKORES_CONT
@@ -93,8 +159,9 @@ public:
   viskores::Vec2f_32 GetPan() const
   {
     viskores::Vec2f_32 pan;
-    pan[0] = this->XPan;
-    pan[1] = this->YPan;
+    // 2D and 3D values should be the same.
+    pan[0] = this->Camera3D.XPan;
+    pan[1] = this->Camera3D.YPan;
     return pan;
   }
 
@@ -128,6 +195,70 @@ public:
   VISKORES_CONT
   viskores::Vec3f_32 GetLookAt() const;
 
+  VISKORES_CONT void SetClippingRange(viskores::Float32 nearPlane, viskores::Float32 farPlane)
+  {
+    this->NearPlane = nearPlane;
+    this->FarPlane = farPlane;
+  }
+
+  VISKORES_CONT void GetClippingRange(viskores::Float32& nearPlane,
+                                      viskores::Float32& farPlane) const
+  {
+    nearPlane = this->NearPlane;
+    farPlane = this->FarPlane;
+  }
+
+  VISKORES_CONT void SetIsOrthogonalProjection(bool isOrtho)
+  {
+    this->IsOrthogonalProjection = isOrtho;
+  }
+
+  VISKORES_CONT bool GetIsOrthogonalProjection() const { return this->IsOrthogonalProjection; }
+
+  VISKORES_CONT void SetCamera3D(const viskores::rendering::raytracing::Camera3DStruct& camera3d)
+  {
+    this->Camera3D = camera3d;
+  }
+
+  VISKORES_CONT const viskores::rendering::raytracing::Camera3DStruct& GetCamera3D() const
+  {
+    return this->Camera3D;
+  }
+
+  VISKORES_CONT void SetCamera2D(const viskores::rendering::raytracing::Camera2DStruct& camera2d)
+  {
+    this->Camera2D = camera2d;
+  }
+
+  VISKORES_CONT const viskores::rendering::raytracing::Camera2DStruct& GetCamera2D() const
+  {
+    return this->Camera2D;
+  }
+
+  VISKORES_CONT void SetViewport(viskores::Float32 left,
+                                 viskores::Float32 right,
+                                 viskores::Float32 bottom,
+                                 viskores::Float32 top)
+  {
+    this->ViewportLeft = left;
+    this->ViewportRight = right;
+    this->ViewportBottom = bottom;
+    this->ViewportTop = top;
+  }
+
+  VISKORES_CONT void GetViewport(viskores::Float32& left,
+                                 viskores::Float32& right,
+                                 viskores::Float32& bottom,
+                                 viskores::Float32& top) const
+  {
+    left = this->ViewportLeft;
+    right = this->ViewportRight;
+    bottom = this->ViewportBottom;
+    top = this->ViewportTop;
+  }
+
+  VISKORES_CONT viskores::Matrix<viskores::Float32, 4, 4>& GetViewProjectionMatrix() const;
+
   VISKORES_CONT
   void ResetIsViewDirty();
 
@@ -152,8 +283,6 @@ public:
 
   void CreateDebugRay(viskores::Vec2i_32 pixel, Ray<viskores::Float64>& rays);
 
-  bool operator==(const Camera& other) const;
-
 private:
   template <typename Precision>
   VISKORES_CONT void CreateDebugRayImp(viskores::Vec2i_32 pixel, Ray<Precision>& rays);
@@ -165,9 +294,9 @@ private:
   void WriteSettingsToLog();
 
   template <typename Precision>
-  VISKORES_CONT void UpdateDimensions(Ray<Precision>& rays,
-                                      const viskores::Bounds& boundingBox,
-                                      bool ortho2D);
+  VISKORES_CONT void UpdateDimensions(Ray<Precision>& rays, const viskores::Bounds& boundingBox);
+
+  VISKORES_CONT void UpdateViewProjectionMatrix() const;
 
 }; // class camera
 }

--- a/viskores/rendering/raytracing/RayOperations.cxx
+++ b/viskores/rendering/raytracing/RayOperations.cxx
@@ -24,13 +24,12 @@ namespace raytracing
 {
 
 void RayOperations::MapCanvasToRays(Ray<viskores::Float32>& rays,
-                                    const viskores::rendering::Camera& camera,
+                                    const viskores::rendering::raytracing::Camera& camera,
                                     const viskores::rendering::CanvasRayTracer& canvas)
 {
   viskores::Id width = canvas.GetWidth();
   viskores::Id height = canvas.GetHeight();
-  viskores::Matrix<viskores::Float32, 4, 4> projview = viskores::MatrixMultiply(
-    camera.CreateProjectionMatrix(width, height), camera.CreateViewMatrix());
+  viskores::Matrix<viskores::Float32, 4, 4> projview = camera.GetViewProjectionMatrix();
   bool valid;
   viskores::Matrix<viskores::Float32, 4, 4> inverse = viskores::MatrixInverse(projview, valid);
   (void)valid; // this can be a false negative for really tiny spatial domains.

--- a/viskores/rendering/raytracing/RayOperations.h
+++ b/viskores/rendering/raytracing/RayOperations.h
@@ -19,8 +19,8 @@
 #define viskores_rendering_raytracing_Ray_Operations_h
 
 #include <viskores/Matrix.h>
-#include <viskores/rendering/Camera.h>
 #include <viskores/rendering/CanvasRayTracer.h>
+#include <viskores/rendering/raytracing/Camera.h>
 #include <viskores/rendering/raytracing/ChannelBufferOperations.h>
 #include <viskores/rendering/raytracing/Ray.h>
 #include <viskores/rendering/raytracing/Worklets.h>
@@ -143,7 +143,7 @@ public:
 
   VISKORES_RENDERING_EXPORT static void MapCanvasToRays(
     Ray<viskores::Float32>& rays,
-    const viskores::rendering::Camera& camera,
+    const viskores::rendering::raytracing::Camera& camera,
     const viskores::rendering::CanvasRayTracer& canvas);
 
   template <typename T>


### PR DESCRIPTION
The previous implementation of the `Camera` object in the raytracing package required callbacks to functions in the Camera object in the rendering package. Move these functions into raycasting.

This is part of a larger goal to make the raycasting code its own module. This will help detangle circular dependencies between the rendering libraries and various ANARI components.