### PR TITLE
Fix issues when compiling with Cuda 13.2 (backport version 1.1)

### DIFF
--- a/viskores/cont/cuda/internal/DeviceAdapterAlgorithmCuda.h
+++ b/viskores/cont/cuda/internal/DeviceAdapterAlgorithmCuda.h
@@ -57,7 +57,9 @@ VISKORES_THIRDPARTY_PRE_INCLUDE
 #include <thrust/binary_search.h>
 #include <thrust/copy.h>
 #include <thrust/count.h>
+#include <thrust/distance.h>
 #include <thrust/iterator/counting_iterator.h>
+#include <thrust/pair.h>
 #include <thrust/scan.h>
 #include <thrust/sort.h>
 #include <thrust/system/cpp/memory.h>

--- a/viskores/exec/cuda/internal/ExecutionPolicy.h
+++ b/viskores/exec/cuda/internal/ExecutionPolicy.h
@@ -25,6 +25,7 @@
 #include <viskores/exec/cuda/internal/ThrustPatches.h>
 VISKORES_THIRDPARTY_PRE_INCLUDE
 #include <thrust/execution_policy.h>
+#include <thrust/pair.h>
 #include <thrust/sort.h>
 #include <thrust/system/cuda/execution_policy.h>
 #include <thrust/system/cuda/memory.h>


### PR DESCRIPTION
Header files for thrust components like distance and pair need to be explicitly included.