### PR TITLE
Add a chapter for sources to the users guide

### DIFF
--- a/docs/users-guide/acknowledgements.rst
+++ b/docs/users-guide/acknowledgements.rst
@@ -6,8 +6,6 @@ Acknowledgements
 Contributors
 ------------------------------
 
-.. todo:: Make sure contribution section cross references are correct.
-
 This book includes contributions from the Viskores community including the
 Viskores development team and the user community.
 We would like to thank the following people for their significant
@@ -26,15 +24,11 @@ contributions to this text:
 .. Mark Kim: ZFP compression
 .. Hank Childs: Mesh Quality Metrics
 
-**Allison Vacanti** for her documentation of..
-
-.. several |Viskores| features in the `Extract Component Arrays`_ and `SwizzleArrays`_ sections as well as select filters.
+**Allison Vacanti** for her documentation of several |Viskores| features in :secref:`fancy-array-handles:Extract Component Arrays` and :secref:`fancy-array-handles:Swizzle Arrays` sections as well as select filters.
 
 .. Allie Vacanti filters: Surface normals.
 
-**David Pugmire** for his documentation of..
-
-.. partitioned data sets (Section \ref{sec:DataSets:PartitionedDataSet}) and select filters.
+**David Pugmire** for his documentation of partitioned data sets in :secref:`dataset:Partitioned Data Sets` and select filters.
 
 .. Dave Pugmire filters: Streamlines, point transform, coordinate system transforms, add ghost cells, remove ghost cells.
 
@@ -43,16 +37,18 @@ contributions to this text:
 .. Abhishek Yenpure: General cell locators and BoundingIntervalHierarchy
 .. Li-Ta Lo: General point locators and uniform grid point locator, particle density
 
-**Li-Ta Lo** for his documentation of random array handles and particle
-density filters.
+**Li-Ta Lo** for his documentation of random array handles in :secref:`fancy-array-handles:Random Arrays` and particle
+density filters in :secref:`provided-filters:Particle Density`.
 
 .. ArrayHandleRandomUniformBits.
 
 **James Kress** for his documentation on |Viskores|'s testing classes.
 
-**Manish Mathai** for his documentation of rendering features..
+.. todo:: Add reference to testing classes when available.
 
-.. (Chapter~\ref{chap:Rendering}).
+**Manish Mathai** for his documentation of rendering features in :chapref:`rendering:Rendering`.
+
+AI was used to assist the writing of some parts of this documentation.
 
 
 ------------------------------

--- a/docs/users-guide/examples/CMakeLists.txt
+++ b/docs/users-guide/examples/CMakeLists.txt
@@ -43,6 +43,7 @@ set(examples
   GuideExampleProvidedFilters.cxx
   GuideExampleRendering.cxx
   GuideExampleRuntimeDeviceTracker.cxx
+  GuideExampleSource.cxx
   GuideExampleTimer.cxx
   GuideExampleTraits.cxx
   GuideExampleTuple.cxx

--- a/docs/users-guide/examples/GuideExampleSource.cxx
+++ b/docs/users-guide/examples/GuideExampleSource.cxx
@@ -1,0 +1,155 @@
+//============================================================================
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//============================================================================
+
+//============================================================================
+//  Copyright (c) Kitware, Inc.
+//  All rights reserved.
+//  See LICENSE.txt for details.
+//
+//  This software is distributed WITHOUT ANY WARRANTY; without even
+//  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+//  PURPOSE.  See the above copyright notice for more information.
+//============================================================================
+
+#include <viskores/source/Amr.h>
+#include <viskores/source/Oscillator.h>
+#include <viskores/source/PerlinNoise.h>
+#include <viskores/source/Tangle.h>
+#include <viskores/source/Wavelet.h>
+
+#include <viskores/cont/DataSet.h>
+#include <viskores/cont/PartitionedDataSet.h>
+#include <viskores/cont/testing/Testing.h>
+
+namespace
+{
+
+void UseTangle()
+{
+  ////
+  //// BEGIN-EXAMPLE SourceTangle
+  ////
+  viskores::source::Tangle tangle;
+  tangle.SetCellDimensions({ 64, 64, 64 });
+
+  viskores::cont::DataSet dataSet = tangle.Execute();
+  ////
+  //// END-EXAMPLE SourceTangle
+  ////
+
+  VISKORES_TEST_ASSERT(dataSet.HasPointField("tangle"));
+}
+
+void UsePerlinNoise()
+{
+  ////
+  //// BEGIN-EXAMPLE SourcePerlinNoise
+  ////
+  viskores::source::PerlinNoise noise;
+  noise.SetCellDimensions({ 64, 64, 64 });
+  noise.SetOrigin({ 0.0f, 0.0f, 0.0f });
+  noise.SetSeed(12345);
+
+  viskores::cont::DataSet dataSet = noise.Execute();
+  ////
+  //// END-EXAMPLE SourcePerlinNoise
+  ////
+
+  VISKORES_TEST_ASSERT(dataSet.HasPointField("perlinnoise"));
+}
+
+void UseOscillator()
+{
+  ////
+  //// BEGIN-EXAMPLE SourceOscillator
+  ////
+  viskores::source::Oscillator oscillator;
+  oscillator.SetPointDimensions({ 65, 65, 65 });
+  oscillator.SetTime(0.25f);
+  oscillator.AddPeriodic(0.50f, 0.50f, 0.50f, 0.25f, 0.10f, 0.20f);
+  oscillator.AddDamped(0.25f, 0.25f, 0.25f, 0.30f, 0.15f, 0.10f);
+
+  viskores::cont::DataSet dataSet = oscillator.Execute();
+  ////
+  //// END-EXAMPLE SourceOscillator
+  ////
+
+  VISKORES_TEST_ASSERT(dataSet.HasPointField("oscillating"));
+}
+
+void UseWavelet()
+{
+  ////
+  //// BEGIN-EXAMPLE SourceWavelet
+  ////
+  viskores::source::Wavelet wavelet;
+  wavelet.SetExtent({ -32, -32, -32 }, { 32, 32, 32 });
+  wavelet.SetSpacing({ 0.5f, 0.5f, 0.5f });
+  wavelet.SetCenter({ 0.0f, 0.0f, 0.0f });
+
+  viskores::cont::DataSet dataSet = wavelet.Execute();
+  ////
+  //// END-EXAMPLE SourceWavelet
+  ////
+
+  VISKORES_TEST_ASSERT(dataSet.HasPointField("RTData"));
+}
+
+void UseWavelet2D()
+{
+  ////
+  //// BEGIN-EXAMPLE SourceWavelet2D
+  ////
+  viskores::source::Wavelet wavelet2D;
+  wavelet2D.SetExtent({ -32, -32, 0 }, { 32, 32, 0 });
+
+  viskores::cont::DataSet imageData = wavelet2D.Execute();
+  ////
+  //// END-EXAMPLE SourceWavelet2D
+  ////
+
+  VISKORES_TEST_ASSERT(imageData.HasPointField("RTData"));
+}
+
+void UseAmr()
+{
+  ////
+  //// BEGIN-EXAMPLE SourceAmr
+  ////
+  viskores::source::Amr amr;
+  amr.SetDimension(3);
+  amr.SetCellsPerDimension(8);
+  amr.SetNumberOfLevels(3);
+
+  viskores::cont::PartitionedDataSet dataSet = amr.Execute();
+  ////
+  //// END-EXAMPLE SourceAmr
+  ////
+
+  VISKORES_TEST_ASSERT(dataSet.GetNumberOfPartitions() == 7,
+                       "Unexpected number of partitions.");
+  VISKORES_TEST_ASSERT(dataSet.GetPartition(0).HasPointField("RTData"));
+  VISKORES_TEST_ASSERT(dataSet.GetPartition(0).HasCellField("RTDataCells"));
+}
+
+void Test()
+{
+  UseTangle();
+  UsePerlinNoise();
+  UseOscillator();
+  UseWavelet();
+  UseWavelet2D();
+  UseAmr();
+}
+
+} // namespace
+
+int GuideExampleSource(int argc, char* argv[])
+{
+  return viskores::cont::testing::Testing::Run(Test, argc, argv);
+}

--- a/docs/users-guide/part-using.rst
+++ b/docs/users-guide/part-using.rst
@@ -10,6 +10,7 @@ Using |Viskores|
    initialization.rst
    dataset.rst
    io.rst
+   source.rst
    running-filters.rst
    provided-filters.rst
    rendering.rst

--- a/docs/users-guide/source.rst
+++ b/docs/users-guide/source.rst
@@ -1,0 +1,198 @@
+==============================
+Sources
+==============================
+
+.. index::
+   single: source
+   single: data set; source
+
+Before |Viskores| can process data, data must be placed in a
+:class:`viskores::cont::DataSet` or
+:class:`viskores::cont::PartitionedDataSet`.
+Files are one common way to get data into |Viskores|, as described in
+:chapref:`io:File I/O`.
+|Viskores| also provides a set of *source* classes that generate synthetic data.
+These sources are useful for examples, tests, benchmarks, and for quickly
+constructing input to filters without managing external files.
+
+All source classes provided by |Viskores| are located in the
+``viskores::source`` namespace and declared in headers under
+:file:`viskores/source`.
+Most sources derive from :class:`viskores::source::Source`.
+The general interface is to construct a source, set any desired parameters, and
+call ``Execute`` to generate the data.
+
+.. doxygenclass:: viskores::source::Source
+   :members:
+
+------------------------------
+Uniform Grid Sources
+------------------------------
+
+Several source classes generate structured 3D data sets with uniform point
+coordinates.
+Most of these sources provide ``SetPointDimensions`` and ``SetCellDimensions`` methods.
+Point dimensions specify the number of points in each direction.
+Cell dimensions specify the number of cells in each direction, and the source
+will create one more point than cell in each direction.
+
+Tangle
+==============================
+
+.. index::
+   single: source; Tangle
+   single: Tangle
+
+The :class:`viskores::source::Tangle` source creates a uniform structured data
+set over the unit cube.
+It adds a scalar point field named ``tangle``.
+The field is computed from a polynomial with a smooth, rounded shape that is
+useful for contouring, clipping, and other scalar-field operations.
+The ``tangle`` field usually ranges from just below 0 to about 25, with the
+most interesting contour surfaces near the lower end of that range.
+Good starting contour values are 0, 0.5, 1, and 2.
+
+.. doxygenclass:: viskores::source::Tangle
+   :members:
+
+.. load-example:: SourceTangle
+   :file: GuideExampleSource.cxx
+   :caption: Creating a tangle data set.
+
+Perlin Noise
+==============================
+
+.. index::
+   single: source; PerlinNoise
+   single: Perlin noise
+
+The :class:`viskores::source::PerlinNoise` source creates a uniform structured
+data set with a scalar point field named ``perlinnoise``.
+The field contains tileable Perlin noise, which provides a smooth random-looking
+field for testing algorithms on noisy data.
+The ``perlinnoise`` field is normalized to values typically between 0 and 1.
+Contours at 0.3, 0.4, 0.5, 0.6, and 0.7 usually provide a useful spread of
+features.
+
+If a seed is set with
+:func:`viskores::source::PerlinNoise::SetSeed`, repeated executions produce the
+same field values.
+If no seed is set, a new seed is selected each time ``Execute`` is called.
+The origin of the generated coordinate system can be changed with
+:func:`viskores::source::PerlinNoise::SetOrigin`.
+
+.. doxygenclass:: viskores::source::PerlinNoise
+   :members:
+
+.. load-example:: SourcePerlinNoise
+   :file: GuideExampleSource.cxx
+   :caption: Creating a deterministic Perlin noise data set.
+
+Oscillator
+==============================
+
+.. index::
+   single: source; Oscillator
+   single: oscillator source
+
+The :class:`viskores::source::Oscillator` source creates a time-varying uniform
+structured data set.
+It adds a scalar point field named ``oscillating``.
+The field is formed from one or more Gaussian oscillator terms.
+The oscillators are configured by adding periodic, damped, or decaying
+oscillators and by setting the current time.
+
+Each oscillator is specified by a center point, radius, angular frequency, and
+damping factor.
+The generated coordinate system spans the unit cube.
+The range of the ``oscillating`` field depends on the oscillators that have
+been added and the selected time.
+With a small number of moderate oscillators, values often fall near -1 to 1.
+For contouring, inspect the generated field range and start with values around
+0, or with several values symmetrically distributed around 0 such as -0.5, 0,
+and 0.5.
+
+.. doxygenclass:: viskores::source::Oscillator
+   :members:
+
+.. load-example:: SourceOscillator
+   :file: GuideExampleSource.cxx
+   :caption: Creating a time-varying oscillator data set.
+
+Wavelet Source
+==============================
+
+.. index::
+   single: source; Wavelet
+   single: wavelet source
+   single: RTData
+
+The :class:`viskores::source::Wavelet` source creates a structured data set
+similar to VTK's ``vtkRTAnalyticSource``.
+It adds a scalar point field named ``RTData``.
+This source is useful for examples that need a smooth scalar field with
+nontrivial variation throughout the domain.
+
+The geometry of the generated data set is controlled by the logical point
+extent, spacing, and origin.
+The source creates points for every logical index between the minimum and
+maximum extent values, inclusive.
+If the z extent has zero length, the generated data set uses a 2D structured
+cell set; otherwise it uses a 3D structured cell set.
+
+The scalar field is controlled by parameters such as center, standard
+deviation, maximum value, frequency, and magnitude.
+By default the extent is ``{-10, -10, -10}`` to ``{10, 10, 10}``, spacing is
+``{1, 1, 1}``, and the field center is at ``{0, 0, 0}``.
+With the default parameters, the ``RTData`` field is typically between about
+40 and 280.
+Useful contour values generally include 100, 150, 200, and 250.
+
+.. doxygenclass:: viskores::source::Wavelet
+   :members:
+
+.. load-example:: SourceWavelet
+   :file: GuideExampleSource.cxx
+   :caption: Creating a 3D wavelet data set.
+
+.. load-example:: SourceWavelet2D
+   :file: GuideExampleSource.cxx
+   :caption: Creating a 2D wavelet data set by using a zero-length z extent.
+
+------------------------------
+AMR Source
+------------------------------
+
+.. index::
+   single: source; Amr
+   single: AMR
+   single: PartitionedDataSet; source
+
+The :class:`viskores::source::Amr` source creates a
+:class:`viskores::cont::PartitionedDataSet` that represents a simple adaptive
+mesh refinement hierarchy.
+Unlike the other source classes in this chapter, ``Amr`` does not derive from
+:class:`viskores::source::Source` because its ``Execute`` method returns a
+partitioned data set rather than a single data set.
+
+Each partition is generated from a wavelet source and contains a point field
+named ``RTData`` and a cell field named ``RTDataCells``.
+The source also runs :class:`viskores::filter::multi_block::AmrArrays` to add
+helper arrays used by AMR-aware filters.
+
+The source can generate either 2D or 3D AMR data.
+The number of cells per dimension must be even and greater than 1.
+The number of levels controls how many refinement levels are generated; level
+``l`` contains ``2^l`` partitions.
+Because the AMR source uses wavelet data for each partition, the point field
+``RTData`` and cell field ``RTDataCells`` usually have values in roughly the
+same range as the wavelet source, about 40 to 285 for common parameters.
+Contours at 100, 150, 200, and 250 are good starting values for exploring the
+generated hierarchy.
+
+.. doxygenclass:: viskores::source::Amr
+   :members:
+
+.. load-example:: SourceAmr
+   :file: GuideExampleSource.cxx
+   :caption: Creating an AMR partitioned data set.

--- a/docs/users-guide/viskores.module
+++ b/docs/users-guide/viskores.module
@@ -13,4 +13,5 @@ TEST_DEPENDS
   viskores_filter_geometry_refinement
   viskores_filter_mesh_info
   viskores_rendering
+  viskores_source
   viskores_worklet

--- a/viskores/source/Amr.h
+++ b/viskores/source/Amr.h
@@ -66,6 +66,10 @@ namespace source
 class VISKORES_SOURCE_EXPORT Amr
 {
 public:
+  /// \brief Constructs an AMR source with default parameters.
+  ///
+  /// The default source generates 2D AMR data with 6 cells per dimension and
+  /// 4 refinement levels.
   VISKORES_CONT Amr() = default;
 
   VISKORES_CONT VISKORES_DEPRECATED(2.0, "Use Set* methods to set parameters.")
@@ -75,24 +79,43 @@ public:
 
   VISKORES_CONT ~Amr() = default;
 
+  /// \brief Sets whether generated partitions are 2D or 3D.
+  ///
+  /// Supported values are 2 and 3.
   VISKORES_CONT void SetDimension(viskores::IdComponent dimension) { this->Dimension = dimension; }
+
+  /// \brief Gets the dimension of the generated partitions.
   VISKORES_CONT viskores::IdComponent GetDimension() const { return this->Dimension; }
 
+  /// \brief Sets the number of cells along each dimension of a partition.
+  ///
+  /// The value must be even and greater than 1.
   VISKORES_CONT void SetCellsPerDimension(viskores::IdComponent cellsPerDimension)
   {
     this->CellsPerDimension = cellsPerDimension;
   }
+
+  /// \brief Gets the number of cells along each dimension of a partition.
   VISKORES_CONT viskores::IdComponent GetCellsPerDimension() const
   {
     return this->CellsPerDimension;
   }
 
+  /// \brief Sets the number of AMR refinement levels to generate.
+  ///
+  /// Level \c l contains 2 to the \c l partitions.
   VISKORES_CONT void SetNumberOfLevels(viskores::IdComponent numberOfLevels)
   {
     this->NumberOfLevels = numberOfLevels;
   }
+
+  /// \brief Gets the number of AMR refinement levels to generate.
   VISKORES_CONT viskores::IdComponent GetNumberOfLevels() const { return this->NumberOfLevels; }
 
+  /// \brief Generates the AMR partitioned data set.
+  ///
+  /// Each partition contains the point field \c RTData and the cell field
+  /// \c RTDataCells. Additional AMR helper arrays are added to the result.
   VISKORES_CONT viskores::cont::PartitionedDataSet Execute() const;
 
 private:

--- a/viskores/source/Oscillator.h
+++ b/viskores/source/Oscillator.h
@@ -36,9 +36,12 @@ namespace source
 class VISKORES_SOURCE_EXPORT Oscillator final : public viskores::source::Source
 {
 public:
+  /// \brief Constructs an oscillator source with default parameters.
+  ///
+  /// The default point dimensions are 3 by 3 by 3. Oscillators can be added
+  /// with \c AddPeriodic, \c AddDamped, and \c AddDecaying.
   VISKORES_CONT Oscillator();
 
-  ///Construct a Oscillator with Cell Dimensions
   VISKORES_CONT VISKORES_DEPRECATED(
     2.0,
     "Use SetCellDimensions or SetPointDimensions.") explicit Oscillator(viskores::Id3 dims);
@@ -48,14 +51,35 @@ public:
   // in Oscillator.cxx does have ~Oscillator() = default;
   VISKORES_CONT ~Oscillator() override;
 
+  /// \brief Sets the number of points in each dimension.
+  ///
+  /// The dimensions must be greater than 1 in each direction to generate cells.
   VISKORES_CONT void SetPointDimensions(viskores::Id3 pointDimensions);
+
+  /// \brief Gets the number of points in each dimension.
   VISKORES_CONT viskores::Id3 GetPointDimensions() const;
+
+  /// \brief Sets the number of cells in each dimension.
+  ///
+  /// The point dimensions are set to one more than the given cell dimensions in
+  /// each direction.
   VISKORES_CONT void SetCellDimensions(viskores::Id3 pointDimensions);
+
+  /// \brief Gets the number of cells in each dimension.
+  ///
+  /// This value is computed from the point dimensions by subtracting 1 in each
+  /// direction.
   VISKORES_CONT viskores::Id3 GetCellDimensions() const;
 
+  /// \brief Sets the time used to evaluate the oscillator field.
   VISKORES_CONT
   void SetTime(viskores::FloatDefault time);
 
+  /// \brief Adds a periodic oscillator contribution.
+  ///
+  /// The first three parameters specify the oscillator center. The radius
+  /// controls the Gaussian spatial falloff. The omega and zeta parameters
+  /// control the oscillator's temporal behavior.
   VISKORES_CONT
   void AddPeriodic(viskores::FloatDefault x,
                    viskores::FloatDefault y,
@@ -64,6 +88,11 @@ public:
                    viskores::FloatDefault omega,
                    viskores::FloatDefault zeta);
 
+  /// \brief Adds a damped oscillator contribution.
+  ///
+  /// The first three parameters specify the oscillator center. The radius
+  /// controls the Gaussian spatial falloff. The omega and zeta parameters
+  /// control the oscillator's temporal behavior.
   VISKORES_CONT
   void AddDamped(viskores::FloatDefault x,
                  viskores::FloatDefault y,
@@ -72,6 +101,11 @@ public:
                  viskores::FloatDefault omega,
                  viskores::FloatDefault zeta);
 
+  /// \brief Adds a decaying oscillator contribution.
+  ///
+  /// The first three parameters specify the oscillator center. The radius
+  /// controls the Gaussian spatial falloff. The omega and zeta parameters
+  /// control the oscillator's temporal behavior.
   VISKORES_CONT
   void AddDecaying(viskores::FloatDefault x,
                    viskores::FloatDefault y,

--- a/viskores/source/PerlinNoise.h
+++ b/viskores/source/PerlinNoise.h
@@ -37,6 +37,10 @@ namespace source
 class VISKORES_SOURCE_EXPORT PerlinNoise final : public viskores::source::Source
 {
 public:
+  /// \brief Constructs a Perlin noise source with default parameters.
+  ///
+  /// The default point dimensions are 16 by 16 by 16, the origin is at
+  /// 0, 0, 0, and no deterministic seed is selected.
   VISKORES_CONT PerlinNoise() = default;
   VISKORES_CONT ~PerlinNoise() = default;
 
@@ -54,25 +58,52 @@ public:
   VISKORES_DEPRECATED(2.0, "Use Set*Dimensions, SetOrigin, and SetSeed.")
   VISKORES_CONT PerlinNoise(viskores::Id3 dims, viskores::Vec3f origin, viskores::IdComponent seed);
 
+  /// \brief Gets the number of points in each dimension.
+  ///
+  /// The generated structured data set has one fewer cell than point in each
+  /// dimension.
   VISKORES_CONT viskores::Id3 GetPointDimensions() const { return this->PointDimensions; }
+
+  /// \brief Sets the number of points in each dimension.
+  ///
+  /// The dimensions must be greater than 1 in each direction to generate cells.
   VISKORES_CONT void SetPointDimensions(viskores::Id3 dims) { this->PointDimensions = dims; }
 
+  /// \brief Gets the number of cells in each dimension.
+  ///
+  /// This value is computed from the point dimensions by subtracting 1 in each
+  /// direction.
   VISKORES_CONT viskores::Id3 GetCellDimensions() const
   {
     return this->PointDimensions - viskores::Id3(1);
   }
+
+  /// \brief Sets the number of cells in each dimension.
+  ///
+  /// The point dimensions are set to one more than the given cell dimensions in
+  /// each direction.
   VISKORES_CONT void SetCellDimensions(viskores::Id3 dims)
   {
     this->PointDimensions = dims + viskores::Id3(1);
   }
 
+  /// \brief Gets the origin of the generated coordinate system.
   VISKORES_CONT viskores::Vec3f GetOrigin() const { return this->Origin; }
+
+  /// \brief Sets the origin of the generated coordinate system.
   VISKORES_CONT void SetOrigin(const viskores::Vec3f& origin) { this->Origin = origin; }
 
-  /// \brief The seed used for the pseudorandom number generation of the noise.
+  /// \brief Gets the seed used for the pseudorandom generation of the noise.
   ///
-  /// If the seed is not set, then a new, unique seed is picked each time `Execute` is run.
+  /// If the seed is not set, then a new seed is picked each time \c Execute
+  /// is run.
   VISKORES_CONT viskores::IdComponent GetSeed() const { return this->Seed; }
+
+  /// \brief Sets the seed used for pseudorandom noise generation.
+  ///
+  /// Setting a seed makes repeated calls to \c Execute produce the same scalar
+  /// field for the same source parameters. If the seed is not set, then a new
+  /// seed is picked each time \c Execute is run.
   VISKORES_CONT void SetSeed(viskores::IdComponent seed)
   {
     this->Seed = seed;

--- a/viskores/source/Source.h
+++ b/viskores/source/Source.h
@@ -28,17 +28,28 @@ namespace viskores
 namespace source
 {
 
+/// \brief Base class for sources that generate a single data set.
+///
+/// A source creates a new \c viskores::cont::DataSet when \c Execute is
+/// called. Subclasses implement \c DoExecute to construct the concrete data
+/// set.
 class VISKORES_SOURCE_EXPORT Source
 {
 public:
   VISKORES_CONT
   virtual ~Source() = default;
 
+  /// \brief Generates the data set for this source.
+  ///
+  /// The returned data set is newly generated from the current source
+  /// parameters.
   viskores::cont::DataSet Execute() const { return this->DoExecute(); }
 
 protected:
+  /// \brief Implementation hook used by subclasses to generate their data.
   virtual viskores::cont::DataSet DoExecute() const = 0;
 
+  /// \brief Invoker used by source implementations to run worklets.
   viskores::cont::Invoker Invoke;
 };
 

--- a/viskores/source/Tangle.h
+++ b/viskores/source/Tangle.h
@@ -43,6 +43,10 @@ namespace source
 class VISKORES_SOURCE_EXPORT Tangle final : public viskores::source::Source
 {
 public:
+  /// \brief Constructs a tangle source with the default point dimensions.
+  ///
+  /// The default point dimensions are ``{16, 16, 16}``, which produces
+  /// ``{15, 15, 15}`` cells.
   VISKORES_CONT Tangle() = default;
   VISKORES_CONT ~Tangle() = default;
 
@@ -52,13 +56,30 @@ public:
   {
   }
 
+  /// \brief Gets the number of points in each dimension.
+  ///
+  /// The generated structured data set has one fewer cell than point in each
+  /// dimension.
   VISKORES_CONT viskores::Id3 GetPointDimensions() const { return this->PointDimensions; }
+
+  /// \brief Sets the number of points in each dimension.
+  ///
+  /// The dimensions must be greater than 1 in each direction to generate cells.
   VISKORES_CONT void SetPointDimensions(viskores::Id3 dims) { this->PointDimensions = dims; }
 
+  /// \brief Gets the number of cells in each dimension.
+  ///
+  /// This value is computed from the point dimensions by subtracting 1 in each
+  /// direction.
   VISKORES_CONT viskores::Id3 GetCellDimensions() const
   {
     return this->PointDimensions - viskores::Id3(1);
   }
+
+  /// \brief Sets the number of cells in each dimension.
+  ///
+  /// The point dimensions are set to one more than the given cell dimensions in
+  /// each direction.
   VISKORES_CONT void SetCellDimensions(viskores::Id3 dims)
   {
     this->PointDimensions = dims + viskores::Id3(1);

--- a/viskores/source/Wavelet.h
+++ b/viskores/source/Wavelet.h
@@ -69,28 +69,31 @@ namespace source
 class VISKORES_SOURCE_EXPORT Wavelet final : public viskores::source::Source
 {
 public:
+  /// \brief Constructs a wavelet source with default parameters.
+  ///
+  /// The default extent is -10 to 10 in each dimension, the spacing is
+  /// 1 by 1 by 1, and the generated point field is named \c RTData.
   VISKORES_CONT Wavelet() = default;
   VISKORES_CONT ~Wavelet() = default;
 
   VISKORES_DEPRECATED(2.0, "Use SetExtent.")
   VISKORES_CONT Wavelet(viskores::Id3 minExtent, viskores::Id3 maxExtent = { 10 });
 
-  ///@{
   /// \brief Specifies the center of the wavelet function.
   ///
   /// Note that the center of the function can be anywhere in space including
   /// outside the domain of the data created (as specified by the origin,
   /// spacing and extent).
   VISKORES_CONT void SetCenter(const viskores::Vec3f& center) { this->Center = center; }
+  /// @copydoc SetCenter
   VISKORES_CONT viskores::Vec3f GetCenter() const { return this->Center; }
-  ///@}
 
-  ///@{
   /// \brief Specifies the origin (lower left corner) of the dataset created.
   ///
   /// If the origin is not specified, it will be placed such that extent
   /// index (0, 0, 0) is at the coordinate system origin.
   VISKORES_CONT void SetOrigin(const viskores::Vec3f& origin) { this->Origin = origin; }
+  /// @copydoc SetOrigin
   VISKORES_CONT viskores::Vec3f GetOrigin() const
   {
     if (!viskores::IsNan(this->Origin[0]))
@@ -103,43 +106,73 @@ public:
     }
   }
 
+  /// \brief Specifies the distance between adjacent points in each dimension.
   VISKORES_CONT void SetSpacing(const viskores::Vec3f& spacing) { this->Spacing = spacing; }
+  /// @copydoc SetSpacing
   VISKORES_CONT viskores::Vec3f GetSpacing() const { return this->Spacing; }
 
+  /// \brief Specifies the frequency of the periodic scalar contributions.
+  ///
+  /// The components correspond to the x, y, and z periodic terms.
   VISKORES_CONT void SetFrequency(const viskores::Vec3f& frequency) { this->Frequency = frequency; }
+  /// @copydoc SetFrequency
   VISKORES_CONT viskores::Vec3f GetFrequency() const { return this->Frequency; }
 
+  /// \brief Specifies the magnitude of the periodic scalar contributions.
+  ///
+  /// The components correspond to the x, y, and z periodic terms.
   VISKORES_CONT void SetMagnitude(const viskores::Vec3f& magnitude) { this->Magnitude = magnitude; }
+  /// @copydoc SetMagnitude
   VISKORES_CONT viskores::Vec3f GetMagnitude() const { return this->Magnitude; }
 
+  /// \brief Specifies the minimum logical point extent.
+  ///
+  /// The minimum and maximum extents are inclusive. Use \c SetExtent to set
+  /// both bounds at the same time.
   VISKORES_CONT void SetMinimumExtent(const viskores::Id3& minExtent)
   {
     this->MinimumExtent = minExtent;
   }
+  /// @copydoc SetMinimumExtent
   VISKORES_CONT viskores::Id3 GetMinimumExtent() const { return this->MinimumExtent; }
 
+  /// \brief Specifies the maximum logical point extent.
+  ///
+  /// The minimum and maximum extents are inclusive. Use \c SetExtent to set
+  /// both bounds at the same time.
   VISKORES_CONT void SetMaximumExtent(const viskores::Id3& maxExtent)
   {
     this->MaximumExtent = maxExtent;
   }
+  /// @copydoc SetMaximumExtent
   VISKORES_CONT viskores::Id3 GetMaximumExtent() const { return this->MaximumExtent; }
 
+  /// \brief Sets the inclusive minimum and maximum logical point extents.
+  ///
+  /// If the z extent has zero length, \c Execute generates a 2D structured
+  /// data set. Otherwise, it generates a 3D structured data set.
   VISKORES_CONT void SetExtent(const viskores::Id3& minExtent, const viskores::Id3& maxExtent)
   {
     this->MinimumExtent = minExtent;
     this->MaximumExtent = maxExtent;
   }
 
+  /// \brief Specifies the maximum value of the Gaussian scalar contribution.
   VISKORES_CONT void SetMaximumValue(const viskores::FloatDefault& maxVal)
   {
     this->MaximumValue = maxVal;
   }
+  /// @copydoc SetMaximumValue
   VISKORES_CONT viskores::FloatDefault GetMaximumValue() const { return this->MaximumValue; }
 
+  /// \brief Specifies the width of the Gaussian scalar contribution.
+  ///
+  /// Larger values produce a wider Gaussian contribution.
   VISKORES_CONT void SetStandardDeviation(const viskores::FloatDefault& stdev)
   {
     this->StandardDeviation = stdev;
   }
+  /// @copydoc SetStandardDeviation
   VISKORES_CONT viskores::FloatDefault GetStandardDeviation() const
   {
     return this->StandardDeviation;


### PR DESCRIPTION
Added a chapter to the User's Guide on how to use the Source objects in the viskores::source namespace.

Codex was used to assist with the writing of this documentation.