### PR TITLE
Add minimal Python UnknownArrayHandle bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,7 @@ viskores_option(Viskores_ENABLE_MPI "Enable MPI support" OFF)
 viskores_option(Viskores_ENABLE_DOCUMENTATION "Build Doxygen documentation" OFF)
 viskores_option(Viskores_ENABLE_EXAMPLES "Build examples" OFF)
 viskores_option(Viskores_ENABLE_TUTORIALS "Build tutorials" OFF)
+viskores_option(Viskores_ENABLE_PYTHON_BINDINGS "Build Python bindings" OFF)
 if (NOT DEFINED Viskores_ENABLE_TESTING)
     if(EXISTS "${CMAKE_SOURCE_DIR}/.git")
       viskores_option(Viskores_ENABLE_TESTING "Enable Viskores Testing" ON)
@@ -253,6 +254,7 @@ viskores_module_force_group(Testing
   )
 viskores_module_force_group(Benchmarking ENABLE_OPTION Viskores_ENABLE_BENCHMARKS)
 viskores_module_force_group(ANARI ENABLE_OPTION Viskores_ENABLE_ANARI)
+viskores_module_force_group(PythonBindings ENABLE_OPTION Viskores_ENABLE_PYTHON_BINDINGS)
 
 # The tutorial requires several common filters. This logic might need to
 # become more complicated (or less compliated if we decide to always
@@ -379,7 +381,7 @@ add_subdirectory(viskoresstd)
 #-----------------------------------------------------------------------------
 # Process modules
 viskores_modules_scan(
-  SCAN_DIRECTORIES viskores benchmarking docs
+  SCAN_DIRECTORIES viskores benchmarking docs python_bindings
   PROVIDED_MODULES all_modules
   )
 viskores_modules_build(

--- a/docs/changelog/python-bindings-minimal-array.md
+++ b/docs/changelog/python-bindings-minimal-array.md
@@ -1,0 +1,23 @@
+## Add minimal Python bindings for UnknownArrayHandle
+
+Viskores now provides Python bindings for `viskores::cont::UnknownArrayHandle`
+and zero-copy conversion to and from NumPy:
+
+* `viskores.cont.array_from_numpy(array, allow_copy=False)` wraps a NumPy
+  array as a `UnknownArrayHandle`, sharing storage when the input is
+  C-contiguous, aligned, and writable. Pass `allow_copy=True` to let the
+  binding make a contiguous, writable copy when the input layout cannot be
+  shared directly. Supported on 1D scalar and 2D vector NumPy arrays for
+  every dtype that has a Viskores scalar equivalent.
+
+* `viskores.cont.asnumpy(array)` (and the `asnumpy` method on
+  `UnknownArrayHandle`) returns a read-only NumPy view of any basic or
+  runtime-vec `ArrayHandle`. Pointer stability is provided by
+  `Buffer::PinHost`, so the view is zero-copy even when the source buffer
+  was allocated by Viskores rather than by NumPy. Other array layouts are
+  resolved through `CastAndCallForTypes` and copied into a fresh NumPy
+  array.
+
+The build is opt-in via `Viskores_ENABLE_PYTHON_BINDINGS=ON` and
+optionally targets the CPython stable ABI with
+`VISKORES_PYTHON_STABLE_ABI=ON` (requires Python 3.12 and CMake 3.26).

--- a/python_bindings/CMakeLists.txt
+++ b/python_bindings/CMakeLists.txt
@@ -1,0 +1,133 @@
+##============================================================================
+##  The contents of this file are covered by the Viskores license. See
+##  LICENSE.txt for details.
+##
+##  By contributing to this file, all contributors agree to the Developer
+##  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+##============================================================================
+
+# Keep stable ABI support optional while the binding surface is small. This
+# lets developers check abi3 compatibility without making it the default build.
+option(VISKORES_PYTHON_STABLE_ABI "Build Python bindings with the CPython stable ABI" OFF)
+
+set(Viskores_PYTHON_COMPONENTS Interpreter Development)
+if (VISKORES_PYTHON_STABLE_ABI AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.26)
+  list(APPEND Viskores_PYTHON_COMPONENTS Development.SABIModule)
+endif()
+find_package(Python 3.8 REQUIRED COMPONENTS ${Viskores_PYTHON_COMPONENTS})
+
+# Minimum nanobind version. nb::ndarray dtype dispatch and the stable-ABI
+# support used here require nanobind 2.0 or newer.
+set(Viskores_PYTHON_NANOBIND_MIN_VERSION "2.0.0")
+
+execute_process(
+  COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir
+  OUTPUT_VARIABLE Viskores_PYTHON_NANOBIND_CMAKE_DIR
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  RESULT_VARIABLE Viskores_PYTHON_NANOBIND_RESULT
+)
+if (NOT Viskores_PYTHON_NANOBIND_RESULT EQUAL 0)
+  message(FATAL_ERROR
+    "nanobind ${Viskores_PYTHON_NANOBIND_MIN_VERSION} or newer is required to "
+    "build Viskores Python bindings. Install with: pip install 'nanobind>="
+    "${Viskores_PYTHON_NANOBIND_MIN_VERSION}'.")
+endif()
+
+find_package(nanobind ${Viskores_PYTHON_NANOBIND_MIN_VERSION} CONFIG REQUIRED
+  PATHS "${Viskores_PYTHON_NANOBIND_CMAKE_DIR}"
+  NO_DEFAULT_PATH
+)
+
+set(Viskores_PYTHON_NANOBIND_STABLE_ABI)
+if (VISKORES_PYTHON_STABLE_ABI)
+  if (Python_VERSION VERSION_LESS 3.12)
+    message(FATAL_ERROR
+      "VISKORES_PYTHON_STABLE_ABI requires Python 3.12 or newer.")
+  endif()
+  if (NOT TARGET Python::SABIModule)
+    message(FATAL_ERROR
+      "VISKORES_PYTHON_STABLE_ABI requires CMake FindPython support for "
+      "Python::SABIModule. Use CMake 3.26 or newer, or configure with "
+      "-DVISKORES_PYTHON_STABLE_ABI=OFF.")
+  endif()
+  set(Viskores_PYTHON_NANOBIND_STABLE_ABI STABLE_ABI)
+endif()
+
+# Minimum NumPy version. The binding uses the buffer protocol and the standard
+# ndarray flags (c_contiguous, aligned, writeable) that have been stable since
+# NumPy 1.20.
+set(Viskores_PYTHON_NUMPY_MIN_VERSION "1.20.0")
+
+# Pass the minimum version as an argv argument rather than substituting it into
+# the Python source string, so an unexpected character in the version literal
+# cannot interact with Python parsing. NumPy ships its own version comparator
+# (numpy.lib.NumpyVersion), so we don't need the third-party `packaging` module.
+execute_process(
+  COMMAND "${Python_EXECUTABLE}" -c
+    "import sys; from numpy.lib import NumpyVersion; import numpy; \
+sys.exit(0 if NumpyVersion(numpy.__version__) >= NumpyVersion(sys.argv[1]) else 1)"
+    "${Viskores_PYTHON_NUMPY_MIN_VERSION}"
+  RESULT_VARIABLE Viskores_PYTHON_NUMPY_RESULT
+)
+if (NOT Viskores_PYTHON_NUMPY_RESULT EQUAL 0)
+  message(FATAL_ERROR
+    "NumPy ${Viskores_PYTHON_NUMPY_MIN_VERSION} or newer is required to build "
+    "Viskores Python bindings.")
+endif()
+
+set(Viskores_PYTHON_PACKAGE_ROOT "${Viskores_BINARY_DIR}/python_bindings")
+set(Viskores_PYTHON_PACKAGE_DIR "${Viskores_PYTHON_PACKAGE_ROOT}/viskores")
+file(MAKE_DIRECTORY "${Viskores_PYTHON_PACKAGE_DIR}")
+
+# List Python source files explicitly. The set is small and listing files keeps
+# the dependency graph deterministic; revisit if the package grows.
+set(Viskores_PYTHON_PACKAGE_FILES
+  "${CMAKE_CURRENT_SOURCE_DIR}/viskores/__init__.py"
+  "${CMAKE_CURRENT_SOURCE_DIR}/viskores/cont/__init__.py"
+)
+set(Viskores_PYTHON_PACKAGE_STAMP
+  "${Viskores_BINARY_DIR}/python_bindings/.python_package_sync.stamp")
+
+add_custom_command(
+  OUTPUT "${Viskores_PYTHON_PACKAGE_STAMP}"
+  COMMAND "${CMAKE_COMMAND}" -E make_directory "${Viskores_PYTHON_PACKAGE_ROOT}"
+  COMMAND "${CMAKE_COMMAND}" -E copy_directory
+          "${CMAKE_CURRENT_SOURCE_DIR}/viskores"
+          "${Viskores_PYTHON_PACKAGE_DIR}"
+  COMMAND "${CMAKE_COMMAND}" -E touch "${Viskores_PYTHON_PACKAGE_STAMP}"
+  DEPENDS ${Viskores_PYTHON_PACKAGE_FILES}
+)
+add_custom_target(viskores_python_package_sync
+  DEPENDS "${Viskores_PYTHON_PACKAGE_STAMP}")
+
+nanobind_add_module(viskores_python_bindings ${Viskores_PYTHON_NANOBIND_STABLE_ABI} NOMINSIZE
+  src/cont_bindings.cxx
+  src/viskores_python_bindings.cxx
+)
+target_compile_features(viskores_python_bindings PRIVATE cxx_std_17)
+target_compile_definitions(viskores_python_bindings PRIVATE PY_SSIZE_T_CLEAN)
+target_include_directories(viskores_python_bindings
+  PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}/src"
+)
+target_link_libraries(viskores_python_bindings PRIVATE
+  viskores_cont
+  viskores_interop_python
+)
+add_dependencies(viskores_python_bindings viskores_python_package_sync)
+set_target_properties(viskores_python_bindings PROPERTIES
+  PREFIX ""
+  OUTPUT_NAME "_viskores"
+  LIBRARY_OUTPUT_DIRECTORY "${Viskores_PYTHON_PACKAGE_DIR}"
+  RUNTIME_OUTPUT_DIRECTORY "${Viskores_PYTHON_PACKAGE_DIR}"
+)
+
+set(_viskores_python_site_dir
+  "lib/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages")
+install(TARGETS viskores_python_bindings
+  LIBRARY DESTINATION "${_viskores_python_site_dir}/viskores"
+)
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/viskores/"
+  DESTINATION "${_viskores_python_site_dir}/viskores"
+  FILES_MATCHING PATTERN "*.py"
+)

--- a/python_bindings/README.md
+++ b/python_bindings/README.md
@@ -1,0 +1,125 @@
+# Minimal Python Bindings
+
+This directory contains an initial manual Python binding slice for
+`viskores::cont::UnknownArrayHandle` NumPy input/output.
+
+The current binding surface includes:
+
+- `viskores.cont.UnknownArrayHandle`
+- `viskores.cont.array_from_numpy`
+- `viskores.cont.asnumpy`
+
+Dense scalar and runtime-vector arrays can be viewed as NumPy arrays.
+
+## NumPy Ownership
+
+`viskores.cont.array_from_numpy` shares storage with dense NumPy arrays rather
+than copying them. Viskores does not delete the NumPy array memory directly.
+Instead, the binding gives the Viskores `ArrayHandleBasic` a small owner object
+that keeps the Python array alive for as long as Viskores can access its data.
+
+The lifetime chain is:
+
+1. The binding creates a `PyBufferOwner` for the NumPy array.
+2. `PyBufferOwner` stores a Python reference to the NumPy array, increasing the
+   array's reference count.
+3. `PyBufferOwner` also acquires a writable Python buffer export for the array
+   data.
+4. `ArrayHandleBasic` receives the raw buffer pointer, the `PyBufferOwner`
+   pointer as its container, and a deleter callback.
+5. When the last Viskores buffer reference is destroyed, Viskores calls the
+   deleter callback with the `PyBufferOwner` pointer.
+6. The deleter acquires Python's Global Interpreter Lock and deletes
+   `PyBufferOwner`.
+7. `PyBufferOwner` releases the Python buffer export and drops its Python
+   reference to the NumPy array.
+8. If no other Python references remain, NumPy can then destroy the array and
+   release its memory.
+
+Destroying one Python `UnknownArrayHandle` object does not necessarily release
+the NumPy array immediately. Other Viskores handles that share the same buffer,
+such as copied `UnknownArrayHandle` objects or derived `ArrayHandle` objects,
+keep the owner alive until the last shared Viskores buffer reference is gone.
+
+## Non-Shareable Inputs
+
+By default `array_from_numpy(arr)` requires the NumPy array to be C-contiguous,
+aligned, and writable so its storage can be shared with Viskores. Inputs that
+do not meet those requirements (e.g., slices like `arr[::2]`, or read-only
+arrays) are rejected with a descriptive error.
+
+Pass `allow_copy=True` to allow the binding to make a contiguous, writable copy
+automatically:
+
+```python
+unknown = viskores.cont.array_from_numpy(arr[::2], allow_copy=True)
+```
+
+`allow_copy=True` is permissive, not mandatory: when the input is already shareable,
+the binding still uses the zero-copy path. When a copy is made, the original
+NumPy array is no longer connected to the resulting `UnknownArrayHandle`.
+
+## Mutability and Resizing
+
+Sharing storage means writes are visible across the boundary in both directions:
+
+- The source NumPy array remains writable. Mutations through it are immediately
+  visible to Viskores. NumPy views returned by `asnumpy` are read-only so
+  Python code cannot accidentally mutate Viskores-owned data through a view; to
+  modify the data, mutate the original NumPy array.
+- A Viskores filter or worklet that writes through the shared `ArrayHandle`
+  mutates the original NumPy array in place. If you do not want filter writes
+  to land in your input array, copy the array before passing it through
+  `array_from_numpy`.
+
+Buffers created from NumPy cannot be resized through the Viskores
+`ArrayHandle`. Calls that would reallocate the buffer (for example
+`ArrayHandle::Allocate` with a different size) raise
+`viskores::cont::ErrorBadAllocation`. The Python NumPy array owns the
+allocation, so Viskores is not allowed to free or replace it.
+
+## NumPy Output: Zero-Copy View
+
+`viskores.cont.UnknownArrayHandle.asnumpy` and `viskores.cont.asnumpy` return a
+zero-copy NumPy view of any basic or runtime-vec `ArrayHandle`, regardless of
+whether the buffer was originally created from NumPy or allocated by Viskores
+itself (for example, the output of a filter). Other array layouts are resolved
+through `CastAndCallForTypes` and always copied.
+
+Pointer stability for the view is provided by `Buffer::PinHost`, which the
+binding calls on the source buffer before constructing the view. PinHost is
+irreversible: once an `ArrayHandle` has been exposed to NumPy through
+`asnumpy`, its host buffer is locked in place for the remainder of the
+program. Any subsequent attempt to grow that buffer from the Viskores side
+raises `ErrorBadAllocation` rather than silently relocating the pointer and
+invalidating the NumPy view.
+
+## Stable ABI (optional)
+
+Pass `-DVISKORES_PYTHON_STABLE_ABI=ON` at configure time to build the
+extension against CPython's stable ABI (`abi3`). The resulting `.so` then
+loads on any Python interpreter at or above the version it was built
+against, without rebuilding.
+
+This option requires Python 3.12 or newer and CMake 3.26 or newer; both
+are prerequisites of CMake's `Python::SABIModule` target. The binding's
+`PyObject_GetBuffer` / `PyBuffer_Release` calls have been part of the
+Python Limited API since 3.11, so they remain valid on every supported
+Python version.
+
+## Building and Running
+
+Enable the bindings with:
+
+```sh
+cmake -S . -B <build-dir> -DViskores_ENABLE_PYTHON_BINDINGS=ON
+cmake --build <build-dir> --target viskores_python_bindings
+```
+
+Run the examples with:
+
+```sh
+PYTHONPATH=<build-dir>/python_bindings python python_bindings/examples/roundtrip_scalar_dtypes.py
+PYTHONPATH=<build-dir>/python_bindings python python_bindings/examples/roundtrip_vectors.py
+PYTHONPATH=<build-dir>/python_bindings python python_bindings/examples/roundtrip_allow_copy.py
+```

--- a/python_bindings/examples/roundtrip_allow_copy.py
+++ b/python_bindings/examples/roundtrip_allow_copy.py
@@ -1,0 +1,40 @@
+##============================================================================
+##  The contents of this file are covered by the Viskores license. See
+##  LICENSE.txt for details.
+##
+##  By contributing to this file, all contributors agree to the Developer
+##  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+##============================================================================
+
+import numpy as np
+
+import viskores
+import viskores.cont
+
+
+# Demonstrate the allow_copy=True kwarg on viskores.cont.array_from_numpy.
+# By default the binding requires a directly-shareable input (C-contiguous,
+# aligned, writable) so it can wrap the NumPy buffer with zero copy. Inputs
+# that don't meet those requirements are rejected with a descriptive error.
+# Pass allow_copy=True to let the binding make a contiguous, writable copy
+# automatically when the input is not directly shareable.
+
+base = np.arange(12, dtype=np.float32)
+
+# A non-contiguous slice would normally be rejected.
+sliced = base[::2]
+try:
+    viskores.cont.array_from_numpy(sliced)
+except RuntimeError as error:
+    print(f"non-contiguous default: rejected ({str(error).splitlines()[0]})")
+
+# allow_copy=True accepts the slice by copying it.
+unknown = viskores.cont.array_from_numpy(sliced, allow_copy=True)
+print(f"non-contiguous + allow_copy: {unknown}")
+np.testing.assert_array_equal(unknown.asnumpy(), sliced)
+
+# A directly-shareable input still takes the zero-copy path even with
+# allow_copy=True. Only inputs that need a copy are copied.
+unknown = viskores.cont.array_from_numpy(base, allow_copy=True)
+print(f"contiguous + allow_copy: shares storage = "
+      f"{np.shares_memory(unknown.asnumpy(), base)}")

--- a/python_bindings/examples/roundtrip_scalar_dtypes.py
+++ b/python_bindings/examples/roundtrip_scalar_dtypes.py
@@ -1,0 +1,35 @@
+##============================================================================
+##  The contents of this file are covered by the Viskores license. See
+##  LICENSE.txt for details.
+##
+##  By contributing to this file, all contributors agree to the Developer
+##  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+##============================================================================
+
+import numpy as np
+
+import viskores
+import viskores.cont
+
+
+# Demonstrate NumPy -> UnknownArrayHandle -> NumPy for every supported scalar dtype.
+DTYPES = [
+    np.int8,
+    np.int16,
+    np.int32,
+    np.int64,
+    np.uint8,
+    np.uint16,
+    np.uint32,
+    np.uint64,
+    np.float32,
+    np.float64,
+]
+
+
+for dtype in DTYPES:
+    values = np.arange(6, dtype=dtype)
+    unknown = viskores.cont.array_from_numpy(values)
+    result = unknown.asnumpy()
+    np.testing.assert_array_equal(result, values)
+    print(f"{values.dtype}: {unknown} -> {result}")

--- a/python_bindings/examples/roundtrip_vectors.py
+++ b/python_bindings/examples/roundtrip_vectors.py
@@ -1,0 +1,28 @@
+##============================================================================
+##  The contents of this file are covered by the Viskores license. See
+##  LICENSE.txt for details.
+##
+##  By contributing to this file, all contributors agree to the Developer
+##  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+##============================================================================
+
+import numpy as np
+
+import viskores
+import viskores.cont
+
+
+# Demonstrate 2D NumPy arrays becoming runtime-component Viskores Vec arrays.
+cases = [
+    np.arange(8, dtype=np.float32).reshape(4, 2),
+    np.arange(12, dtype=np.float64).reshape(4, 3),
+    np.arange(16, dtype=np.uint8).reshape(4, 4),
+    np.arange(20, dtype=np.int32).reshape(4, 5),
+]
+
+
+for values in cases:
+    unknown = viskores.cont.array_from_numpy(values)
+    result = viskores.cont.asnumpy(unknown)
+    np.testing.assert_array_equal(result, values)
+    print(f"{values.dtype} shape={values.shape}: {unknown} ->\n{result}")

--- a/python_bindings/src/cont_bindings.cxx
+++ b/python_bindings/src/cont_bindings.cxx
@@ -1,0 +1,77 @@
+//============================================================================
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//============================================================================
+
+#include "viskores_python_bindings.h"
+
+#include <viskores/interop/python/ArrayHandleToNumPy.h>
+#include <viskores/interop/python/NumPyToArrayHandle.h>
+
+#include <viskores/cont/UnknownArrayHandle.h>
+
+#include <string>
+
+namespace vip = viskores::interop::python;
+
+namespace viskores::python::bindings
+{
+namespace
+{
+
+std::string UnknownArrayHandleRepr(const viskores::cont::UnknownArrayHandle& self)
+{
+  return "viskores.cont.UnknownArrayHandle(values=" +
+    std::to_string(self.GetNumberOfValues()) +
+    ", components=" + std::to_string(self.GetNumberOfComponentsFlat()) + ")";
+}
+
+} // namespace
+
+void BindCont(nb::module_& m)
+{
+  nb::class_<viskores::cont::UnknownArrayHandle>(m, "UnknownArrayHandle")
+    .def(nb::init<>())
+    .def("__len__", &viskores::cont::UnknownArrayHandle::GetNumberOfValues)
+    .def("__repr__", &UnknownArrayHandleRepr)
+    .def("GetNumberOfValues",
+         &viskores::cont::UnknownArrayHandle::GetNumberOfValues,
+         "Number of elements (tuples) in the array.")
+    .def("GetNumberOfComponentsFlat",
+         &viskores::cont::UnknownArrayHandle::GetNumberOfComponentsFlat,
+         "Number of scalar components per element, counting nested Vec components.")
+    .def("NewInstanceBasic",
+         &viskores::cont::UnknownArrayHandle::NewInstanceBasic,
+         "Allocate a new Viskores-managed array of the same value type.")
+    .def("DeepCopyFrom",
+         [](viskores::cont::UnknownArrayHandle& self,
+            const viskores::cont::UnknownArrayHandle& source) { self.DeepCopyFrom(source); },
+         nb::arg("source"),
+         "Deep copy data from source into this array, allocating as needed.")
+    .def("asnumpy",
+         &vip::ArrayHandleToNumPy,
+         "Return a read-only NumPy view of this array. Zero-copy for basic and\n"
+         "runtime-vec storage; other layouts are copied element-by-element.\n"
+         "The view keeps the source array alive for its entire lifetime.");
+
+  m.def("array_from_numpy",
+        &vip::NumPyToArrayHandle,
+        nb::arg("array"),
+        nb::arg("allow_copy") = false,
+        "Wrap a NumPy array as a Viskores UnknownArrayHandle. By default the\n"
+        "binding shares storage with the NumPy buffer; this requires the input\n"
+        "to be C-contiguous, aligned, and writable. Pass allow_copy=True to\n"
+        "let the binding make a contiguous, writable copy when the input\n"
+        "layout is not directly shareable. allow_copy is permission, not a\n"
+        "command: a directly-shareable input still takes the zero-copy path.");
+  m.def("asnumpy",
+        &vip::ArrayHandleToNumPy,
+        nb::arg("array"),
+        "Return a read-only NumPy view of a Viskores UnknownArrayHandle.\n"
+        "Equivalent to array.asnumpy().");
+}
+
+} // namespace viskores::python::bindings

--- a/python_bindings/src/viskores_python_bindings.cxx
+++ b/python_bindings/src/viskores_python_bindings.cxx
@@ -1,0 +1,17 @@
+//============================================================================
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//============================================================================
+
+#include "viskores_python_bindings.h"
+
+NB_MODULE(_viskores, m)
+{
+  m.doc() = "Minimal manual Viskores Python bindings.";
+
+  nb::module_ cont = m.def_submodule("cont");
+  viskores::python::bindings::BindCont(cont);
+}

--- a/python_bindings/src/viskores_python_bindings.h
+++ b/python_bindings/src/viskores_python_bindings.h
@@ -1,0 +1,23 @@
+//============================================================================
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//============================================================================
+
+#ifndef viskores_python_bindings_h
+#define viskores_python_bindings_h
+
+#include <nanobind/nanobind.h>
+
+namespace nb = nanobind;
+
+namespace viskores::python::bindings
+{
+
+void BindCont(nb::module_& m);
+
+} // namespace viskores::python::bindings
+
+#endif

--- a/python_bindings/testing/CMakeLists.txt
+++ b/python_bindings/testing/CMakeLists.txt
@@ -1,0 +1,23 @@
+##============================================================================
+##  The contents of this file are covered by the Viskores license. See
+##  LICENSE.txt for details.
+##
+##  By contributing to this file, all contributors agree to the Developer
+##  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+##============================================================================
+
+# Viskores' module system processes this file in an isolated scope, so the
+# Python discovery from the parent python_bindings CMakeLists is not visible
+# here. Re-run it locally; find_package hits the CMake cache, so this is cheap
+# and does not depend on the parent's ordering.
+find_package(Python REQUIRED COMPONENTS Interpreter)
+
+add_test(
+  NAME PythonBindingsUnknownArrayHandleNumPy
+  COMMAND
+    "${Python_EXECUTABLE}"
+    "${CMAKE_CURRENT_SOURCE_DIR}/PythonBindingsUnknownArrayHandleNumPy.py"
+)
+set_tests_properties(PythonBindingsUnknownArrayHandleNumPy PROPERTIES
+  ENVIRONMENT "PYTHONPATH=${Viskores_BINARY_DIR}/python_bindings"
+)

--- a/python_bindings/testing/PythonBindingsUnknownArrayHandleNumPy.py
+++ b/python_bindings/testing/PythonBindingsUnknownArrayHandleNumPy.py
@@ -1,0 +1,370 @@
+##============================================================================
+##  The contents of this file are covered by the Viskores license. See
+##  LICENSE.txt for details.
+##
+##  By contributing to this file, all contributors agree to the Developer
+##  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+##============================================================================
+
+import gc
+
+import numpy as np
+
+import viskores
+import viskores.cont
+
+
+# Keep this list aligned with the C++ dtype table in cont_bindings.cxx.
+SCALAR_DTYPES = [
+    np.int8,
+    np.int16,
+    np.int32,
+    np.int64,
+    np.uint8,
+    np.uint16,
+    np.uint32,
+    np.uint64,
+    np.float32,
+    np.float64,
+]
+
+
+def scalar_values(dtype):
+    if np.issubdtype(dtype, np.floating):
+        return np.linspace(-2.5, 3.5, 7, dtype=dtype)
+    if np.issubdtype(dtype, np.unsignedinteger):
+        return np.arange(7, dtype=dtype)
+    return np.arange(-3, 4, dtype=dtype)
+
+
+def vector_values(dtype, components):
+    return np.arange(4 * components, dtype=dtype).reshape(4, components)
+
+
+def check_roundtrip(values):
+    # Exercise both the bound method and module-level helper for dense scalar and
+    # runtime-component vector arrays.
+    unknown = viskores.cont.array_from_numpy(values)
+    assert isinstance(unknown, viskores.cont.UnknownArrayHandle)
+    assert unknown.GetNumberOfValues() == values.shape[0]
+    assert unknown.GetNumberOfComponentsFlat() == (1 if values.ndim == 1 else values.shape[1])
+
+    method_values = unknown.asnumpy()
+    function_values = viskores.cont.asnumpy(unknown)
+    assert method_values.dtype == values.dtype
+    assert function_values.dtype == values.dtype
+    np.testing.assert_array_equal(method_values, values)
+    np.testing.assert_array_equal(function_values, values)
+
+
+def mutation_value(dtype, value):
+    return np.asarray(value, dtype=dtype).item()
+
+
+def check_dense_shared_storage(values):
+    # Dense NumPy input and output should share storage with Viskores. The
+    # returned view is read-only so multiple Python views can coexist while
+    # Viskores holds read access to the array.
+    unknown = viskores.cont.array_from_numpy(values)
+    result = unknown.asnumpy()
+    assert np.shares_memory(result, values)
+    assert not result.flags.writeable
+
+    values.reshape(-1)[0] = mutation_value(values.dtype, 7)
+    assert result.reshape(-1)[0] == values.reshape(-1)[0]
+
+    try:
+        result.reshape(-1)[-1] = mutation_value(values.dtype, 3)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("Expected asnumpy() view to be read-only.")
+
+
+def check_dense_lifetime(values):
+    # The UnknownArrayHandle should keep NumPy-owned input storage alive, and a
+    # NumPy view returned from asnumpy should keep the Viskores array alive.
+    expected = values.copy()
+    unknown = viskores.cont.array_from_numpy(values)
+    del values
+    gc.collect()
+
+    result = unknown.asnumpy()
+    np.testing.assert_array_equal(result, expected)
+
+    del unknown
+    gc.collect()
+    np.testing.assert_array_equal(result, expected)
+
+
+def check_double_wrap_keeps_view_path():
+    # Wrapping the same NumPy array twice must keep both wrappers on the
+    # zero-copy view path: the second wrapper must continue to produce a
+    # zero-copy view of the same NumPy buffer after the first wrapper is
+    # destroyed.
+    # Use a sufficiently large array so any chance reuse of the same allocation
+    # by numpy.empty cannot fool np.shares_memory.
+    base = np.arange(1024 * 1024, dtype=np.float32)
+    u1 = viskores.cont.array_from_numpy(base)
+    u2 = viskores.cont.array_from_numpy(base)
+    del u1
+    gc.collect()
+    view = u2.asnumpy()
+    assert np.shares_memory(view, base), \
+        "Second wrapper must still produce a zero-copy view after the first is gone."
+    # Mutating the source must propagate through the view.
+    base[0] = -1.0
+    assert view[0] == -1.0
+
+
+def check_view_outlives_both_source_and_unknown(values):
+    # Strongest lifetime check: drop both the Python NumPy source and the
+    # UnknownArrayHandle in one step. The view returned by asnumpy must still
+    # be readable because its capsule holds the Viskores ArrayHandle (which
+    # holds the PyBufferOwner that owns the buffer).
+    expected = values.copy()
+    unknown = viskores.cont.array_from_numpy(values)
+    view = unknown.asnumpy()
+    del values, unknown
+    gc.collect()
+    np.testing.assert_array_equal(view, expected)
+
+
+def check_rejects_nonshareable_arrays(dtype):
+    # Both 1D scalar and 2D vector inputs share the same shareability checks,
+    # so exercise both shapes for the non-contiguous and read-only cases.
+    for values in (scalar_values(dtype), vector_values(dtype, 3)):
+        # A non-contiguous slice of either shape must be rejected without allow_copy=True.
+        try:
+            viskores.cont.array_from_numpy(values[::2])
+        except RuntimeError:
+            pass
+        else:
+            raise AssertionError("Expected non-contiguous input to be rejected.")
+
+        readonly = values.copy()
+        readonly.flags.writeable = False
+        try:
+            viskores.cont.array_from_numpy(readonly)
+        except RuntimeError:
+            pass
+        else:
+            raise AssertionError("Expected read-only input to be rejected.")
+
+
+def check_rejects_non_dlpack_kinds():
+    # All dtype kinds that lack a DLPack representation must be rejected with
+    # a clean message before reaching the nb::ndarray cast (which would surface
+    # them as an opaque std::bad_cast). Object dtype is one example; structured
+    # records, byte/unicode strings, and datetime/timedelta are others.
+    values = np.empty(2, dtype=object)
+    values[0] = np.asarray([1, 2], dtype=np.int32)
+    values[1] = np.asarray([3], dtype=np.int32)
+    cases = [
+        values,
+        np.array([(1, 2.0)], dtype=[("a", "i4"), ("b", "f4")]),  # structured
+        np.array(["hello", "world"]),                              # unicode str
+        np.array([b"hi", b"bye"]),                                  # byte string
+        np.array(["2024-01-01"], dtype="datetime64[D]"),
+        np.array([1], dtype="timedelta64[D]"),
+    ]
+    for arr in cases:
+        try:
+            viskores.cont.array_from_numpy(arr)
+        except RuntimeError as error:
+            assert "are not supported" in str(error), (
+                f"Expected dtype-rejection message for {arr.dtype}, got: {error}")
+        else:
+            raise AssertionError(
+                f"Expected dtype {arr.dtype} (kind={arr.dtype.kind}) to be rejected.")
+
+
+def check_rejects_unsupported_shapes():
+    # The binding accepts only 1D scalar and 2D vector inputs. Other ranks
+    # (0-dim scalars, 3D and higher) must be rejected with the shape-error
+    # message so users understand the constraint.
+    for unsupported in (np.asarray(5), np.zeros((2, 3, 4)), np.zeros((2, 3, 4, 5))):
+        try:
+            viskores.cont.array_from_numpy(unsupported)
+        except RuntimeError:
+            pass
+        else:
+            raise AssertionError(
+                f"Expected ndim={unsupported.ndim} input to be rejected.")
+
+
+def check_rejects_default_constructed():
+    # A default-constructed UnknownArrayHandle holds no array. Calling asnumpy
+    # on it must raise a Python error (not segfault inside Viskores).
+    empty = viskores.cont.UnknownArrayHandle()
+    try:
+        empty.asnumpy()
+    except RuntimeError:
+        pass
+    else:
+        raise AssertionError("Expected asnumpy on empty UnknownArrayHandle to be rejected.")
+
+
+def check_rejects_non_native_byte_order():
+    # Non-native byte-order dtypes (e.g., '>f4' on a little-endian host) cannot
+    # be represented in DLPack and must be rejected with a clean message rather
+    # than the std::bad_cast that nanobind would otherwise raise.
+    # Construct an array with a swapped byte-order dtype. dtype.newbyteorder("S")
+    # returns the dtype with the opposite byte order; astype reinterprets the
+    # values into that dtype.
+    swapped_dtype = np.dtype(np.float32).newbyteorder("S")
+    swapped = np.arange(8, dtype=np.float32).astype(swapped_dtype)
+    if swapped.dtype.isnative:
+        # Skip on platforms where '<f4' and '>f4' are both native (none today,
+        # but be defensive).
+        return
+    try:
+        viskores.cont.array_from_numpy(swapped)
+    except RuntimeError as error:
+        assert "byte-order" in str(error), \
+            f"Expected byte-order error message, got: {error}"
+    else:
+        raise AssertionError("Expected non-native byte-order input to be rejected.")
+
+
+def check_rejects_unsupported_dtypes():
+    # Boolean, half-precision float, and complex arrays have no Viskores scalar
+    # equivalent in the dispatch table. The error message should name the dtype
+    # in its human-readable form (bool/float16/complex128, not |b1/<f2/<c16).
+    cases = [
+        (np.array([True, False]), "bool"),
+        (np.array([1, 2], dtype=np.float16), "float16"),
+        (np.array([1 + 2j, 3 + 4j], dtype=np.complex128), "complex128"),
+    ]
+    for arr, expected_name in cases:
+        try:
+            viskores.cont.array_from_numpy(arr)
+        except RuntimeError as error:
+            assert expected_name in str(error), (
+                f"Expected dtype name {expected_name!r} in error message, got: {error}")
+        else:
+            raise AssertionError(f"Expected dtype {expected_name} to be rejected.")
+
+
+def check_empty_arrays():
+    # Zero-length arrays must round-trip without crashing. Both 1D and 2D
+    # forms are exercised because they take different code paths in the
+    # binding (ArrayHandleBasic vs. ArrayHandleRuntimeVec).
+    for dtype in (np.float32, np.int64, np.uint8):
+        empty_1d = np.empty(0, dtype=dtype)
+        unknown = viskores.cont.array_from_numpy(empty_1d)
+        assert unknown.GetNumberOfValues() == 0
+        result = unknown.asnumpy()
+        assert result.shape == (0,)
+        assert result.dtype == dtype
+
+        empty_2d = np.empty((0, 3), dtype=dtype)
+        unknown = viskores.cont.array_from_numpy(empty_2d)
+        assert unknown.GetNumberOfValues() == 0
+        assert unknown.GetNumberOfComponentsFlat() == 3
+        result = unknown.asnumpy()
+        assert result.shape == (0, 3)
+        assert result.dtype == dtype
+
+
+def check_copy_kwarg_accepts_unshareable(dtype):
+    # allow_copy=True must accept non-contiguous and read-only inputs that the default
+    # allow_copy=False rejects, and the resulting ArrayHandle must round-trip.
+    for values in (scalar_values(dtype), vector_values(dtype, 3)):
+        sliced = values[::2]
+        unknown = viskores.cont.array_from_numpy(sliced, allow_copy=True)
+        np.testing.assert_array_equal(unknown.asnumpy(), sliced)
+        # allow_copy=True breaks the storage link: mutating the source must not affect
+        # the resulting ArrayHandle's view.
+        expected = unknown.asnumpy().copy()
+        values.reshape(-1)[0] = mutation_value(dtype, 99)
+        np.testing.assert_array_equal(unknown.asnumpy(), expected)
+
+        readonly = values.copy()
+        readonly.flags.writeable = False
+        unknown = viskores.cont.array_from_numpy(readonly, allow_copy=True)
+        np.testing.assert_array_equal(unknown.asnumpy(), readonly)
+
+
+def check_copy_kwarg_does_not_force_copy(dtype):
+    # allow_copy=True is permissive, not mandatory: a directly-shareable input still
+    # gets the zero-copy path and continues to share storage with the result.
+    for values in (scalar_values(dtype), vector_values(dtype, 3)):
+        unknown = viskores.cont.array_from_numpy(values, allow_copy=True)
+        assert np.shares_memory(unknown.asnumpy(), values)
+
+
+def check_source_mutation_propagates(values):
+    # Writes through the source NumPy array must be visible through both the
+    # ArrayHandle and any view returned by asnumpy. This is the documented
+    # shared-storage behavior for arrays created via array_from_numpy.
+    unknown = viskores.cont.array_from_numpy(values)
+    view = unknown.asnumpy()
+    flat_source = values.reshape(-1)
+    flat_view = view.reshape(-1)
+    flat_source[0] = mutation_value(values.dtype, 42)
+    assert flat_view[0] == flat_source[0]
+
+
+def check_viskores_allocated_zero_copy(values):
+    # Produces an UnknownArrayHandle whose buffer was allocated by Viskores
+    # (no PyBufferOwner). The asnumpy zero-copy path for this case relies on
+    # Buffer::PinHost; verify that the returned NumPy view really does share
+    # storage with the source ArrayHandle, that two views over the same array
+    # see the same memory, and that a view outlives the originating
+    # UnknownArrayHandle.
+    expected = values.copy()
+    source = viskores.cont.array_from_numpy(values)
+    allocated = source.NewInstanceBasic()
+    allocated.DeepCopyFrom(source)
+    del source
+    gc.collect()
+
+    view_a = allocated.asnumpy()
+    view_b = allocated.asnumpy()
+    np.testing.assert_array_equal(view_a, expected)
+    np.testing.assert_array_equal(view_b, expected)
+    assert np.shares_memory(view_a, view_b), \
+        "Both asnumpy views of a Viskores-allocated array must share storage."
+    assert not view_a.flags.writeable
+
+    # The view's capsule holds the ArrayHandle, so the view must outlive the
+    # UnknownArrayHandle that produced it.
+    del allocated, view_b
+    gc.collect()
+    np.testing.assert_array_equal(view_a, expected)
+
+
+def main():
+    for dtype in SCALAR_DTYPES:
+        check_roundtrip(scalar_values(dtype))
+        check_dense_shared_storage(scalar_values(dtype))
+        check_dense_lifetime(scalar_values(dtype))
+        check_view_outlives_both_source_and_unknown(scalar_values(dtype))
+        check_rejects_nonshareable_arrays(dtype)
+
+    for dtype in SCALAR_DTYPES:
+        for components in (1, 2, 3, 4, 5):
+            check_roundtrip(vector_values(dtype, components))
+            check_dense_shared_storage(vector_values(dtype, components))
+            check_dense_lifetime(vector_values(dtype, components))
+            check_view_outlives_both_source_and_unknown(vector_values(dtype, components))
+
+    check_rejects_non_dlpack_kinds()
+    check_rejects_unsupported_shapes()
+    check_rejects_unsupported_dtypes()
+    check_rejects_default_constructed()
+    check_rejects_non_native_byte_order()
+    check_double_wrap_keeps_view_path()
+    check_empty_arrays()
+    for dtype in (np.float32, np.int64):
+        check_source_mutation_propagates(scalar_values(dtype))
+        check_source_mutation_propagates(vector_values(dtype, 3))
+        check_copy_kwarg_accepts_unshareable(dtype)
+        check_copy_kwarg_does_not_force_copy(dtype)
+        check_viskores_allocated_zero_copy(scalar_values(dtype))
+        check_viskores_allocated_zero_copy(vector_values(dtype, 3))
+
+
+if __name__ == "__main__":
+    main()

--- a/python_bindings/viskores.module
+++ b/python_bindings/viskores.module
@@ -1,0 +1,7 @@
+NAME
+  viskores_python_bindings
+GROUPS
+  PythonBindings
+DEPENDS
+  viskores_cont
+  viskores_interop_python

--- a/python_bindings/viskores/__init__.py
+++ b/python_bindings/viskores/__init__.py
@@ -1,0 +1,9 @@
+##============================================================================
+##  The contents of this file are covered by the Viskores license. See
+##  LICENSE.txt for details.
+##
+##  By contributing to this file, all contributors agree to the Developer
+##  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+##============================================================================
+
+__all__ = []

--- a/python_bindings/viskores/cont/__init__.py
+++ b/python_bindings/viskores/cont/__init__.py
@@ -1,0 +1,17 @@
+##============================================================================
+##  The contents of this file are covered by the Viskores license. See
+##  LICENSE.txt for details.
+##
+##  By contributing to this file, all contributors agree to the Developer
+##  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+##============================================================================
+
+from .._viskores.cont import UnknownArrayHandle
+from .._viskores.cont import array_from_numpy
+from .._viskores.cont import asnumpy
+
+__all__ = [
+    "UnknownArrayHandle",
+    "array_from_numpy",
+    "asnumpy",
+]

--- a/viskores/interop/python/ArrayHandleToNumPy.cxx
+++ b/viskores/interop/python/ArrayHandleToNumPy.cxx
@@ -1,0 +1,46 @@
+//============================================================================
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//============================================================================
+
+#include <viskores/interop/python/ArrayHandleToNumPy.h>
+
+namespace viskores
+{
+namespace interop
+{
+namespace python
+{
+
+nb::object ArrayHandleToNumPy(const viskores::cont::UnknownArrayHandle& array)
+{
+  if (!array.IsValid())
+  {
+    throw viskores::cont::ErrorBadValue("UnknownArrayHandle is empty (no underlying array).");
+  }
+
+  nb::object result;
+  if (TryAnyRuntimeVecArrayToNumPy(array, result))
+  {
+    return result;
+  }
+
+  // The storage type is not directly representable as a RuntimeVec. Deep-copy to
+  // a Viskores-allocated basic array so the zero-copy view path can succeed.
+  viskores::cont::UnknownArrayHandle copy = array.NewInstanceBasic();
+  copy.DeepCopyFrom(array);
+  if (TryAnyRuntimeVecArrayToNumPy(copy, result))
+  {
+    return result;
+  }
+
+  throw viskores::cont::ErrorBadValue(
+    "UnknownArrayHandle component type is not supported for NumPy conversion.");
+}
+
+} // namespace python
+} // namespace interop
+} // namespace viskores

--- a/viskores/interop/python/ArrayHandleToNumPy.h
+++ b/viskores/interop/python/ArrayHandleToNumPy.h
@@ -1,0 +1,185 @@
+//============================================================================
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//============================================================================
+
+// Convert a Viskores UnknownArrayHandle to a NumPy ndarray.
+// Requires nanobind (nanobind/ndarray.h) and Python development headers.
+
+#ifndef viskores_interop_python_ArrayHandleToNumPy_h
+#define viskores_interop_python_ArrayHandleToNumPy_h
+
+#include <viskores/interop/python/viskores_interop_python_export.h>
+
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
+
+#include <viskores/cont/ArrayHandleBasic.h>
+#include <viskores/cont/ArrayHandleRuntimeVec.h>
+#include <viskores/cont/Error.h>
+#include <viskores/cont/Token.h>
+#include <viskores/cont/UnknownArrayHandle.h>
+
+#include <memory>
+#include <type_traits>
+
+namespace nb = nanobind;
+
+// X-macro listing every scalar dtype supported in both conversion directions.
+// Each entry maps a Viskores scalar type to its NumPy dtype string.
+#define VISKORES_PYTHON_NUMPY_SCALAR_TYPES(V) \
+  V(viskores::Int8, "int8")                   \
+  V(viskores::Int16, "int16")                 \
+  V(viskores::Int32, "int32")                 \
+  V(viskores::Int64, "int64")                 \
+  V(viskores::UInt8, "uint8")                 \
+  V(viskores::UInt16, "uint16")               \
+  V(viskores::UInt32, "uint32")               \
+  V(viskores::UInt64, "uint64")               \
+  V(viskores::Float32, "float32")             \
+  V(viskores::Float64, "float64")
+
+namespace viskores
+{
+namespace interop
+{
+namespace python
+{
+
+// Map a Viskores scalar type to its canonical NumPy dtype string.
+template <typename ValueType>
+constexpr const char* NumPyDType()
+{
+  using ComponentType = std::remove_cv_t<ValueType>;
+#define VISKORES_PYTHON_NUMPY_DTYPE_CASE(Type, Name) \
+  if constexpr (std::is_same_v<ComponentType, Type>) \
+  {                                                  \
+    return Name;                                     \
+  }
+  VISKORES_PYTHON_NUMPY_SCALAR_TYPES(VISKORES_PYTHON_NUMPY_DTYPE_CASE)
+#undef VISKORES_PYTHON_NUMPY_DTYPE_CASE
+  static_assert(sizeof(ComponentType) == 0, "Unsupported NumPy component type.");
+  return nullptr;
+}
+
+// RAII wrapper that pins the host buffer of an ArrayHandleRuntimeVec and keeps
+// it alive for the lifetime of a NumPy view. All scalar and vector Viskores
+// arrays are routed through this class: scalar ArrayHandleBasic<T> arrays are
+// first extracted as a 1-component RuntimeVec, so this single owner class
+// handles both shapes without needing a separate BasicArrayViewOwner.
+template <typename ComponentType>
+class RuntimeVecArrayViewOwner
+{
+public:
+  // Pin the host components buffer (irreversible) before capturing the data
+  // pointer. A single Token covers both operations so the buffer stays
+  // attached across the pin-then-fetch pair. PinHost provides pointer
+  // stability without retaining the Token; retaining the Token would block
+  // subsequent Viskores writes until the NumPy view is garbage-collected.
+  explicit RuntimeVecArrayViewOwner(
+    const viskores::cont::ArrayHandleRuntimeVec<ComponentType>& array)
+    : ComponentsArray(array.GetComponentsArray())
+  {
+    viskores::cont::Token token;
+    this->ComponentsArray.GetBuffers()[0].PinHost(token);
+    this->Data = this->ComponentsArray.GetReadPointer(token);
+  }
+
+  const ComponentType* GetData() const { return this->Data; }
+
+private:
+  // Holding ComponentsArray (the ArrayHandleBasic extracted from the RuntimeVec)
+  // is sufficient to keep the underlying Buffer alive: ArrayHandleBasic and
+  // ArrayHandleRuntimeVec share the same Buffer object via reference counting,
+  // so either one prevents the Buffer from being destroyed.
+  viskores::cont::ArrayHandleBasic<ComponentType> ComponentsArray;
+  const ComponentType* Data = nullptr;
+};
+
+// Transfer ownership of an RAII owner object into an nb::capsule.
+// Taking owner by value keeps it in a unique_ptr until the capsule is
+// successfully constructed; if nb::capsule throws, unique_ptr cleans up.
+template <typename OwnerType>
+inline nb::capsule MakeArrayViewOwnerCapsule(std::unique_ptr<OwnerType> owner)
+{
+  nb::capsule capsule(owner.get(),
+                      [](void* pointer) noexcept { delete static_cast<OwnerType*>(pointer); });
+  // Capsule now owns the object; release without deleting.
+  owner.release();
+  return capsule;
+}
+
+// Return a zero-copy NumPy view of an ArrayHandleRuntimeVec.
+// flattenScalar: when true and numberOfComponents == 1, emit a 1D (N,) array
+// rather than (N, 1). Pass true only for scalar ArrayHandleBasic storage;
+// explicit 1-component RuntimeVec arrays (from (N,1) NumPy input) must stay 2D.
+template <typename ComponentType>
+nb::object RuntimeVecArrayToNumPy(const viskores::cont::ArrayHandleRuntimeVec<ComponentType>& array,
+                                  bool flattenScalar)
+{
+  using OwnerType = RuntimeVecArrayViewOwner<ComponentType>;
+  const size_t numberOfValues = static_cast<size_t>(array.GetNumberOfValues());
+  const size_t numberOfComponents = static_cast<size_t>(array.GetNumberOfComponents());
+
+  auto owner = std::make_unique<OwnerType>(array);
+  const ComponentType* data = owner->GetData();
+  nb::capsule ownerCapsule = MakeArrayViewOwnerCapsule(std::move(owner));
+
+  if (numberOfComponents == 1 && flattenScalar)
+  {
+    return nb::ndarray<nb::numpy, const ComponentType>(data, { numberOfValues }, ownerCapsule)
+      .cast();
+  }
+  return nb::ndarray<nb::numpy, const ComponentType>(
+           data, { numberOfValues, numberOfComponents }, ownerCapsule)
+    .cast();
+}
+
+// Try to extract an UnknownArrayHandle as ArrayHandleRuntimeVec<ComponentType>
+// and return a NumPy view. Returns false if the conversion is not possible.
+template <typename ComponentType>
+bool TryRuntimeVecArrayToNumPy(const viskores::cont::UnknownArrayHandle& unknown,
+                               nb::object& result)
+{
+  using RuntimeVecArray = viskores::cont::ArrayHandleRuntimeVec<ComponentType>;
+  if (!unknown.CanConvert<RuntimeVecArray>())
+  {
+    return false;
+  }
+  RuntimeVecArray array;
+  unknown.AsArrayHandle(array);
+  // Emit 1D only when the underlying storage is a plain scalar ArrayHandleBasic;
+  // an explicit 1-component RuntimeVec (e.g. from a (N,1) NumPy input) stays 2D.
+  const bool flattenScalar = unknown.IsType<viskores::cont::ArrayHandleBasic<ComponentType>>();
+  result = RuntimeVecArrayToNumPy(array, flattenScalar);
+  return true;
+}
+
+// Try every supported component type for the RuntimeVec NumPy output path.
+inline bool TryAnyRuntimeVecArrayToNumPy(const viskores::cont::UnknownArrayHandle& unknown,
+                                         nb::object& result)
+{
+#define VISKORES_PYTHON_TRY_RUNTIME_VEC_TO_NUMPY(ValueType, DTypeName) \
+  if (TryRuntimeVecArrayToNumPy<ValueType>(unknown, result))           \
+  {                                                                    \
+    return true;                                                       \
+  }
+  VISKORES_PYTHON_NUMPY_SCALAR_TYPES(VISKORES_PYTHON_TRY_RUNTIME_VEC_TO_NUMPY)
+#undef VISKORES_PYTHON_TRY_RUNTIME_VEC_TO_NUMPY
+  return false;
+}
+
+// Convert an UnknownArrayHandle to a NumPy ndarray. Zero-copy for
+// ArrayHandleBasic and ArrayHandleRuntimeVec; other storage types are
+// deep-copied to a basic array first.
+VISKORES_INTEROP_PYTHON_EXPORT
+nb::object ArrayHandleToNumPy(const viskores::cont::UnknownArrayHandle& array);
+
+} // namespace python
+} // namespace interop
+} // namespace viskores
+
+#endif // viskores_interop_python_ArrayHandleToNumPy_h

--- a/viskores/interop/python/CMakeLists.txt
+++ b/viskores/interop/python/CMakeLists.txt
@@ -1,0 +1,60 @@
+##============================================================================
+##  The contents of this file are covered by the Viskores license. See
+##  LICENSE.txt for details.
+##
+##  By contributing to this file, all contributors agree to the Developer
+##  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+##============================================================================
+
+find_package(Python 3.8 REQUIRED COMPONENTS Interpreter Development)
+
+set(Viskores_PYTHON_NANOBIND_MIN_VERSION "2.0.0")
+
+execute_process(
+  COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir
+  OUTPUT_VARIABLE _viskores_interop_python_nanobind_cmake_dir
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  RESULT_VARIABLE _viskores_interop_python_nanobind_result
+)
+if(NOT _viskores_interop_python_nanobind_result EQUAL 0)
+  message(FATAL_ERROR
+    "nanobind ${Viskores_PYTHON_NANOBIND_MIN_VERSION} or newer is required to "
+    "build viskores_interop_python. Install with: pip install 'nanobind>="
+    "${Viskores_PYTHON_NANOBIND_MIN_VERSION}'.")
+endif()
+
+find_package(nanobind ${Viskores_PYTHON_NANOBIND_MIN_VERSION} CONFIG REQUIRED
+  PATHS "${_viskores_interop_python_nanobind_cmake_dir}"
+  NO_DEFAULT_PATH
+)
+
+set(headers
+  ArrayHandleToNumPy.h
+  NumPyToArrayHandle.h
+)
+
+set(sources
+  ArrayHandleToNumPy.cxx
+  NumPyToArrayHandle.cxx
+)
+
+# Build as a static library so the object files are linked directly into the
+# Python extension module.  This ensures viskores_interop_python and the
+# extension share exactly one copy of the nanobind runtime (whatever variant
+# nanobind_add_module picks, e.g. nanobind-static-abi3 for stable-ABI builds).
+viskores_library(
+  NAME viskores_interop_python
+  STATIC
+  SOURCES ${sources}
+  HEADERS ${headers}
+)
+
+target_compile_definitions(viskores_interop_python PRIVATE PY_SSIZE_T_CLEAN)
+
+# Provide nanobind and Python headers at compile time.  The nanobind runtime
+# itself is supplied by the consumer (the extension module).
+target_include_directories(viskores_interop_python
+  PRIVATE ${NB_DIR}/include
+  PRIVATE ${Python_INCLUDE_DIRS}
+)
+nanobind_compile_options(viskores_interop_python)

--- a/viskores/interop/python/NumPyToArrayHandle.cxx
+++ b/viskores/interop/python/NumPyToArrayHandle.cxx
@@ -1,0 +1,93 @@
+//============================================================================
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//============================================================================
+
+#include <viskores/interop/python/NumPyToArrayHandle.h>
+
+namespace viskores
+{
+namespace interop
+{
+namespace python
+{
+
+viskores::cont::UnknownArrayHandle NumPyToArrayHandle(nb::handle object, bool allowCopy)
+{
+  nb::object numpy = nb::module_::import_("numpy");
+  // Normalize the input through numpy.asarray so we accept Python lists,
+  // scalars, and other array-like objects in addition to NumPy arrays.
+  nb::object array = numpy.attr("asarray")(object);
+
+  nb::object dtypeObject = array.attr("dtype");
+  // Reject dtype kinds that don't have a DLPack representation: the nb::ndarray
+  // cast below would otherwise surface them as an opaque std::bad_cast. Numeric
+  // kinds (b=bool, i=signed int, u=unsigned int, f=float, c=complex) pass
+  // through; bool and complex are then rejected by the dispatch table with a
+  // clean dtype name because the binding doesn't support them as scalar
+  // component types.
+  const std::string dtypeKind = nb::cast<std::string>(dtypeObject.attr("kind"));
+  if (dtypeKind != "b" && dtypeKind != "i" && dtypeKind != "u" && dtypeKind != "f" &&
+      dtypeKind != "c")
+  {
+    const std::string dtypeName = nb::cast<std::string>(dtypeObject.attr("name"));
+    throw viskores::cont::ErrorBadValue("NumPy arrays with " + dtypeName +
+                                        " dtype are not supported.");
+  }
+  // Non-native byte-order dtypes (e.g., '>f4' on a little-endian host) cannot
+  // be cast to nb::ndarray<nb::numpy, ...> and would surface as an opaque
+  // std::bad_cast. Reject up front with a clean message.
+  if (!nb::cast<bool>(dtypeObject.attr("isnative")))
+  {
+    throw viskores::cont::ErrorBadValue(
+      "NumPy arrays with non-native byte-order dtype are not supported. "
+      "Convert with array.astype(array.dtype.newbyteorder('=')) before passing.");
+  }
+
+  // Cast with nb::ro so shape and dtype are accessible regardless of
+  // writability; the shareability check reports write-access errors separately.
+  auto inspector = nb::cast<nb::ndarray<nb::numpy, nb::ro>>(array);
+  const size_t ndim = inspector.ndim();
+  // Use dtype.name (e.g., "bool", "float16", "complex128") for the error message
+  // instead of dtype.str (e.g., "|b1", "<f2", "<c16"); the human-readable form
+  // is what NumPy users expect.
+  const std::string dtypeName = nb::cast<std::string>(dtypeObject.attr("name"));
+  const NumPyDTypeEntry& entry = FindNumPyDTypeEntry(inspector.dtype(), dtypeName.c_str());
+
+  const ShareableCheck shareability = CheckShareableNumPyArray(array);
+  if (shareability != ShareableCheck::Shareable)
+  {
+    if (!allowCopy)
+    {
+      ThrowUnshareableNumPyArrayReason(shareability);
+    }
+    // ndarray.copy() always returns a writable, C-contiguous array. (Unlike
+    // numpy.ascontiguousarray, which returns the input unchanged when it is
+    // already contiguous and therefore preserves a read-only flag.) Shape and
+    // dtype are preserved, so the values captured from `inspector` remain
+    // valid for dispatch.
+    array = array.attr("copy")();
+  }
+
+  if (ndim == 1)
+  {
+    return entry.Scalar(array, static_cast<viskores::Id>(inspector.shape(0)));
+  }
+
+  if (ndim == 2)
+  {
+    return entry.Vector(array,
+                        static_cast<viskores::Id>(inspector.shape(0)),
+                        static_cast<viskores::IdComponent>(inspector.shape(1)));
+  }
+
+  throw viskores::cont::ErrorBadValue(
+    "Only one-dimensional scalar arrays and two-dimensional vector arrays are supported.");
+}
+
+} // namespace python
+} // namespace interop
+} // namespace viskores

--- a/viskores/interop/python/NumPyToArrayHandle.h
+++ b/viskores/interop/python/NumPyToArrayHandle.h
@@ -1,0 +1,241 @@
+//============================================================================
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//============================================================================
+
+// Convert a NumPy ndarray to a Viskores UnknownArrayHandle.
+// Requires nanobind (nanobind/ndarray.h) and Python development headers.
+
+#ifndef viskores_interop_python_NumPyToArrayHandle_h
+#define viskores_interop_python_NumPyToArrayHandle_h
+
+// VISKORES_PYTHON_NUMPY_SCALAR_TYPES, NumPyDType<T>, and the export macro live here.
+#include <viskores/interop/python/ArrayHandleToNumPy.h>
+
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
+#include <nanobind/stl/string.h>
+
+#include <viskores/cont/ArrayHandleBasic.h>
+#include <viskores/cont/ArrayHandleRuntimeVec.h>
+#include <viskores/cont/Error.h>
+#include <viskores/cont/UnknownArrayHandle.h>
+
+#include <memory>
+#include <string>
+
+namespace nb = nanobind;
+
+namespace viskores
+{
+namespace interop
+{
+namespace python
+{
+
+// Own the Python-side lifetime state for a NumPy array shared with Viskores.
+//
+// Viskores stores only a raw data pointer in the ArrayHandleBasic buffer. This
+// owner is passed to Viskores as the buffer container so the NumPy array remains
+// alive while any Viskores buffer reference can still use that pointer.
+// Releasing the final Viskores buffer reference calls ReleasePythonBufferOwner,
+// which deletes this object, releases the Python buffer export, and drops the
+// Python reference to the NumPy array, allowing it to be deleted once all other
+// Python references are dropped.
+class PyBufferOwner
+{
+public:
+  // Hold a Python reference plus a writable buffer export for the same array.
+  // PyObject_GetBuffer/PyBuffer_Release have been part of the CPython Limited
+  // API since 3.11, so they remain callable when the binding is built with
+  // VISKORES_PYTHON_STABLE_ABI=ON (which itself requires Python 3.12+).
+  explicit PyBufferOwner(nb::handle object)
+    : Object(nb::borrow<nb::object>(object))
+  {
+    if (PyObject_GetBuffer(this->Object.ptr(), &this->Buffer, PyBUF_WRITABLE) < 0)
+    {
+      throw nb::python_error();
+    }
+    this->HasBuffer = true;
+  }
+
+  ~PyBufferOwner()
+  {
+    if (this->HasBuffer)
+    {
+      PyBuffer_Release(&this->Buffer);
+    }
+  }
+
+  PyBufferOwner(const PyBufferOwner&) = delete;
+  PyBufferOwner& operator=(const PyBufferOwner&) = delete;
+
+  template <typename ValueType>
+  ValueType* Data() const
+  {
+    return static_cast<ValueType*>(this->Buffer.buf);
+  }
+
+private:
+  nb::object Object;
+  Py_buffer Buffer = {};
+  bool HasBuffer = false;
+};
+
+inline void ReleasePythonBufferOwner(void* container)
+{
+  // Viskores can release buffers outside a direct Python call path. Acquire
+  // Python's Global Interpreter Lock before releasing the Python buffer export
+  // and dropping the object reference.
+  nb::gil_scoped_acquire gil;
+  PyBufferOwner* owner = static_cast<PyBufferOwner*>(container);
+  delete owner;
+}
+
+// Result of checking whether a NumPy array's layout can be shared with Viskores.
+// `Shareable` means it can; the other values name the specific constraint that
+// prevents sharing.
+//
+// Layout flags are read from `array.flags.<name>` rather than from nb::ndarray
+// because nb::ndarray does not expose a runtime accessor for writability or
+// alignment. (Contiguity could be inferred from strides, but going through
+// flags keeps all three checks consistent.)
+enum class ShareableCheck
+{
+  Shareable,
+  NotCContiguous,
+  NotAligned,
+  NotWriteable,
+};
+
+inline ShareableCheck CheckShareableNumPyArray(nb::handle array)
+{
+  nb::object flags = array.attr("flags");
+  if (!nb::cast<bool>(flags.attr("c_contiguous")))
+  {
+    return ShareableCheck::NotCContiguous;
+  }
+  if (!nb::cast<bool>(flags.attr("aligned")))
+  {
+    return ShareableCheck::NotAligned;
+  }
+  if (!nb::cast<bool>(flags.attr("writeable")))
+  {
+    return ShareableCheck::NotWriteable;
+  }
+  return ShareableCheck::Shareable;
+}
+
+// Throw explaining why a NumPy array's layout cannot be shared.
+// Pre: reason != ShareableCheck::Shareable.
+[[noreturn]] inline void ThrowUnshareableNumPyArrayReason(ShareableCheck reason)
+{
+  switch (reason)
+  {
+    case ShareableCheck::NotCContiguous:
+      throw viskores::cont::ErrorBadValue(
+        "NumPy array input must be C-contiguous to share with Viskores. "
+        "Pass `allow_copy=True` to make a contiguous copy automatically.");
+    case ShareableCheck::NotAligned:
+      throw viskores::cont::ErrorBadValue(
+        "NumPy array input must be aligned to share with Viskores. "
+        "Pass `allow_copy=True` to make an aligned copy automatically.");
+    case ShareableCheck::NotWriteable:
+      throw viskores::cont::ErrorBadValue(
+        "NumPy array input must be writable to share with Viskores. "
+        "Pass `allow_copy=True` to make a writable copy automatically.");
+    case ShareableCheck::Shareable:
+      break;
+  }
+  throw viskores::cont::ErrorBadValue("Unknown NumPy shareability failure.");
+}
+
+// Build a basic ArrayHandle that shares storage with a NumPy array.
+template <typename ValueType>
+viskores::cont::ArrayHandleBasic<ValueType> SharedBasicArrayFromNumPy(nb::handle array,
+                                                                      viskores::Id numberOfValues)
+{
+  auto owner = std::make_unique<PyBufferOwner>(array);
+  ValueType* data = owner->Data<ValueType>();
+  // The constructor's default InvalidRealloc reallocater causes any Viskores
+  // resize attempt on the Python-owned buffer to throw rather than reallocate.
+  // Viskores calls ReleasePythonBufferOwner when the last shared buffer
+  // reference is destroyed, not necessarily when one Python UnknownArrayHandle
+  // wrapper goes away.
+  viskores::cont::ArrayHandleBasic<ValueType> result(
+    data, owner.get(), numberOfValues, &ReleasePythonBufferOwner);
+  owner.release();
+  return result;
+}
+
+template <typename ValueType>
+viskores::cont::UnknownArrayHandle ArrayFromNumPyScalarArray(nb::handle array,
+                                                             viskores::Id numberOfValues)
+{
+  return SharedBasicArrayFromNumPy<ValueType>(array, numberOfValues);
+}
+
+template <typename ComponentType>
+viskores::cont::UnknownArrayHandle ArrayFromNumPyVectorArray(
+  nb::handle array,
+  viskores::Id numberOfValues,
+  viskores::IdComponent numberOfComponents)
+{
+  if (numberOfComponents < 1)
+  {
+    throw viskores::cont::ErrorBadValue("2D NumPy array input must have at least one component.");
+  }
+  auto componentArray =
+    SharedBasicArrayFromNumPy<ComponentType>(array, numberOfValues * numberOfComponents);
+  return viskores::cont::ArrayHandleRuntimeVec<ComponentType>(numberOfComponents, componentArray);
+}
+
+// Dispatch entry for a single supported NumPy scalar dtype. Matching uses the
+// dlpack::dtype struct so we avoid string round-trips through Python; the
+// human-readable dtype name in the error path is taken from the input array's
+// dtype.name attribute.
+struct NumPyDTypeEntry
+{
+  nb::dlpack::dtype DType;
+  viskores::cont::UnknownArrayHandle (*Scalar)(nb::handle, viskores::Id);
+  viskores::cont::UnknownArrayHandle (*Vector)(nb::handle, viskores::Id, viskores::IdComponent);
+};
+
+#define VISKORES_PYTHON_NUMPY_DTYPE_ENTRY(ValueType, DTypeName) \
+  NumPyDTypeEntry{ nb::dtype<ValueType>(),                      \
+                   &ArrayFromNumPyScalarArray<ValueType>,       \
+                   &ArrayFromNumPyVectorArray<ValueType> },
+
+constexpr NumPyDTypeEntry NumPyDTypeTable[] = { VISKORES_PYTHON_NUMPY_SCALAR_TYPES(
+  VISKORES_PYTHON_NUMPY_DTYPE_ENTRY) };
+#undef VISKORES_PYTHON_NUMPY_DTYPE_ENTRY
+
+// Find the dispatch entry for a dlpack dtype, or throw if the dtype is not
+// one of the supported scalar types.
+inline const NumPyDTypeEntry& FindNumPyDTypeEntry(nb::dlpack::dtype dtype,
+                                                  const char* dtypeNameForError)
+{
+  for (const NumPyDTypeEntry& entry : NumPyDTypeTable)
+  {
+    if (entry.DType == dtype)
+    {
+      return entry;
+    }
+  }
+  throw viskores::cont::ErrorBadValue(std::string("Unsupported NumPy dtype: ") + dtypeNameForError);
+}
+
+// Wrap a Python array-like object as a Viskores UnknownArrayHandle.
+// The input must be C-contiguous, aligned, and writable to share storage; pass
+// allowCopy=true to make a copy when those constraints are not met.
+VISKORES_INTEROP_PYTHON_EXPORT
+viskores::cont::UnknownArrayHandle NumPyToArrayHandle(nb::handle object, bool allowCopy);
+
+} // namespace python
+} // namespace interop
+} // namespace viskores
+
+#endif // viskores_interop_python_NumPyToArrayHandle_h

--- a/viskores/interop/python/viskores.module
+++ b/viskores/interop/python/viskores.module
@@ -1,0 +1,7 @@
+NAME
+  viskores_interop_python
+GROUPS
+  PythonBindings
+NO_TESTING
+DEPENDS
+  viskores_cont


### PR DESCRIPTION
## Summary

Adds an optional \`python_bindings\` module group (\`Viskores_ENABLE_PYTHON_BINDINGS=ON\`) that builds a [nanobind](https://github.com/wjakob/nanobind) extension with NumPy I/O for \`viskores::cont::UnknownArrayHandle\`:

- \`viskores.cont.array_from_numpy(array, allow_copy=False)\` — wrap a NumPy array as an \`UnknownArrayHandle\` sharing the same storage. Pass \`allow_copy=True\` to accept non-shareable inputs by copying.
- \`viskores.cont.asnumpy(array)\` / \`UnknownArrayHandle.asnumpy()\` — return a NumPy view of an \`UnknownArrayHandle\`. Zero-copy for basic and runtime-vec storage; element-by-element copy otherwise.

Design rationale is in \`python_bindings/src/cont_bindings.cxx\`.

## Naming Convention

CamelCase for C++-mirrored symbols (\`UnknownArrayHandle\`, \`GetNumberOfValues\`); lowercase for Python-specific helpers (\`array_from_numpy\`, \`asnumpy\`). Worth a sign-off in review.

## Testing

\`\`\`sh
cmake --build <build-dir> --target viskores_python_bindings -j 4
ctest --test-dir <build-dir> -R PythonBindingsUnknownArrayHandleNumPy --output-on-failure
\`\`\`

Stable-ABI variant: configure with \`-DVISKORES_PYTHON_STABLE_ABI=ON\` (requires Python >= 3.12 and CMake >= 3.26).

## Deferred

- **Install rule.** Build-tree only; packaging deferred until the binding surface grows.
- **CI hook.** No \`.gitlab-ci.yml\` job for \`Viskores_ENABLE_PYTHON_BINDINGS=ON\` yet.
- **Non-basic storage copy-path test.** \`asnumpy\` has two paths: zero-copy for \`ArrayHandleBasic\` and \`ArrayHandleRuntimeVec\` (covered by \`check_viskores_allocated_zero_copy\`), and an element-by-element fallback via \`CastAndCallForTypes\` for other storage layouts (\`ArrayHandleUniformPoints\`, \`ArrayHandleCartesianProduct\`, \`ArrayHandleSOAStride\`). The fallback compiles and the logic is straightforward, but exercising it at runtime requires constructing one of those non-basic arrays from Python, which is out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)