### PR TITLE
Remove data conversion warnings

### DIFF
--- a/viskores/cont/ArrayHandleSOAStride.h
+++ b/viskores/cont/ArrayHandleSOAStride.h
@@ -58,7 +58,7 @@ public:
   VISKORES_CONT ArrayPortalSOAStrideRead(const T* array,
                                          viskores::Id numberOfValues,
                                          viskores::IdComponent stride,
-                                         viskores::IdComponent offset)
+                                         viskores::Id offset)
     : Array(array + offset)
     , NumberOfValues(numberOfValues)
     , Stride(stride)
@@ -103,7 +103,7 @@ public:
   VISKORES_CONT ArrayPortalSOAStrideWrite(T* array,
                                           viskores::Id numberOfValues,
                                           viskores::IdComponent stride,
-                                          viskores::IdComponent offset)
+                                          viskores::Id offset)
     : Array(array + offset)
     , NumberOfValues(numberOfValues)
     , Stride(stride)

--- a/viskores/cont/ArrayHandleSOAStride.h
+++ b/viskores/cont/ArrayHandleSOAStride.h
@@ -633,10 +633,10 @@ struct Serialization<viskores::cont::ArrayHandleSOAStride<ValueType>>
     for (std::size_t componentIndex = 0; componentIndex < NUM_COMPONENTS; ++componentIndex)
     {
       viskores::Id numValues;
-      viskores::Id stride;
+      viskores::IdComponent stride;
       viskores::Id offset;
-      viskores::Id modulo;
-      viskores::Id divisor;
+      viskores::IdComponent modulo;
+      viskores::IdComponent divisor;
       viskores::cont::internal::Buffer componentBuffer;
 
       viskoresdiy::load(bb, numValues);

--- a/viskores/cont/ArrayHandleStride.h
+++ b/viskores/cont/ArrayHandleStride.h
@@ -32,8 +32,8 @@ namespace internal
 struct ArrayStrideInfo
 {
   viskores::Id NumberOfValues = 0;
+  viskores::Id Offset = 0;
   viskores::IdComponent Stride = 1;
-  viskores::IdComponent Offset = 0;
   viskores::IdComponent Modulo = 0;
   viskores::IdComponent Divisor = 0;
 
@@ -45,8 +45,8 @@ struct ArrayStrideInfo
                   viskores::Id modulo,
                   viskores::Id divisor)
     : NumberOfValues(numValues)
-    , Stride(stride)
     , Offset(offset)
+    , Stride(stride)
     , Modulo(modulo)
     , Divisor(divisor)
   {

--- a/viskores/cont/ArrayHandleStride.h
+++ b/viskores/cont/ArrayHandleStride.h
@@ -40,10 +40,10 @@ struct ArrayStrideInfo
   ArrayStrideInfo() = default;
 
   ArrayStrideInfo(viskores::Id numValues,
-                  viskores::Id stride,
+                  viskores::IdComponent stride,
                   viskores::Id offset,
-                  viskores::Id modulo,
-                  viskores::Id divisor)
+                  viskores::IdComponent modulo,
+                  viskores::IdComponent divisor)
     : NumberOfValues(numValues)
     , Offset(offset)
     , Stride(stride)
@@ -354,8 +354,17 @@ public:
                     viskores::Id divisor = 1)
     : Superclass(StorageType::CreateBuffers(
         viskores::cont::internal::Buffer{},
-        viskores::internal::ArrayStrideInfo(0, stride, offset, modulo, divisor)))
+        viskores::internal::ArrayStrideInfo(0,
+                                            static_cast<viskores::IdComponent>(stride),
+                                            offset,
+                                            static_cast<viskores::IdComponent>(modulo),
+                                            static_cast<viskores::IdComponent>(divisor))))
   {
+    constexpr viskores::Id maxval = std::numeric_limits<viskores::IdComponent>::max();
+    constexpr viskores::Id minval = std::numeric_limits<viskores::IdComponent>::min();
+    VISKORES_ASSERT((stride >= minval) && (stride <= maxval));
+    VISKORES_ASSERT((modulo >= minval) && (modulo <= maxval));
+    VISKORES_ASSERT((divisor >= minval) && (divisor <= maxval));
   }
 
   /// @brief Construct an `ArrayHandleStride` from a basic array with specified access patterns.
@@ -367,8 +376,17 @@ public:
                     viskores::Id divisor = 1)
     : Superclass(StorageType::CreateBuffers(
         array.GetBuffers()[0],
-        viskores::internal::ArrayStrideInfo(numValues, stride, offset, modulo, divisor)))
+        viskores::internal::ArrayStrideInfo(numValues,
+                                            static_cast<viskores::IdComponent>(stride),
+                                            offset,
+                                            static_cast<viskores::IdComponent>(modulo),
+                                            static_cast<viskores::IdComponent>(divisor))))
   {
+    constexpr viskores::Id maxval = std::numeric_limits<viskores::IdComponent>::max();
+    constexpr viskores::Id minval = std::numeric_limits<viskores::IdComponent>::min();
+    VISKORES_ASSERT((stride >= minval) && (stride <= maxval));
+    VISKORES_ASSERT((modulo >= minval) && (modulo <= maxval));
+    VISKORES_ASSERT((divisor >= minval) && (divisor <= maxval));
   }
 
   ArrayHandleStride(const viskores::cont::internal::Buffer& buffer,
@@ -379,8 +397,17 @@ public:
                     viskores::Id divisor = 1)
     : Superclass(StorageType::CreateBuffers(
         buffer,
-        viskores::internal::ArrayStrideInfo(numValues, stride, offset, modulo, divisor)))
+        viskores::internal::ArrayStrideInfo(numValues,
+                                            static_cast<viskores::IdComponent>(stride),
+                                            offset,
+                                            static_cast<viskores::IdComponent>(modulo),
+                                            static_cast<viskores::IdComponent>(divisor))))
   {
+    constexpr viskores::Id maxval = std::numeric_limits<viskores::IdComponent>::max();
+    constexpr viskores::Id minval = std::numeric_limits<viskores::IdComponent>::min();
+    VISKORES_ASSERT((stride >= minval) && (stride <= maxval));
+    VISKORES_ASSERT((modulo >= minval) && (modulo <= maxval));
+    VISKORES_ASSERT((divisor >= minval) && (divisor <= maxval));
   }
 
   /// @brief Get the stride that values are accessed.
@@ -388,7 +415,10 @@ public:
   /// The stride is the spacing between consecutive values. The stride is measured
   /// in terms of the number of values. A stride of 1 means a fully packed array.
   /// A stride of 2 means selecting every other values.
-  viskores::Id GetStride() const { return StorageType::GetInfo(this->GetBuffers()).Stride; }
+  viskores::IdComponent GetStride() const
+  {
+    return StorageType::GetInfo(this->GetBuffers()).Stride;
+  }
 
   /// @brief Get the offset to start reading values.
   ///
@@ -408,14 +438,20 @@ public:
   /// in the array.
   ///
   /// If the modulo is set to 0, then it is ignored.
-  viskores::Id GetModulo() const { return StorageType::GetInfo(this->GetBuffers()).Modulo; }
+  viskores::IdComponent GetModulo() const
+  {
+    return StorageType::GetInfo(this->GetBuffers()).Modulo;
+  }
 
   /// @brief Get the divisor of the array index.
   ///
   /// The index is divided by the divisor before the other effects. The default divisor of
   /// 1 will have no effect on the indexing. Setting the divisor to a value greater than 1
   /// has the effect of repeating each value that many times.
-  viskores::Id GetDivisor() const { return StorageType::GetInfo(this->GetBuffers()).Divisor; }
+  viskores::IdComponent GetDivisor() const
+  {
+    return StorageType::GetInfo(this->GetBuffers()).Divisor;
+  }
 
   /// @brief Return the underlying data as a basic array handle.
   ///
@@ -546,10 +582,10 @@ public:
   static VISKORES_CONT void load(BinaryBuffer& bb, BaseType& obj)
   {
     viskores::Id numValues;
-    viskores::Id stride;
+    viskores::IdComponent stride;
     viskores::Id offset;
-    viskores::Id modulo;
-    viskores::Id divisor;
+    viskores::IdComponent modulo;
+    viskores::IdComponent divisor;
     viskores::cont::internal::Buffer buffer;
 
     viskoresdiy::load(bb, numValues);

--- a/viskores/cont/testing/UnitTestSplineEvaluate.cxx
+++ b/viskores/cont/testing/UnitTestSplineEvaluate.cxx
@@ -44,9 +44,10 @@ VISKORES_EXEC
 viskores::FloatDefault EvaluateNormalizedGyroid(const viskores::Vec3f& point)
 {
   //f(x,y,z)=sin(2πx)cos(2πy)+sin(2πy)cos(2πz)+sin(2πz)cos(2πx)
-  return viskores::Sin(viskores::TwoPi() * point[0]) * viskores::Cos(viskores::TwoPi() * point[1]) +
-    viskores::Sin(viskores::TwoPi() * point[1]) * viskores::Cos(viskores::TwoPi() * point[2]) +
-    viskores::Sin(viskores::TwoPi() * point[2]) * viskores::Cos(viskores::TwoPi() * point[0]);
+  constexpr viskores::FloatDefault twoPi = viskores::TwoPi<viskores::FloatDefault>();
+  return (viskores::Sin(twoPi * point[0]) * viskores::Cos(twoPi * point[1])) +
+    (viskores::Sin(twoPi * point[1]) * viskores::Cos(twoPi * point[2])) +
+    (viskores::Sin(twoPi * point[2]) * viskores::Cos(twoPi * point[0]));
 }
 
 class EvalWorklet : public viskores::worklet::WorkletMapField
@@ -88,7 +89,7 @@ std::vector<viskores::cont::DataSet> MakeDataSet3D(const std::vector<viskores::I
   std::vector<viskores::cont::DataSet> dataSets;
   for (const auto& d : dims)
   {
-    viskores::Vec3f spacing(1.0 / (d[0] - 1), 1.0 / (d[1] - 1), 1.0 / (d[2] - 1));
+    viskores::Vec3f spacing = viskores::Vec3f(1) / (viskores::Vec3f(d) - viskores::Vec3f(1));
     auto ds = builder.Create(d, origin, spacing);
 
     viskores::cont::Invoker invoker;
@@ -236,7 +237,7 @@ template <typename SplineEvalType>
 void CompareResults(SplineEvalType& splineEval,
                     const viskores::cont::ArrayHandle<viskores::Vec3f>& points,
                     const viskores::cont::ArrayHandle<viskores::FloatDefault>& expectedValues,
-                    viskores::FloatDefault eps)
+                    viskores::Float64 eps)
 {
   viskores::cont::ArrayHandle<viskores::FloatDefault> results;
   viskores::cont::Invoker invoke;

--- a/viskores/filter/uncertainty/worklet/FiberUncertainUniform.h
+++ b/viskores/filter/uncertainty/worklet/FiberUncertainUniform.h
@@ -89,11 +89,11 @@ public:
       if ((min1_intersection < max1_intersection) && (ensembleMin2 >= min2_user) &&
           (ensembleMin2 <= max2_user))
       {
-        viskores::FloatDefault rangeX = ensembleMax1 - ensembleMin1;
+        viskores::Float64 rangeX = ensembleMax1 - ensembleMin1;
         for (viskores::IdComponent i = 0; i < this->NumSamples; i++)
         {
-          viskores::FloatDefault r1 = randomPortal.Get(i);
-          viskores::FloatDefault n1 = ensembleMin1 + r1 * rangeX;
+          viskores::Float64 r1 = randomPortal.Get(i);
+          viskores::Float64 n1 = ensembleMin1 + r1 * rangeX;
 
           if ((n1 > min1_user) && (n1 < max1_user))
           {
@@ -107,11 +107,11 @@ public:
       if ((min2_intersection < max2_intersection) && (ensembleMin1 >= min1_user) &&
           (ensembleMin1 <= max1_user))
       {
-        viskores::FloatDefault rangeY = ensembleMax2 - ensembleMin2;
+        viskores::Float64 rangeY = ensembleMax2 - ensembleMin2;
         for (viskores::IdComponent i = 0; i < this->NumSamples; i++)
         {
-          viskores::FloatDefault r2 = randomPortal.Get(i + this->NumSamples);
-          viskores::FloatDefault n2 = ensembleMin2 + r2 * rangeY;
+          viskores::Float64 r2 = randomPortal.Get(i + this->NumSamples);
+          viskores::Float64 n2 = ensembleMin2 + r2 * rangeY;
 
           if ((n2 > min2_user) && (n2 < max2_user))
           {
@@ -122,14 +122,14 @@ public:
     }
     else
     {
-      viskores::FloatDefault rangeX = ensembleMax1 - ensembleMin1;
-      viskores::FloatDefault rangeY = ensembleMax2 - ensembleMin2;
+      viskores::Float64 rangeX = ensembleMax1 - ensembleMin1;
+      viskores::Float64 rangeY = ensembleMax2 - ensembleMin2;
       for (viskores::IdComponent i = 0; i < this->NumSamples; i++)
       {
-        viskores::FloatDefault r1 = randomPortal.Get(i);
-        viskores::FloatDefault r2 = randomPortal.Get(i + this->NumSamples);
-        viskores::FloatDefault n1 = ensembleMin1 + r1 * rangeX;
-        viskores::FloatDefault n2 = ensembleMin2 + r2 * rangeY;
+        viskores::Float64 r1 = randomPortal.Get(i);
+        viskores::Float64 r2 = randomPortal.Get(i + this->NumSamples);
+        viskores::Float64 n1 = ensembleMin1 + r1 * rangeX;
+        viskores::Float64 n2 = ensembleMin2 + r2 * rangeY;
 
         if ((n1 > min1_user) && (n1 < max1_user) && (n2 > min2_user) && (n2 < max2_user))
         {
@@ -178,10 +178,10 @@ public:
     Max1 max1_user = static_cast<Max1>(this->RangeAxis1.Max);
     Max2 max2_user = static_cast<Max2>(this->RangeAxis2.Max);
 
-    viskores::FloatDefault intersectionArea = 0.0;
-    viskores::FloatDefault intersectionProbability = 0.0;
-    viskores::FloatDefault intersectionHeight = 0.0;
-    viskores::FloatDefault intersectionWidth = 0.0;
+    viskores::Float64 intersectionArea = 0.0;
+    viskores::Float64 intersectionProbability = 0.0;
+    viskores::Float64 intersectionHeight = 0.0;
+    viskores::Float64 intersectionWidth = 0.0;
 
     Min1 min1_intersection = viskores::Max(min1_user, ensembleMin1);
     Min2 min2_intersection = viskores::Max(min2_user, ensembleMin2);
@@ -241,7 +241,7 @@ public:
         intersectionProbability = intersectionArea / DataArea;
       }
     }
-    probability = intersectionProbability;
+    probability = static_cast<OutCellFieldType>(intersectionProbability);
     return;
   }
 


### PR DESCRIPTION
ArrayHandleStride.h had some recent changes with how the stride information was stored that is now causing a conversion from `Id` to `IdComponent`. This makes that conversion implicit without warnings from the compiler.