### PR TITLE
Build CI in /tmp directory

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,9 +20,9 @@
 
 .docker_image: &docker_image
   variables:
-    CCACHE_BASEDIR: "${CI_PROJECT_DIR}"
+    CCACHE_BASEDIR: "/tmp"
     CCACHE_COMPILERCHECK: "content"
-    CCACHE_DIR: "$CI_PROJECT_DIR/.ccache"
+    CCACHE_DIR: "/tmp/.ccache"
     CCACHE_HASHDIR: "true"
     CCACHE_NAMESPACE: "${CI_PROJECT_PATH}/${CI_JOB_NAME}"
     CCACHE_SLOPPINESS: "include_file_mtime,time_macros"
@@ -183,11 +183,12 @@ stages:
     fallback_keys:
       - "$CI_JOB_NAME-main"
     paths:
-      - "$CI_PROJECT_DIR/.ccache/"
+      - "$CCACHE_DIR/"
   before_script:
     - *install_cmake
     - "cmake -VV -P .gitlab/ci/config/ninja.cmake"
     - export PATH="${PWD}/.gitlab:${PATH}"
+    - export CTEST_BINARY_DIRECTORY=/tmp/build
     - "cmake -VV -P .gitlab/ci/config/gitlab-bridge-set-vars.cmake"
     - "CCACHE_INSTALL_DIR=${PWD}/.gitlab cmake -V -P .gitlab/ci/config/ccache.cmake"
     - export PATH="${PWD}/.gitlab/ccache:${PATH}"

--- a/.gitlab/ci/check_warnings.cmake
+++ b/.gitlab/ci/check_warnings.cmake
@@ -23,7 +23,8 @@ set(configure_warning_exceptions
   )
 
 # Find the path of the logs from the last configure
-set(cnf_log_path "${CMAKE_SOURCE_DIR}/build/Testing/Temporary/LastConfigure*.log")
+include("$ENV{CI_PROJECT_DIR}/build/CIState.cmake")
+set(cnf_log_path "${CTEST_BINARY_DIRECTORY}/Testing/Temporary/LastConfigure*.log")
 file(GLOB cnf_log_files ${cnf_log_path})
 
 # Check for warnings during the configure phase
@@ -47,7 +48,7 @@ endforeach()
 
 # `compile_num_warnings` contains a single integer symbolizing the number of
 # warnings of the last build.
-set(bld_log_path "${CMAKE_SOURCE_DIR}/build/compile_num_warnings.log")
+set(bld_log_path "${CTEST_BINARY_DIRECTORY}/compile_num_warnings.log")
 file(STRINGS "${bld_log_path}" output)
 if (NOT "${output}" STREQUAL "0")
   message(FATAL_ERROR "Build warnings detected, please check cdash-commit job")

--- a/.gitlab/ci/config/gitlab_ci_setup.cmake
+++ b/.gitlab/ci/config/gitlab_ci_setup.cmake
@@ -25,7 +25,11 @@ endif ()
 
 # Set up the source and build paths.
 set(CTEST_SOURCE_DIRECTORY "$ENV{CI_PROJECT_DIR}")
-set(CTEST_BINARY_DIRECTORY "${CTEST_SOURCE_DIRECTORY}/build")
+if (DEFINED ENV{CTEST_BINARY_DIRECTORY})
+  set(CTEST_BINARY_DIRECTORY "$ENV{CTEST_BINARY_DIRECTORY}")
+else ()
+  set(CTEST_BINARY_DIRECTORY "${CTEST_SOURCE_DIRECTORY}/build")
+endif ()
 
 if ("$ENV{VISKORES_SETTINGS}" STREQUAL "")
   message(FATAL_ERROR
@@ -132,4 +136,4 @@ set(state
 "
 )
 message("OUT: ${state}")
-file(WRITE ${CTEST_BINARY_DIRECTORY}/CIState.cmake "${state}")
+file(WRITE ${CTEST_SOURCE_DIRECTORY}/build/CIState.cmake "${state}")


### PR DESCRIPTION
We have been having some issues with object files disappearing, and this may be an issue with a networked file system. To get around this issue, compile to the /tmp directory instead.