### PR TITLE
Fix crash in multi-threaded filter execution with OpenMP backend

### DIFF
--- a/docs/changelog/multi-block-filter-threading.md
+++ b/docs/changelog/multi-block-filter-threading.md
@@ -1,0 +1,3 @@
+## Deprecated CPU threading for multiblock filters.
+
+OpenMP and TBB backends are not threadsafe. Disable setting number of threads for these backends.

--- a/viskores/filter/Filter.cxx
+++ b/viskores/filter/Filter.cxx
@@ -109,12 +109,17 @@ viskores::cont::PartitionedDataSet Filter::DoExecutePartitions(
 {
   viskores::cont::PartitionedDataSet output;
 
-  if (this->GetRunMultiThreadedFilter())
+  const bool runMultiThreaded = this->GetRunMultiThreadedFilter();
+  const viskores::Id numThreads =
+    runMultiThreaded ? this->DetermineNumberOfThreads(input) : viskores::Id{ 1 };
+
+  if (numThreads > 1)
   {
     viskores::filter::DataSetQueue inputQueue(input);
     viskores::filter::DataSetQueue outputQueue;
-
-    viskores::Id numThreads = this->DetermineNumberOfThreads(input);
+    viskores::cont::ScopedRuntimeDeviceTracker tracker;
+    tracker.DisableDevice(viskores::cont::DeviceAdapterTagOpenMP{});
+    tracker.DisableDevice(viskores::cont::DeviceAdapterTagTBB{});
 
     //Run 'numThreads' filters.
     std::vector<std::future<void>> futures(static_cast<std::size_t>(numThreads));
@@ -192,7 +197,13 @@ viskores::Id Filter::DetermineNumberOfThreads(const viskores::cont::PartitionedD
 
   auto& tracker = viskores::cont::GetRuntimeDeviceTracker();
 
-  if (tracker.CanRunOn(viskores::cont::DeviceAdapterTagCuda{}))
+  if (tracker.CanRunOn(viskores::cont::DeviceAdapterTagOpenMP{}) ||
+      tracker.CanRunOn(viskores::cont::DeviceAdapterTagTBB{}))
+  {
+    // Filter-level threading should not layer on top of OpenMP or TBB execution.
+    availThreads = 1;
+  }
+  else if (tracker.CanRunOn(viskores::cont::DeviceAdapterTagCuda{}))
     availThreads = this->NumThreadsPerGPU;
   else if (tracker.CanRunOn(viskores::cont::DeviceAdapterTagKokkos{}))
   {
@@ -204,9 +215,9 @@ viskores::Id Filter::DetermineNumberOfThreads(const viskores::cont::PartitionedD
 #endif
   }
   else if (tracker.CanRunOn(viskores::cont::DeviceAdapterTagSerial{}))
-    availThreads = 1;
-  else
     availThreads = this->NumThreadsPerCPU;
+  else
+    availThreads = 1;
 
   viskores::Id numThreads = std::min<viskores::Id>(numDS, availThreads);
   return numThreads;

--- a/viskores/filter/Filter.h
+++ b/viskores/filter/Filter.h
@@ -18,6 +18,7 @@
 #ifndef viskores_filter_Filter_h
 #define viskores_filter_Filter_h
 
+#include <viskores/Deprecated.h>
 #include <viskores/cont/ArrayCopy.h>
 #include <viskores/cont/DataSet.h>
 #include <viskores/cont/Field.h>
@@ -360,16 +361,17 @@ public:
   /// then the derived class should override this method to return false.
   VISKORES_CONT virtual bool CanThread() const;
 
-  VISKORES_CONT void SetThreadsPerCPU(viskores::Id numThreads)
-  {
-    this->NumThreadsPerCPU = numThreads;
-  }
+  VISKORES_CONT
+  void SetThreadsPerCPU(viskores::Id numThreads) { this->NumThreadsPerCPU = numThreads; }
+
   VISKORES_CONT void SetThreadsPerGPU(viskores::Id numThreads)
   {
     this->NumThreadsPerGPU = numThreads;
   }
 
-  VISKORES_CONT viskores::Id GetThreadsPerCPU() const { return this->NumThreadsPerCPU; }
+  VISKORES_CONT
+  viskores::Id GetThreadsPerCPU() const { return this->NumThreadsPerCPU; }
+
   VISKORES_CONT viskores::Id GetThreadsPerGPU() const { return this->NumThreadsPerGPU; }
 
   VISKORES_CONT bool GetRunMultiThreadedFilter() const
@@ -869,8 +871,8 @@ private:
   viskores::filter::FieldSelection FieldsToPass = viskores::filter::FieldSelection::Mode::All;
   bool PassCoordinateSystems = true;
   bool RunFilterWithMultipleThreads = false;
-  viskores::Id NumThreadsPerCPU = 4;
   viskores::Id NumThreadsPerGPU = 8;
+  viskores::Id NumThreadsPerCPU = 4;
 
   std::string OutputFieldName;
 


### PR DESCRIPTION
OpenMP and TBB are not thread-safe. So disable the multiblock threading in the Filters for those devices.




