### PR TITLE
Improve BOV reader format support and tests

### DIFF
--- a/viskores/io/BOVDataSetReader.cxx
+++ b/viskores/io/BOVDataSetReader.cxx
@@ -18,74 +18,644 @@
 
 #include <viskores/io/BOVDataSetReader.h>
 
+#include <viskores/cont/ArrayHandleRuntimeVec.h>
 #include <viskores/cont/DataSetBuilderUniform.h>
 #include <viskores/io/ErrorIO.h>
+#include <viskores/io/FileUtils.h>
+#include <viskores/io/internal/Endian.h>
 
+#include <algorithm>
+#include <cctype>
 #include <fstream>
+#include <limits>
 #include <sstream>
+#include <vector>
 
 namespace
 {
 
 enum class DataFormat
 {
-  ByteData,
-  ShortData,
-  IntegerData,
-  FloatData,
-  DoubleData
+  Byte,
+  Short,
+  Integer,
+  Float,
+  Double
 };
 
-template <typename T>
-void ReadBuffer(const std::string& fName, const viskores::Id& sz, std::vector<T>& buff)
+enum class Centering
 {
-  FILE* fp = fopen(fName.c_str(), "rb");
-  size_t readSize = static_cast<size_t>(sz);
-  if (fp == nullptr)
+  Nodal,
+  Zonal
+};
+
+struct BOVHeader
+{
+  BOVHeader()
+    : DataSize(0, 0, 0)
+    , Origin(0, 0, 0)
+    , BrickSize(1, 1, 1)
   {
+  }
+
+  std::string DataFile;
+  std::string VariableName;
+  viskores::Id3 DataSize;
+  viskores::Vec3f Origin;
+  viskores::Vec3f BrickSize;
+  viskores::IdComponent NumComponents = 1;
+  viskores::Id ByteOffset = 0;
+  DataFormat Format = DataFormat::Float;
+  Centering FieldCentering = Centering::Nodal;
+  bool HasDataFile = false;
+  bool HasDataSize = false;
+  bool HasFormat = false;
+  bool HasVariable = false;
+  bool HasBrickSize = false;
+  bool HasEndian = false;
+  bool DataIsLittleEndian = false;
+};
+
+std::string Trim(const std::string& value)
+{
+  auto begin = std::find_if_not(
+    value.begin(), value.end(), [](unsigned char ch) { return std::isspace(ch) != 0; });
+  auto end = std::find_if_not(
+    value.rbegin(), value.rend(), [](unsigned char ch) { return std::isspace(ch) != 0; });
+
+  if (begin >= end.base())
+    return std::string();
+  return std::string(begin, end.base());
+}
+
+std::string ToUpper(const std::string& value)
+{
+  std::string result = value;
+  std::transform(result.begin(),
+                 result.end(),
+                 result.begin(),
+                 [](unsigned char ch) { return static_cast<char>(std::toupper(ch)); });
+  return result;
+}
+
+std::string NormalizeKey(const std::string& key)
+{
+  std::string normalized;
+  bool lastWasSpace = true;
+  for (char ch : Trim(key))
+  {
+    const auto uch = static_cast<unsigned char>(ch);
+    if (ch == '_' || std::isspace(uch) != 0)
+    {
+      if (!lastWasSpace)
+      {
+        normalized.push_back(' ');
+        lastWasSpace = true;
+      }
+    }
+    else
+    {
+      normalized.push_back(static_cast<char>(std::toupper(uch)));
+      lastWasSpace = false;
+    }
+  }
+  return Trim(normalized);
+}
+
+std::string ParseStringOption(const std::string& option, const std::string& optionName)
+{
+  const std::string value = Trim(option);
+  if (value.empty())
+    throw viskores::io::ErrorIO("Missing value for " + optionName);
+
+  if (value[0] == '"' || value[0] == '\'')
+  {
+    const char quote = value[0];
+    const std::string::size_type endQuote = value.find_last_of(quote);
+    if (endQuote == 0)
+      throw viskores::io::ErrorIO("Unterminated quoted value for " + optionName);
+    return value.substr(1, endQuote - 1);
+  }
+
+  std::stringstream stream(value);
+  std::string result;
+  stream >> result;
+  return result;
+}
+
+viskores::Id3 ParseId3Option(const std::string& option, const std::string& optionName)
+{
+  std::stringstream stream(option);
+  viskores::Id3 result;
+  stream >> result[0] >> result[1] >> result[2];
+  if (!stream)
+    throw viskores::io::ErrorIO("Invalid value for " + optionName + ": " + Trim(option));
+  return result;
+}
+
+viskores::Vec3f ParseVec3fOption(const std::string& option, const std::string& optionName)
+{
+  std::stringstream stream(option);
+  viskores::Vec3f result;
+  stream >> result[0] >> result[1] >> result[2];
+  if (!stream)
+    throw viskores::io::ErrorIO("Invalid value for " + optionName + ": " + Trim(option));
+  return result;
+}
+
+viskores::Id ParseIdOption(const std::string& option, const std::string& optionName)
+{
+  std::stringstream stream(option);
+  viskores::Id result;
+  stream >> result;
+  if (!stream || result < 0)
+    throw viskores::io::ErrorIO("Invalid value for " + optionName + ": " + Trim(option));
+  return result;
+}
+
+viskores::IdComponent ParseDataComponentsOption(const std::string& option)
+{
+  const std::string value = ToUpper(Trim(option));
+  if (value == "COMPLEX")
+    return 2;
+
+  std::stringstream stream(value);
+  viskores::Id result;
+  stream >> result;
+  if (!stream || result < 1)
+    throw viskores::io::ErrorIO("Invalid value for DATA_COMPONENTS: " + Trim(option));
+
+  char extra = '\0';
+  if (stream >> extra)
+    throw viskores::io::ErrorIO("Invalid value for DATA_COMPONENTS: " + Trim(option));
+
+  if (result > std::numeric_limits<viskores::IdComponent>::max())
+    throw viskores::io::ErrorIO("DATA_COMPONENTS is too large");
+
+  return static_cast<viskores::IdComponent>(result);
+}
+
+DataFormat ParseDataFormat(const std::string& option)
+{
+  const std::string value = ToUpper(Trim(option));
+  if (value.find("BYTE") != std::string::npos)
+    return DataFormat::Byte;
+  if (value.find("SHORT") != std::string::npos)
+    return DataFormat::Short;
+  if (value == "INT" || value == "INTS" || value.find("INTEGER") != std::string::npos)
+    return DataFormat::Integer;
+  if (value.find("FLOAT") != std::string::npos || value.find("REAL") != std::string::npos)
+    return DataFormat::Float;
+  if (value.find("DOUBLE") != std::string::npos)
+    return DataFormat::Double;
+  throw viskores::io::ErrorIO("Unsupported DATA_FORMAT: " + Trim(option));
+}
+
+Centering ParseCentering(const std::string& option)
+{
+  const std::string value = ToUpper(Trim(option));
+  if (value.find("NODAL") != std::string::npos || value.find("NODE") != std::string::npos ||
+      value.find("POINT") != std::string::npos)
+    return Centering::Nodal;
+  if (value.find("ZONAL") != std::string::npos || value.find("ZONE") != std::string::npos ||
+      value.find("CELL") != std::string::npos)
+    return Centering::Zonal;
+  throw viskores::io::ErrorIO("Unsupported CENTERING: " + Trim(option));
+}
+
+bool ParseDataEndianIsLittle(const std::string& option)
+{
+  const std::string value = ToUpper(Trim(option));
+  if (value.find("LITTLE") != std::string::npos)
+    return true;
+  if (value.find("BIG") != std::string::npos)
+    return false;
+  throw viskores::io::ErrorIO("Unsupported DATA_ENDIAN: " + Trim(option));
+}
+
+bool ParseBoolOption(const std::string& option, const std::string& optionName)
+{
+  const std::string value = ToUpper(Trim(option));
+  if (value == "TRUE" || value == "YES" || value == "ON" || value == "1")
+    return true;
+  if (value == "FALSE" || value == "NO" || value == "OFF" || value == "0")
+    return false;
+  throw viskores::io::ErrorIO("Invalid value for " + optionName + ": " + Trim(option));
+}
+
+void ValidateHeader(const BOVHeader& header)
+{
+  if (!header.HasDataFile || header.DataFile.empty())
+    throw viskores::io::ErrorIO("Missing required DATA_FILE option");
+  if (!header.HasDataSize)
+    throw viskores::io::ErrorIO("Missing required DATA_SIZE option");
+  if (!header.HasFormat)
+    throw viskores::io::ErrorIO("Missing required DATA_FORMAT option");
+  if (!header.HasVariable || header.VariableName.empty())
+    throw viskores::io::ErrorIO("Missing required VARIABLE option");
+  if (header.NumComponents < 1)
+    throw viskores::io::ErrorIO("DATA_COMPONENTS must be >= 1");
+
+  for (viskores::IdComponent i = 0; i < 3; ++i)
+    if (header.DataSize[i] < 1)
+      throw viskores::io::ErrorIO("DATA_SIZE values must be positive");
+
+  if (header.FieldCentering == Centering::Nodal && header.DataSize[0] == 1 &&
+      header.DataSize[1] == 1 && header.DataSize[2] == 1)
+    throw viskores::io::ErrorIO("NODAL DATA_SIZE must define at least one structured cell axis");
+}
+
+BOVHeader ParseHeaderFile(const std::string& fileName)
+{
+  std::ifstream stream(fileName);
+  if (stream.fail())
+    throw viskores::io::ErrorIO("Failed to open file: " + fileName);
+
+  BOVHeader header;
+  std::string line;
+  while (std::getline(stream, line))
+  {
+    line = Trim(line);
+    if (line.empty() || line[0] == '#')
+      continue;
+
+    const std::string::size_type pos = line.find(':');
+    if (pos == std::string::npos)
+      throw viskores::io::ErrorIO("Unsupported option: " + line);
+
+    const std::string token = NormalizeKey(line.substr(0, pos));
+    const std::string options = line.substr(pos + 1);
+
+    if (token == "DATA FILE")
+    {
+      header.DataFile = ParseStringOption(options, "DATA_FILE");
+      header.HasDataFile = true;
+    }
+    else if (token == "DATA SIZE")
+    {
+      header.DataSize = ParseId3Option(options, "DATA_SIZE");
+      header.HasDataSize = true;
+    }
+    else if (token == "BRICK ORIGIN")
+      header.Origin = ParseVec3fOption(options, "BRICK_ORIGIN");
+    else if (token == "BRICK SIZE")
+    {
+      header.BrickSize = ParseVec3fOption(options, "BRICK_SIZE");
+      header.HasBrickSize = true;
+    }
+    else if (token == "DATA FORMAT")
+    {
+      header.Format = ParseDataFormat(options);
+      header.HasFormat = true;
+    }
+    else if (token == "DATA COMPONENTS")
+    {
+      header.NumComponents = ParseDataComponentsOption(options);
+    }
+    else if (token == "VARIABLE")
+    {
+      header.VariableName = ParseStringOption(options, "VARIABLE");
+      header.HasVariable = true;
+    }
+    else if (token == "DATA ENDIAN")
+    {
+      header.DataIsLittleEndian = ParseDataEndianIsLittle(options);
+      header.HasEndian = true;
+    }
+    else if (token == "BYTE OFFSET")
+      header.ByteOffset = ParseIdOption(options, "BYTE_OFFSET");
+    else if (token == "CENTERING")
+      header.FieldCentering = ParseCentering(options);
+    else if (token == "DIVIDE BRICK" && ParseBoolOption(options, "DIVIDE_BRICK"))
+      throw viskores::io::ErrorIO("DIVIDE_BRICK: TRUE is not supported");
+  }
+
+  ValidateHeader(header);
+  return header;
+}
+
+std::string ResolveDataFilePath(const std::string& bovFileName, const std::string& dataFileName)
+{
+  if (viskores::io::IsAbsolutePath(dataFileName))
+    return dataFileName;
+
+  const std::string baseDir = viskores::io::ParentPath(bovFileName);
+  if (baseDir.empty())
+    return dataFileName;
+  return viskores::io::MergePaths(baseDir, dataFileName);
+}
+
+viskores::Id Product(const viskores::Id3& dims)
+{
+  return dims[0] * dims[1] * dims[2];
+}
+
+viskores::Id SafeMultiply(viskores::Id lhs, viskores::Id rhs, const std::string& context)
+{
+  if (lhs < 0 || rhs < 0)
+    throw viskores::io::ErrorIO("Negative value while computing " + context);
+  if (lhs != 0 && rhs > (std::numeric_limits<viskores::Id>::max() / lhs))
+    throw viskores::io::ErrorIO("Overflow while computing " + context);
+  return lhs * rhs;
+}
+
+viskores::Id3 GetPointDimensions(const BOVHeader& header)
+{
+  if (header.FieldCentering == Centering::Zonal)
+    return viskores::Id3(header.DataSize[0] + 1, header.DataSize[1] + 1, header.DataSize[2] + 1);
+  return header.DataSize;
+}
+
+viskores::Vec3f GetSpacing(const BOVHeader& header, const viskores::Id3& pointDimensions)
+{
+  viskores::Vec3f spacing(1, 1, 1);
+  if (!header.HasBrickSize)
+    return spacing;
+
+  for (viskores::IdComponent i = 0; i < 3; ++i)
+  {
+    const viskores::Id divisor =
+      (header.FieldCentering == Centering::Zonal) ? header.DataSize[i] : (header.DataSize[i] - 1);
+    spacing[i] =
+      (divisor > 0) ? (header.BrickSize[i] / static_cast<viskores::FloatDefault>(divisor)) : 1.0f;
+    if (pointDimensions[i] > 1 && spacing[i] <= 0)
+      throw viskores::io::ErrorIO("BRICK_SIZE values must produce positive spacing");
+  }
+
+  return spacing;
+}
+
+template <typename T>
+void ReadBuffer(const std::string& fName,
+                const viskores::Id& sz,
+                const viskores::Id& byteOffset,
+                bool swapEndian,
+                std::vector<T>& buff)
+{
+  const size_t readSize = static_cast<size_t>(sz);
+  std::ifstream stream(fName, std::ios::binary);
+  if (stream.fail())
     throw viskores::io::ErrorIO("Unable to open data file: " + fName);
-  }
-  buff.resize(readSize);
-  size_t nread = fread(&buff[0], sizeof(T), readSize, fp);
-  if (nread != readSize)
+
+  if (byteOffset > 0)
   {
-    throw viskores::io::ErrorIO("Data file read failed: " + fName);
+    stream.seekg(static_cast<std::streamoff>(byteOffset), std::ios::beg);
+    if (stream.fail())
+      throw viskores::io::ErrorIO("Unable to seek data file: " + fName);
   }
-  fclose(fp);
+
+  buff.resize(readSize);
+  stream.read(reinterpret_cast<char*>(buff.data()),
+              static_cast<std::streamsize>(sizeof(T) * readSize));
+  if (stream.fail())
+    throw viskores::io::ErrorIO("Data file read failed: " + fName);
+
+  if (swapEndian && sizeof(T) > 1)
+    viskores::io::internal::FlipEndianness(buff);
 }
 
 template <typename T>
 void ReadScalar(const std::string& fName,
                 const viskores::Id& nTuples,
+                const viskores::Id& byteOffset,
+                bool swapEndian,
                 viskores::cont::ArrayHandle<T>& var)
 {
   std::vector<T> buff;
-  ReadBuffer(fName, nTuples, buff);
+  ReadBuffer(fName, nTuples, byteOffset, swapEndian, buff);
+  var.Allocate(nTuples);
+  auto writePortal = var.WritePortal();
+  for (viskores::Id i = 0; i < nTuples; i++)
+    writePortal.Set(i, buff[static_cast<size_t>(i)]);
+}
+
+template <typename T>
+void ReadVector(const std::string& fName,
+                const viskores::Id& nTuples,
+                viskores::IdComponent numComponents,
+                const viskores::Id& byteOffset,
+                bool swapEndian,
+                viskores::cont::ArrayHandle<viskores::Vec<T, 2>>& var)
+{
+  if (numComponents != 2)
+    throw viskores::io::ErrorIO("Internal error: invalid Vec2 component count");
+
+  std::vector<T> buff;
+  ReadBuffer(fName, SafeMultiply(nTuples, 2, "BOV Vec2 tuple count"), byteOffset, swapEndian, buff);
+
   var.Allocate(nTuples);
   auto writePortal = var.WritePortal();
   for (viskores::Id i = 0; i < nTuples; i++)
   {
-    writePortal.Set(i, buff[static_cast<size_t>(i)]);
+    writePortal.Set(
+      i,
+      viskores::Vec<T, 2>(buff[static_cast<size_t>(i * 2)], buff[static_cast<size_t>(i * 2 + 1)]));
   }
 }
 
 template <typename T>
 void ReadVector(const std::string& fName,
                 const viskores::Id& nTuples,
+                viskores::IdComponent numComponents,
+                const viskores::Id& byteOffset,
+                bool swapEndian,
                 viskores::cont::ArrayHandle<viskores::Vec<T, 3>>& var)
 {
+  if (numComponents != 3)
+    throw viskores::io::ErrorIO("Internal error: invalid Vec3 component count");
+
   std::vector<T> buff;
-  ReadBuffer(fName, nTuples * 3, buff);
+  ReadBuffer(fName, SafeMultiply(nTuples, 3, "BOV Vec3 tuple count"), byteOffset, swapEndian, buff);
 
   var.Allocate(nTuples);
-  viskores::Vec<T, 3> v;
   auto writePortal = var.WritePortal();
   for (viskores::Id i = 0; i < nTuples; i++)
   {
-    v[0] = buff[static_cast<size_t>(i * 3 + 0)];
-    v[1] = buff[static_cast<size_t>(i * 3 + 1)];
-    v[2] = buff[static_cast<size_t>(i * 3 + 2)];
-    writePortal.Set(i, v);
+    writePortal.Set(i,
+                    viskores::Vec<T, 3>(buff[static_cast<size_t>(i * 3)],
+                                        buff[static_cast<size_t>(i * 3 + 1)],
+                                        buff[static_cast<size_t>(i * 3 + 2)]));
+  }
+}
+
+template <typename T>
+void ReadRuntimeVector(const std::string& fName,
+                       const viskores::Id& nTuples,
+                       viskores::IdComponent numComponents,
+                       const viskores::Id& byteOffset,
+                       bool swapEndian,
+                       viskores::cont::ArrayHandleRuntimeVec<T>& var)
+{
+  if (numComponents < 1)
+    throw viskores::io::ErrorIO("DATA_COMPONENTS must be >= 1");
+
+  std::vector<T> buff;
+  ReadBuffer(
+    fName,
+    SafeMultiply(nTuples, static_cast<viskores::Id>(numComponents), "BOV runtime tuple count"),
+    byteOffset,
+    swapEndian,
+    buff);
+  var = viskores::cont::make_ArrayHandleRuntimeVecMove(numComponents, std::move(buff));
+}
+
+template <typename ArrayHandleType>
+void AddField(viskores::cont::DataSet& dataSet, const BOVHeader& header, const ArrayHandleType& var)
+{
+  if (header.FieldCentering == Centering::Zonal)
+    dataSet.AddCellField(header.VariableName, var);
+  else
+    dataSet.AddPointField(header.VariableName, var);
+}
+
+template <typename T>
+void ReadAndAddScalarField(viskores::cont::DataSet& dataSet,
+                           const BOVHeader& header,
+                           const std::string& dataFileName,
+                           viskores::Id numTuples,
+                           bool swapEndian)
+{
+  viskores::cont::ArrayHandle<T> var;
+  ReadScalar(dataFileName, numTuples, header.ByteOffset, swapEndian, var);
+  AddField(dataSet, header, var);
+}
+
+template <typename T, viskores::IdComponent NUM_COMPONENTS>
+void ReadAndAddVectorField(viskores::cont::DataSet& dataSet,
+                           const BOVHeader& header,
+                           const std::string& dataFileName,
+                           viskores::Id numTuples,
+                           bool swapEndian)
+{
+  viskores::cont::ArrayHandle<viskores::Vec<T, NUM_COMPONENTS>> var;
+  ReadVector(dataFileName, numTuples, header.NumComponents, header.ByteOffset, swapEndian, var);
+  AddField(dataSet, header, var);
+}
+
+template <typename T>
+void ReadAndAddRuntimeVectorField(viskores::cont::DataSet& dataSet,
+                                  const BOVHeader& header,
+                                  const std::string& dataFileName,
+                                  viskores::Id numTuples,
+                                  bool swapEndian)
+{
+  viskores::cont::ArrayHandleRuntimeVec<T> var;
+  ReadRuntimeVector(
+    dataFileName, numTuples, header.NumComponents, header.ByteOffset, swapEndian, var);
+  AddField(dataSet, header, var);
+}
+
+void ReadAndAddField(viskores::cont::DataSet& dataSet,
+                     const BOVHeader& header,
+                     const std::string& dataFileName)
+{
+  const viskores::Id numTuples = Product(header.DataSize);
+  const bool swapEndian =
+    header.HasEndian && (header.DataIsLittleEndian != viskores::io::internal::IsLittleEndian());
+
+  if (header.NumComponents == 1)
+  {
+    switch (header.Format)
+    {
+      case DataFormat::Byte:
+        ReadAndAddScalarField<viskores::UInt8>(
+          dataSet, header, dataFileName, numTuples, swapEndian);
+        break;
+      case DataFormat::Short:
+        ReadAndAddScalarField<viskores::Int16>(
+          dataSet, header, dataFileName, numTuples, swapEndian);
+        break;
+      case DataFormat::Integer:
+        ReadAndAddScalarField<viskores::Int32>(
+          dataSet, header, dataFileName, numTuples, swapEndian);
+        break;
+      case DataFormat::Float:
+        ReadAndAddScalarField<viskores::Float32>(
+          dataSet, header, dataFileName, numTuples, swapEndian);
+        break;
+      case DataFormat::Double:
+        ReadAndAddScalarField<viskores::Float64>(
+          dataSet, header, dataFileName, numTuples, swapEndian);
+        break;
+    }
+  }
+  else if (header.NumComponents == 2)
+  {
+    switch (header.Format)
+    {
+      case DataFormat::Byte:
+        ReadAndAddVectorField<viskores::UInt8, 2>(
+          dataSet, header, dataFileName, numTuples, swapEndian);
+        break;
+      case DataFormat::Short:
+        ReadAndAddVectorField<viskores::Int16, 2>(
+          dataSet, header, dataFileName, numTuples, swapEndian);
+        break;
+      case DataFormat::Integer:
+        ReadAndAddVectorField<viskores::Int32, 2>(
+          dataSet, header, dataFileName, numTuples, swapEndian);
+        break;
+      case DataFormat::Float:
+        ReadAndAddVectorField<viskores::Float32, 2>(
+          dataSet, header, dataFileName, numTuples, swapEndian);
+        break;
+      case DataFormat::Double:
+        ReadAndAddVectorField<viskores::Float64, 2>(
+          dataSet, header, dataFileName, numTuples, swapEndian);
+        break;
+    }
+  }
+  else if (header.NumComponents == 3)
+  {
+    switch (header.Format)
+    {
+      case DataFormat::Byte:
+        ReadAndAddVectorField<viskores::UInt8, 3>(
+          dataSet, header, dataFileName, numTuples, swapEndian);
+        break;
+      case DataFormat::Short:
+        ReadAndAddVectorField<viskores::Int16, 3>(
+          dataSet, header, dataFileName, numTuples, swapEndian);
+        break;
+      case DataFormat::Integer:
+        ReadAndAddVectorField<viskores::Int32, 3>(
+          dataSet, header, dataFileName, numTuples, swapEndian);
+        break;
+      case DataFormat::Float:
+        ReadAndAddVectorField<viskores::Float32, 3>(
+          dataSet, header, dataFileName, numTuples, swapEndian);
+        break;
+      case DataFormat::Double:
+        ReadAndAddVectorField<viskores::Float64, 3>(
+          dataSet, header, dataFileName, numTuples, swapEndian);
+        break;
+    }
+  }
+  else
+  {
+    switch (header.Format)
+    {
+      case DataFormat::Byte:
+        ReadAndAddRuntimeVectorField<viskores::UInt8>(
+          dataSet, header, dataFileName, numTuples, swapEndian);
+        break;
+      case DataFormat::Short:
+        ReadAndAddRuntimeVectorField<viskores::Int16>(
+          dataSet, header, dataFileName, numTuples, swapEndian);
+        break;
+      case DataFormat::Integer:
+        ReadAndAddRuntimeVectorField<viskores::Int32>(
+          dataSet, header, dataFileName, numTuples, swapEndian);
+        break;
+      case DataFormat::Float:
+        ReadAndAddRuntimeVectorField<viskores::Float32>(
+          dataSet, header, dataFileName, numTuples, swapEndian);
+        break;
+      case DataFormat::Double:
+        ReadAndAddRuntimeVectorField<viskores::Float64>(
+          dataSet, header, dataFileName, numTuples, swapEndian);
+        break;
+    }
   }
 }
 
@@ -129,133 +699,14 @@ void BOVDataSetReader::LoadFile()
   if (this->Loaded)
     return;
 
-  std::ifstream stream(this->FileName);
-  if (stream.fail())
-    throw viskores::io::ErrorIO("Failed to open file: " + this->FileName);
-
-  DataFormat dataFormat = DataFormat::ByteData;
-  std::string bovFile, line, token, options, variableName;
-  viskores::Id numComponents = 1;
-  viskores::Id3 dim;
-  viskores::Vec3f origin(0, 0, 0);
-  viskores::Vec3f spacing(1, 1, 1);
-  bool spacingSet = false;
-
-  while (stream.good())
-  {
-    std::getline(stream, line);
-    if (line.size() == 0 || line[0] == '#')
-      continue;
-    //std::cout<<"::"<<line<<"::"<<std::endl;
-    std::size_t pos = line.find(":");
-    if (pos == std::string::npos)
-      throw viskores::io::ErrorIO("Unsupported option: " + line);
-    token = line.substr(0, pos);
-    options = line.substr(pos + 1, line.size() - 1);
-    //std::cout<<token<<"::"<<options<<std::endl;
-
-    std::stringstream strStream(options);
-
-    //Format supports both space and "_" separated tokens...
-    if (token.find("DATA") != std::string::npos && token.find("FILE") != std::string::npos)
-    {
-      strStream >> bovFile >> std::ws;
-    }
-    else if (token.find("DATA") != std::string::npos && token.find("SIZE") != std::string::npos)
-    {
-      strStream >> dim[0] >> dim[1] >> dim[2] >> std::ws;
-    }
-    else if (token.find("BRICK") != std::string::npos && token.find("ORIGIN") != std::string::npos)
-    {
-      strStream >> origin[0] >> origin[1] >> origin[2] >> std::ws;
-    }
-
-    //DRP
-    else if (token.find("BRICK") != std::string::npos && token.find("SIZE") != std::string::npos)
-    {
-      strStream >> spacing[0] >> spacing[1] >> spacing[2] >> std::ws;
-      spacingSet = true;
-    }
-    else if (token.find("DATA") != std::string::npos && token.find("FORMAT") != std::string::npos)
-    {
-      std::string opt;
-      strStream >> opt >> std::ws;
-      if (opt.find("FLOAT") != std::string::npos || opt.find("REAL") != std::string::npos)
-        dataFormat = DataFormat::FloatData;
-      else if (opt.find("DOUBLE") != std::string::npos)
-        dataFormat = DataFormat::DoubleData;
-      else
-        throw viskores::io::ErrorIO("Unsupported data type: " + token);
-    }
-    else if (token.find("DATA") != std::string::npos &&
-             token.find("COMPONENTS") != std::string::npos)
-    {
-      strStream >> numComponents >> std::ws;
-      if (numComponents != 1 && numComponents != 3)
-        throw viskores::io::ErrorIO("Unsupported number of components");
-    }
-    else if (token.find("VARIABLE") != std::string::npos &&
-             token.find("PALETTE") == std::string::npos)
-    {
-      strStream >> variableName >> std::ws;
-      if (variableName[0] == '"')
-        variableName = variableName.substr(1, variableName.size() - 2);
-    }
-  }
-
-  if (spacingSet)
-  {
-    spacing[0] = (spacing[0]) / static_cast<viskores::FloatDefault>(dim[0] - 1);
-    spacing[1] = (spacing[1]) / static_cast<viskores::FloatDefault>(dim[1] - 1);
-    spacing[2] = (spacing[2]) / static_cast<viskores::FloatDefault>(dim[2] - 1);
-  }
-
-  std::string fullPathDataFile;
-  std::size_t pos = FileName.rfind("/");
-  if (pos != std::string::npos)
-  {
-    std::string baseDir;
-    baseDir = this->FileName.substr(0, pos);
-    fullPathDataFile = baseDir + "/" + bovFile;
-  }
-  else
-    fullPathDataFile = bovFile;
-
+  const BOVHeader header = ParseHeaderFile(this->FileName);
+  const viskores::Id3 pointDimensions = GetPointDimensions(header);
+  const viskores::Vec3f spacing = GetSpacing(header, pointDimensions);
+  const std::string fullPathDataFile = ResolveDataFilePath(this->FileName, header.DataFile);
 
   viskores::cont::DataSetBuilderUniform dataSetBuilder;
-  this->DataSet = dataSetBuilder.Create(dim, origin, spacing);
-
-  viskores::Id numTuples = dim[0] * dim[1] * dim[2];
-  if (numComponents == 1)
-  {
-    if (dataFormat == DataFormat::FloatData)
-    {
-      viskores::cont::ArrayHandle<viskores::Float32> var;
-      ReadScalar(fullPathDataFile, numTuples, var);
-      this->DataSet.AddPointField(variableName, var);
-    }
-    else if (dataFormat == DataFormat::DoubleData)
-    {
-      viskores::cont::ArrayHandle<viskores::Float64> var;
-      ReadScalar(fullPathDataFile, numTuples, var);
-      this->DataSet.AddPointField(variableName, var);
-    }
-  }
-  else if (numComponents == 3)
-  {
-    if (dataFormat == DataFormat::FloatData)
-    {
-      viskores::cont::ArrayHandle<viskores::Vec3f_32> var;
-      ReadVector(fullPathDataFile, numTuples, var);
-      this->DataSet.AddPointField(variableName, var);
-    }
-    else if (dataFormat == DataFormat::DoubleData)
-    {
-      viskores::cont::ArrayHandle<viskores::Vec3f_64> var;
-      ReadVector(fullPathDataFile, numTuples, var);
-      this->DataSet.AddPointField(variableName, var);
-    }
-  }
+  this->DataSet = dataSetBuilder.Create(pointDimensions, header.Origin, spacing);
+  ReadAndAddField(this->DataSet, header, fullPathDataFile);
 
   this->Loaded = true;
 }

--- a/viskores/io/CMakeLists.txt
+++ b/viskores/io/CMakeLists.txt
@@ -93,6 +93,10 @@ viskores_library(
   TEMPLATE_SOURCES ${template_sources}
 )
 
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9)
+  target_link_libraries(viskores_io PUBLIC stdc++fs)
+endif()
+
 if (Viskores_ENABLE_HDF5_IO)
   target_include_directories(viskores_io PRIVATE $<BUILD_INTERFACE:${HDF5_INCLUDE_DIR}>)
   target_link_libraries(viskores_io PRIVATE ${HDF5_HL_LIBRARIES} ${HDF5_LIBRARIES})

--- a/viskores/io/FileUtils.cxx
+++ b/viskores/io/FileUtils.cxx
@@ -20,9 +20,9 @@
 #include <viskores/cont/ErrorBadValue.h>
 
 #include <algorithm>
-// TODO (nadavi): Once we get c++17 installed uncomment this
-// #include <filesystem>
+#include <cctype>
 #include <errno.h>
+#include <filesystem>
 #include <sys/stat.h>
 
 #ifdef _WIN32
@@ -123,6 +123,35 @@ bool CreateDirectoriesFromFilePath(const std::string& filePath)
     default:
       return false;
   }
+}
+
+bool IsAbsolutePath(const std::string& filePath)
+{
+  if (filePath.empty())
+    return false;
+
+#ifdef _WIN32
+  if (filePath[0] == '/' || filePath[0] == '\\')
+    return true;
+
+  if (filePath.size() < 3)
+    return false;
+
+  if (!std::isalpha(static_cast<unsigned char>(filePath[0])) || filePath[1] != ':')
+    return false;
+
+  return filePath[2] == '/' || filePath[2] == '\\';
+#else
+  return filePath[0] == '/';
+#endif
+}
+
+std::string MakeAbsolutePath(const std::string& filePath)
+{
+  if (IsAbsolutePath(filePath))
+    return filePath;
+
+  return std::filesystem::absolute(filePath).string();
 }
 
 std::string MergePaths(const std::string& filePathPrefix, const std::string& filePathSuffix)

--- a/viskores/io/FileUtils.h
+++ b/viskores/io/FileUtils.h
@@ -42,6 +42,13 @@ VISKORES_IO_EXPORT std::string ParentPath(const std::string& filePath);
 /// if they don't exist. Only returns true if directories are actually created.
 VISKORES_IO_EXPORT bool CreateDirectoriesFromFilePath(const std::string& filePath);
 
+/// \brief Returns true if filePath is an absolute filesystem path.
+VISKORES_IO_EXPORT bool IsAbsolutePath(const std::string& filePath);
+
+/// \brief Returns an absolute path to filePath.
+/// If filePath is already absolute, it is returned unchanged.
+VISKORES_IO_EXPORT std::string MakeAbsolutePath(const std::string& filePath);
+
 /// \brief Merges two filepath strings together using the correct system filepath seperator
 /// EX: MergePaths("path/to/merge", "some/filename.txt") = "path/to/merge/some/filename.txt"
 /// EX: MergePaths("path/to/merge/", "/some/filename.txt") = "path/to/merge/some/filename.txt"

--- a/viskores/io/testing/UnitTestBOVDataSetReader.cxx
+++ b/viskores/io/testing/UnitTestBOVDataSetReader.cxx
@@ -17,14 +17,21 @@
 //============================================================================
 
 #include <string>
+#include <vector>
+
+#include <viskores/cont/ArrayHandleRuntimeVec.h>
 #include <viskores/cont/testing/Testing.h>
 #include <viskores/io/BOVDataSetReader.h>
 #include <viskores/io/ErrorIO.h>
+#include <viskores/io/FileUtils.h>
+#include <viskores/io/internal/Endian.h>
+
+#include <fstream>
 
 namespace
 {
 
-inline viskores::cont::DataSet readBOVDataSet(const char* fname)
+inline viskores::cont::DataSet ReadBOVDataSet(const char* fname)
 {
   viskores::cont::DataSet ds;
   viskores::io::BOVDataSetReader reader(fname);
@@ -45,33 +52,428 @@ inline viskores::cont::DataSet readBOVDataSet(const char* fname)
   return ds;
 }
 
-} // anonymous namespace
+std::string TestFileName(const std::string& filename)
+{
+  return "UnitTestBOVDataSetReader-" + filename;
+}
 
-void TestReadingBOVDataSet()
+std::string TestPath(const std::string& filename)
+{
+  return viskores::cont::testing::Testing::WriteDirPath(TestFileName(filename));
+}
+
+void WriteTextFile(const std::string& filename, const std::string& text)
+{
+  std::ofstream out(filename.c_str());
+  VISKORES_TEST_ASSERT(out.good(), "Unable to open test text file");
+  out << text;
+  VISKORES_TEST_ASSERT(out.good(), "Unable to write test text file");
+}
+
+template <typename T>
+void WriteBinaryFile(const std::string& filename,
+                     const std::vector<T>& values,
+                     bool fileLittleEndian = viskores::io::internal::IsLittleEndian(),
+                     const std::vector<viskores::UInt8>& prefix = std::vector<viskores::UInt8>())
+{
+  std::ofstream out(filename.c_str(), std::ios::binary);
+  VISKORES_TEST_ASSERT(out.good(), "Unable to open test binary file");
+
+  for (viskores::UInt8 byte : prefix)
+  {
+    const char ch = static_cast<char>(byte);
+    out.write(&ch, 1);
+  }
+
+  const bool reverseBytes = (fileLittleEndian != viskores::io::internal::IsLittleEndian());
+  for (const T& value : values)
+  {
+    const char* bytes = reinterpret_cast<const char*>(&value);
+    if (reverseBytes && sizeof(T) > 1)
+    {
+      for (std::size_t i = 0; i < sizeof(T); ++i)
+        out.write(bytes + (sizeof(T) - 1 - i), 1);
+    }
+    else
+      out.write(bytes, static_cast<std::streamsize>(sizeof(T)));
+  }
+  VISKORES_TEST_ASSERT(out.good(), "Unable to write test binary file");
+}
+
+template <typename T>
+void CheckField(const viskores::cont::DataSet& ds,
+                const std::string& fieldName,
+                viskores::cont::Field::Association association,
+                const std::vector<T>& expected)
+{
+  const auto& field = ds.GetField(fieldName, association);
+  auto expectedAH = viskores::cont::make_ArrayHandle(expected, viskores::CopyFlag::Off);
+  VISKORES_TEST_ASSERT(test_equal_ArrayHandles(field.GetData(), expectedAH),
+                       "Incorrect scalar value for field ",
+                       fieldName);
+}
+
+template <typename T>
+void CheckScalarField(const viskores::cont::DataSet& ds,
+                      const std::string& fieldName,
+                      viskores::cont::Field::Association association,
+                      const std::vector<T>& expected)
+{
+  CheckField(ds, fieldName, association, expected);
+}
+
+template <typename T>
+void CheckVectorField(const viskores::cont::DataSet& ds,
+                      const std::string& fieldName,
+                      const std::vector<T>& expected)
+{
+  CheckField(ds, fieldName, viskores::cont::Field::Association::Points, expected);
+}
+
+void CheckRuntimeVectorField(const viskores::cont::DataSet& ds,
+                             const std::string& fieldName,
+                             viskores::IdComponent numComponents,
+                             const std::vector<viskores::Float32>& expectedComponents)
+{
+  const auto& field = ds.GetField(fieldName, viskores::cont::Field::Association::Points);
+  const auto& data = field.GetData();
+  VISKORES_TEST_ASSERT(data.IsStorageType<viskores::cont::StorageTagRuntimeVec>(),
+                       "Expected runtime vector storage");
+
+  auto runtimeVec = data.AsArrayHandle<viskores::cont::ArrayHandleRuntimeVec<viskores::Float32>>();
+  VISKORES_TEST_ASSERT(runtimeVec.GetNumberOfComponents() == numComponents,
+                       "Incorrect runtime vector component count");
+  auto expectedAH = viskores::cont::make_ArrayHandle(expectedComponents, viskores::CopyFlag::Off);
+  VISKORES_TEST_ASSERT(test_equal_ArrayHandles(runtimeVec.GetComponentsArray(), expectedAH),
+                       "Incorrect runtime vector component values");
+}
+
+template <typename T>
+void TestScalarFormat(const std::string& testName,
+                      const std::string& bovFormat,
+                      const std::vector<T>& values)
+{
+  const std::string dataFileName = TestFileName(testName + ".bof");
+  const std::string bovFile = TestPath(testName + ".bov");
+  const std::string dataFile = viskores::cont::testing::Testing::WriteDirPath(dataFileName);
+
+  WriteBinaryFile(dataFile, values);
+  WriteTextFile(bovFile,
+                "DATA_FILE: \"" + dataFileName +
+                  "\"\n"
+                  "DATA_SIZE: 2 2 1\n"
+                  "DATA_FORMAT: " +
+                  bovFormat +
+                  "\n"
+                  "CENTERING: NODAL\n"
+                  "VARIABLE: \"values\"\n");
+
+  auto ds = ReadBOVDataSet(bovFile.c_str());
+  VISKORES_TEST_ASSERT(ds.GetNumberOfPoints() == 4, "Incorrect scalar-format point count");
+  CheckScalarField(ds, "values", viskores::cont::Field::Association::Points, values);
+}
+
+void ExpectReadFails(const std::string& bovFile)
+{
+  try
+  {
+    viskores::io::BOVDataSetReader reader(bovFile);
+    reader.ReadDataSet();
+  }
+  catch (viskores::io::ErrorIO&)
+  {
+    return;
+  }
+
+  VISKORES_TEST_FAIL("Expected BOV read to fail");
+}
+
+void TestReadingBundledBOVDataSet()
 {
   std::string bovFile =
     viskores::cont::testing::Testing::DataPath("third_party/visit/example_temp.bov");
 
-  auto const& ds = readBOVDataSet(bovFile.data());
+  auto const& ds = ReadBOVDataSet(bovFile.data());
 
   VISKORES_TEST_ASSERT(ds.GetNumberOfFields() == 2, "Incorrect number of fields");
-  // See the .bov file: DATA SIZE: 50 50 50
   VISKORES_TEST_ASSERT(ds.GetNumberOfPoints() == 50 * 50 * 50, "Incorrect number of points");
   VISKORES_TEST_ASSERT(ds.GetCellSet().GetNumberOfPoints() == 50 * 50 * 50,
                        "Incorrect number of points (from cell set)");
   VISKORES_TEST_ASSERT(ds.GetNumberOfCells() == 49 * 49 * 49, "Incorrect number of cells");
-  // See the .bov file: VARIABLE: "var"
   VISKORES_TEST_ASSERT(ds.HasField("var"), "Should have field 'var', but does not.");
-  VISKORES_TEST_ASSERT(ds.GetNumberOfFields() == 2, "There is only one field in noise.bov");
   VISKORES_TEST_ASSERT(ds.GetNumberOfCoordinateSystems() == 1,
-                       "There is only one coordinate system in noise.bov");
+                       "There is only one coordinate system in example_temp.bov");
 
   auto const& field = ds.GetField("var");
-  // I'm pretty sure that all .bov files have their fields associated with points . . .
   VISKORES_TEST_ASSERT(field.GetAssociation() == viskores::cont::Field::Association::Points,
                        "The field should be associated with points.");
 }
 
+void TestScalarFormats()
+{
+  TestScalarFormat("scalar_byte", "BYTE", std::vector<viskores::UInt8>{ 1, 2, 3, 4 });
+  TestScalarFormat("scalar_short", "SHORT", std::vector<viskores::Int16>{ -1, 2, -3, 4 });
+  TestScalarFormat(
+    "scalar_integer", "INTEGER", std::vector<viskores::Int32>{ -100000, 2, 3000, 400000 });
+  TestScalarFormat(
+    "scalar_float", "FLOAT", std::vector<viskores::Float32>{ 1.5f, 2.5f, 3.5f, 4.5f });
+  TestScalarFormat(
+    "scalar_double", "DOUBLE", std::vector<viskores::Float64>{ 1.25, 2.25, 3.25, 4.25 });
+}
+
+void TestVectorComponents()
+{
+  {
+    const std::string dataFileName = TestFileName("vector2_float.bof");
+    const std::string bovFile = TestPath("vector2_float.bov");
+    const std::string dataFile = viskores::cont::testing::Testing::WriteDirPath(dataFileName);
+    WriteBinaryFile(dataFile, std::vector<viskores::Float32>{ 1, 2, 3, 4, 5, 6, 7, 8 });
+    WriteTextFile(bovFile,
+                  "DATA_FILE: \"" + dataFileName +
+                    "\"\n"
+                    "DATA_SIZE: 2 2 1\n"
+                    "DATA_FORMAT: FLOAT\n"
+                    "DATA_COMPONENTS: 2\n"
+                    "VARIABLE: \"vectors2\"\n");
+
+    auto ds = ReadBOVDataSet(bovFile.c_str());
+    VISKORES_TEST_ASSERT(
+      !ds.GetField("vectors2").GetData().IsStorageType<viskores::cont::StorageTagRuntimeVec>(),
+      "2-component data should use a fixed Vec2 field");
+    CheckVectorField(ds,
+                     "vectors2",
+                     std::vector<viskores::Vec2f_32>{ viskores::Vec2f_32(1, 2),
+                                                      viskores::Vec2f_32(3, 4),
+                                                      viskores::Vec2f_32(5, 6),
+                                                      viskores::Vec2f_32(7, 8) });
+  }
+
+  {
+    const std::string dataFileName = TestFileName("vector3_float.bof");
+    const std::string bovFile = TestPath("vector3_float.bov");
+    const std::string dataFile = viskores::cont::testing::Testing::WriteDirPath(dataFileName);
+    WriteBinaryFile(dataFile,
+                    std::vector<viskores::Float32>{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 });
+    WriteTextFile(bovFile,
+                  "DATA_FILE: \"" + dataFileName +
+                    "\"\n"
+                    "DATA_SIZE: 2 2 1\n"
+                    "DATA_FORMAT: FLOAT\n"
+                    "DATA_COMPONENTS: 3\n"
+                    "VARIABLE: \"vectors3\"\n");
+
+    auto ds = ReadBOVDataSet(bovFile.c_str());
+    VISKORES_TEST_ASSERT(
+      !ds.GetField("vectors3").GetData().IsStorageType<viskores::cont::StorageTagRuntimeVec>(),
+      "3-component data should use a fixed Vec3 field");
+    CheckVectorField(ds,
+                     "vectors3",
+                     std::vector<viskores::Vec3f_32>{ viskores::Vec3f_32(1, 2, 3),
+                                                      viskores::Vec3f_32(4, 5, 6),
+                                                      viskores::Vec3f_32(7, 8, 9),
+                                                      viskores::Vec3f_32(10, 11, 12) });
+  }
+
+  {
+    const std::string dataFileName = TestFileName("vector4_float.bof");
+    const std::string bovFile = TestPath("vector4_float.bov");
+    const std::string dataFile = viskores::cont::testing::Testing::WriteDirPath(dataFileName);
+    std::vector<viskores::Float32> values(16);
+    for (viskores::Id i = 0; i < 16; i++)
+      values[static_cast<std::size_t>(i)] = static_cast<viskores::Float32>(i + 1);
+    WriteBinaryFile(dataFile, values);
+    WriteTextFile(bovFile,
+                  "DATA_FILE: \"" + dataFileName +
+                    "\"\n"
+                    "DATA_SIZE: 2 2 1\n"
+                    "DATA_FORMAT: FLOAT\n"
+                    "DATA_COMPONENTS: 4\n"
+                    "VARIABLE: \"vectors4\"\n");
+
+    auto ds = ReadBOVDataSet(bovFile.c_str());
+    CheckRuntimeVectorField(ds, "vectors4", 4, values);
+  }
+
+  {
+    const std::string dataFileName = TestFileName("vector13_float.bof");
+    const std::string bovFile = TestPath("vector13_float.bov");
+    const std::string dataFile = viskores::cont::testing::Testing::WriteDirPath(dataFileName);
+    std::vector<viskores::Float32> values(52);
+    for (viskores::Id i = 0; i < 52; i++)
+      values[static_cast<std::size_t>(i)] = static_cast<viskores::Float32>(i + 101);
+    WriteBinaryFile(dataFile, values);
+    WriteTextFile(bovFile,
+                  "DATA_FILE: \"" + dataFileName +
+                    "\"\n"
+                    "DATA_SIZE: 2 2 1\n"
+                    "DATA_FORMAT: FLOAT\n"
+                    "DATA_COMPONENTS: 13\n"
+                    "VARIABLE: \"vectors13\"\n");
+
+    auto ds = ReadBOVDataSet(bovFile.c_str());
+    CheckRuntimeVectorField(ds, "vectors13", 13, values);
+  }
+
+  {
+    const std::string dataFileName = TestFileName("vector_complex_float.bof");
+    const std::string bovFile = TestPath("vector_complex_float.bov");
+    const std::string dataFile = viskores::cont::testing::Testing::WriteDirPath(dataFileName);
+    WriteBinaryFile(dataFile, std::vector<viskores::Float32>{ 1, 2, 3, 4, 5, 6, 7, 8 });
+    WriteTextFile(bovFile,
+                  "DATA_FILE: \"" + dataFileName +
+                    "\"\n"
+                    "DATA_SIZE: 2 2 1\n"
+                    "DATA_FORMAT: FLOAT\n"
+                    "DATA_COMPONENTS: COMPLEX\n"
+                    "VARIABLE: \"complex\"\n");
+
+    auto ds = ReadBOVDataSet(bovFile.c_str());
+    CheckVectorField(ds,
+                     "complex",
+                     std::vector<viskores::Vec2f_32>{ viskores::Vec2f_32(1, 2),
+                                                      viskores::Vec2f_32(3, 4),
+                                                      viskores::Vec2f_32(5, 6),
+                                                      viskores::Vec2f_32(7, 8) });
+  }
+}
+
+void TestEndianAndByteOffset()
+{
+  const bool fileLittleEndian = !viskores::io::internal::IsLittleEndian();
+  const std::string endianName = fileLittleEndian ? "LITTLE" : "BIG";
+  const std::string dataFileName = TestFileName("offset_endian.bof");
+  const std::string bovFile = TestPath("offset_endian.bov");
+  const std::string dataFile = viskores::cont::testing::Testing::WriteDirPath(dataFileName);
+  const std::vector<viskores::Int32> values{ 0x01020304, -17, 1000000, 42 };
+
+  WriteBinaryFile(dataFile, values, fileLittleEndian, std::vector<viskores::UInt8>{ 0, 1, 2, 3 });
+  WriteTextFile(bovFile,
+                "DATA_FILE: \"" + dataFileName +
+                  "\"\n"
+                  "DATA_SIZE: 2 2 1\n"
+                  "DATA_FORMAT: INTEGER\n"
+                  "DATA_ENDIAN: " +
+                  endianName +
+                  "\n"
+                  "BYTE_OFFSET: 4\n"
+                  "VARIABLE: \"values\"\n");
+
+  auto ds = ReadBOVDataSet(bovFile.c_str());
+  CheckScalarField(ds, "values", viskores::cont::Field::Association::Points, values);
+}
+
+void TestZonalCentering()
+{
+  const std::string dataFileName = TestFileName("zonal_float.bof");
+  const std::string bovFile = TestPath("zonal_float.bov");
+  const std::string dataFile = viskores::cont::testing::Testing::WriteDirPath(dataFileName);
+  const std::vector<viskores::Float32> values{ 1, 2, 3, 4, 5, 6 };
+
+  WriteBinaryFile(dataFile, values);
+  WriteTextFile(bovFile,
+                "DATA_FILE: \"" + dataFileName +
+                  "\"\n"
+                  "DATA_SIZE: 2 3 1\n"
+                  "DATA_FORMAT: FLOAT\n"
+                  "CENTERING: ZONAL\n"
+                  "BRICK_ORIGIN: -1 -2 -3\n"
+                  "BRICK_SIZE: 2 3 1\n"
+                  "VARIABLE: \"zonevar\"\n");
+
+  auto ds = ReadBOVDataSet(bovFile.c_str());
+  VISKORES_TEST_ASSERT(ds.GetNumberOfCells() == 6, "Incorrect zonal cell count");
+  VISKORES_TEST_ASSERT(ds.GetNumberOfPoints() == 3 * 4 * 2, "Incorrect zonal point count");
+  CheckScalarField(ds, "zonevar", viskores::cont::Field::Association::Cells, values);
+
+  const viskores::Bounds expectedBounds(-1, 1, -2, 1, -3, -2);
+  VISKORES_TEST_ASSERT(test_equal(ds.GetCoordinateSystem().GetBounds(), expectedBounds),
+                       "Incorrect zonal bounds");
+}
+
+void TestAbsoluteDataFile()
+{
+  const std::string bovFile = TestPath("absolute_path.bov");
+  const std::string dataFile = viskores::io::MakeAbsolutePath(TestPath("absolute_path.bof"));
+  const std::vector<viskores::Float64> values{ 9.0, 8.0, 7.0, 6.0 };
+
+  WriteBinaryFile(dataFile, values);
+  WriteTextFile(bovFile,
+                "DATA_FILE: \"" + dataFile +
+                  "\"\n"
+                  "DATA_SIZE: 2 2 1\n"
+                  "DATA_FORMAT: DOUBLE\n"
+                  "VARIABLE: \"absolute\"\n");
+
+  auto ds = ReadBOVDataSet(bovFile.c_str());
+  CheckScalarField(ds, "absolute", viskores::cont::Field::Association::Points, values);
+}
+
+void TestBadHeaders()
+{
+  const std::string dataFile = TestPath("bad_headers.bof");
+  WriteBinaryFile(dataFile, std::vector<viskores::Float32>{ 1, 2, 3, 4 });
+
+  const std::string missingDataFile = TestPath("missing_data_file.bov");
+  WriteTextFile(missingDataFile,
+                "DATA_SIZE: 2 2 1\n"
+                "DATA_FORMAT: FLOAT\n"
+                "VARIABLE: \"bad\"\n");
+  ExpectReadFails(missingDataFile);
+
+  const std::string badComponents = TestPath("bad_components.bov");
+  WriteTextFile(badComponents,
+                "DATA_FILE: \"" + TestFileName("bad_headers.bof") +
+                  "\"\n"
+                  "DATA_SIZE: 2 2 1\n"
+                  "DATA_FORMAT: FLOAT\n"
+                  "DATA_COMPONENTS: abc\n"
+                  "VARIABLE: \"bad\"\n");
+  ExpectReadFails(badComponents);
+
+  const std::string invalidComponents = TestPath("invalid_components.bov");
+  WriteTextFile(invalidComponents,
+                "DATA_FILE: \"" + TestFileName("bad_headers.bof") +
+                  "\"\n"
+                  "DATA_SIZE: 2 2 1\n"
+                  "DATA_FORMAT: FLOAT\n"
+                  "DATA_COMPONENTS: 0\n"
+                  "VARIABLE: \"bad\"\n");
+  ExpectReadFails(invalidComponents);
+
+  const std::string dividedBrick = TestPath("divided_brick.bov");
+  WriteTextFile(dividedBrick,
+                "DATA_FILE: \"" + TestFileName("bad_headers.bof") +
+                  "\"\n"
+                  "DATA_SIZE: 2 2 1\n"
+                  "DATA_FORMAT: FLOAT\n"
+                  "DIVIDE_BRICK: TRUE\n"
+                  "VARIABLE: \"bad\"\n");
+  ExpectReadFails(dividedBrick);
+
+  const std::string truncatedData = TestPath("truncated_data.bov");
+  const std::string truncatedBof = TestPath("truncated_data.bof");
+  WriteBinaryFile(truncatedBof, std::vector<viskores::Float32>{ 1 });
+  WriteTextFile(truncatedData,
+                "DATA_FILE: \"" + TestFileName("truncated_data.bof") +
+                  "\"\n"
+                  "DATA_SIZE: 2 2 1\n"
+                  "DATA_FORMAT: FLOAT\n"
+                  "VARIABLE: \"bad\"\n");
+  ExpectReadFails(truncatedData);
+}
+
+void TestReadingBOVDataSet()
+{
+  TestReadingBundledBOVDataSet();
+  TestScalarFormats();
+  TestVectorComponents();
+  TestEndianAndByteOffset();
+  TestZonalCentering();
+  TestAbsoluteDataFile();
+  TestBadHeaders();
+}
+
+} // anonymous namespace
 
 int UnitTestBOVDataSetReader(int argc, char* argv[])
 {

--- a/viskores/io/testing/UnitTestFileUtils.cxx
+++ b/viskores/io/testing/UnitTestFileUtils.cxx
@@ -153,6 +153,53 @@ void TestMergePaths()
 #endif
 }
 
+void TestIsAbsolutePath()
+{
+  VISKORES_TEST_ASSERT(IsAbsolutePath("/absolute/path"), "Should detect POSIX absolute path");
+  VISKORES_TEST_ASSERT(!IsAbsolutePath("relative/path"), "Should reject relative path");
+  VISKORES_TEST_ASSERT(!IsAbsolutePath(""), "Should reject empty path");
+#ifdef _MSC_VER
+  VISKORES_TEST_ASSERT(IsAbsolutePath("C:\\windows\\path"),
+                       "Should detect Windows drive absolute path");
+  VISKORES_TEST_ASSERT(IsAbsolutePath("C:/windows/path"),
+                       "Should detect Windows drive absolute path with forward slashes");
+  VISKORES_TEST_ASSERT(IsAbsolutePath("\\windows\\path"),
+                       "Should detect Windows rooted absolute path");
+  VISKORES_TEST_ASSERT(IsAbsolutePath("/windows/path"),
+                       "Should detect Windows rooted absolute path with forward slashes");
+  VISKORES_TEST_ASSERT(!IsAbsolutePath("windows\\path"), "Should reject Windows relative path");
+  VISKORES_TEST_ASSERT(!IsAbsolutePath("windows/path"),
+                       "Should reject Windows relative path with forward slashes");
+  VISKORES_TEST_ASSERT(!IsAbsolutePath("C:windows\\path"),
+                       "Should reject Windows drive-relative path");
+  VISKORES_TEST_ASSERT(!IsAbsolutePath("C:windows/path"),
+                       "Should reject Windows drive-relative path with forward slashes");
+#endif
+}
+
+void TestMakeAbsolutePath()
+{
+  VISKORES_TEST_ASSERT(MakeAbsolutePath("/absolute/path") == "/absolute/path",
+                       "Should leave absolute path unchanged");
+
+  const std::string absoluteRelativePath = MakeAbsolutePath("relative/path");
+  VISKORES_TEST_ASSERT(IsAbsolutePath(absoluteRelativePath), "Should make relative path absolute");
+#ifdef _MSC_VER
+  VISKORES_TEST_ASSERT(EndsWith(absoluteRelativePath, "relative/path") ||
+                         EndsWith(absoluteRelativePath, "relative\\path"),
+                       "Should keep relative path suffix");
+#else
+  VISKORES_TEST_ASSERT(EndsWith(absoluteRelativePath, "relative/path"),
+                       "Should keep relative path suffix");
+#endif
+#ifdef _MSC_VER
+  VISKORES_TEST_ASSERT(MakeAbsolutePath("C:\\windows\\path") == "C:\\windows\\path",
+                       "Should leave Windows drive absolute path unchanged");
+  VISKORES_TEST_ASSERT(MakeAbsolutePath("\\windows\\path") == "\\windows\\path",
+                       "Should leave Windows rooted absolute path unchanged");
+#endif
+}
+
 void TestPrefixStringToFilename()
 {
   VISKORES_TEST_ASSERT(PrefixStringToFilename("some/path/filename.txt", "prefix-") ==
@@ -195,6 +242,8 @@ void TestUtils()
   TestParentPath();
   TestCreateDirectoriesFromFilePath();
   TestMergePaths();
+  TestIsAbsolutePath();
+  TestMakeAbsolutePath();
   TestPrefixStringToFilename();
 }
 


### PR DESCRIPTION
Expand BOV parsing to handle scalar/vector fields, endian settings, byte offsets, absolute data paths, and zonal centering. Add validation for malformed or unsupported headers and reject divided bricks explicitly.

Move path absolute checks into FileUtils, add MakeAbsolutePath, and cover both helpers in FileUtils tests. Extend BOV reader tests with generated fixtures for formats, vectors, endian/offset handling, zonal data, absolute paths, and error cases.