### PR TITLE
Use compliant MSVC preprocessor for device code

### DIFF
--- a/CMake/ViskoresCompilerFlags.cmake
+++ b/CMake/ViskoresCompilerFlags.cmake
@@ -81,6 +81,14 @@ if(VISKORES_COMPILER_IS_MSVC)
   endif()
 endif()
 
+# Use a standard-compliant preprocessor (required for recent versions of Thrust).
+if(VISKORES_COMPILER_IS_MSVC)
+  target_compile_options(viskores_compiler_flags INTERFACE $<$<COMPILE_LANGUAGE:CXX>:/Zc:preprocessor>)
+  if(TARGET viskores_cuda)
+    target_compile_options(viskores_compiler_flags INTERFACE $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler="/Zc:preprocessor")
+  endif()
+endif()
+
 # Setup the include directories that are needed for viskores
 target_include_directories(viskores_compiler_flags INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>

--- a/docs/changelog/msvc-preprocessor.md
+++ b/docs/changelog/msvc-preprocessor.md
@@ -1,0 +1,14 @@
+## Use compliant MSVC preprocessor for device code
+
+MSVC has some behavior in their "traditional" preprocessor that is not compliant
+with the C99 and C++11 standards. Starting in MSVC 19 (the current earliest
+version supported by Viskores), MSVC provides a "compliant" preprocessor that
+does meet C and C++ standards. This is enabled with the `/Zc:preprocessor`
+command line flag.
+
+Some device libraries (in particular, Thrust) require this compliant preprocess
+to be used for compatibility. (See bug [#276].) To support that, Viskores now
+adds the `/Zc:preprocessor` flag to compilations of device code. This is done by
+adding the compile option to the `viskores_exec` interface library.
+
+[#276]: https://github.com/Viskores/viskores/issues/276

--- a/viskores/exec/cuda/internal/IteratorFromArrayPortal.h
+++ b/viskores/exec/cuda/internal/IteratorFromArrayPortal.h
@@ -138,7 +138,7 @@ struct is_non_const_reference;
 
 template <typename T>
 struct is_non_const_reference<viskores::internal::ArrayPortalValueReference<T>>
-  : thrust::detail::true_type
+  : ::thrust::detail::true_type
 {
 };
 }

--- a/viskores/exec/cuda/internal/WrappedOperators.h
+++ b/viskores/exec/cuda/internal/WrappedOperators.h
@@ -218,7 +218,7 @@ struct is_commutative<viskores::exec::cuda::internal::WrappedBinaryOperator<T, F
 #else
 template <typename T, typename F>
 struct is_commutative<viskores::exec::cuda::internal::WrappedBinaryOperator<T, F>>
-  : public thrust::detail::is_arithmetic<T>
+  : public ::thrust::detail::is_arithmetic<T>
 {
 };
 #endif


### PR DESCRIPTION
MSVC has some behavior in their "traditional" preprocessor that is not compliant with the C99 and C++11 standards. Starting in MSVC 19 (the current earliest version supported by Viskores), MSVC provides a "compliant" preprocessor that does meet C and C++ standards. This is enabled with the `/Zc:preprocessor` command line flag.

Some device libraries (in particular, Thrust) require this compliant preprocess to be used for compatibility. To support that, Viskores now adds the `/Zc:preprocessor` flag to compilations of device code. This is done by adding the compile option to the `viskores_exec` interface library.

Fixes: #276