### PR TITLE
Add id-only BoundsMap locator for flow

### DIFF
--- a/docs/changelog/flow-boundsmap-id-locator.md
+++ b/docs/changelog/flow-boundsmap-id-locator.md
@@ -1,0 +1,6 @@
+## Use id-only block lookup for flow bounds
+
+Flow filters now build an internal block-bounds locator that can identify all
+blocks containing a particle position using cell-id-only locator queries. This
+provides the foundation for more efficient worklet-based particle routing across
+overlapping blocks.

--- a/viskores/filter/flow/internal/AdvectAlgorithm.h
+++ b/viskores/filter/flow/internal/AdvectAlgorithm.h
@@ -98,7 +98,7 @@ public:
       //Note: For duplicate blocks, this will give the seeds to the rank that are first in the list.
       if (!ids.empty())
       {
-        auto ranks = this->BoundsMap.FindRank(ids[0]);
+        const auto& ranks = this->BoundsMap.FindRank(ids[0]);
         if (!ranks.empty() && this->Rank == ranks[0])
         {
           particles.emplace_back(p);
@@ -289,7 +289,7 @@ public:
       const auto& bid = this->ParticleBlockIDsMap[p.GetID()];
       VISKORES_ASSERT(!bid.empty());
 
-      auto ranks = this->BoundsMap.FindRank(bid[0]);
+      const auto& ranks = this->BoundsMap.FindRank(bid[0]);
       VISKORES_ASSERT(!ranks.empty());
 
       //Only 1 rank has the block.

--- a/viskores/filter/flow/internal/BoundsMap.cxx
+++ b/viskores/filter/flow/internal/BoundsMap.cxx
@@ -8,11 +8,20 @@
 
 #include <viskores/filter/flow/internal/BoundsMap.h>
 
+#include <viskores/CellShape.h>
 #include <viskores/cont/AssignerPartitionedDataSet.h>
+#include <viskores/cont/DataSetBuilderExplicit.h>
 #include <viskores/cont/EnvironmentTracker.h>
 #include <viskores/cont/ErrorFilterExecution.h>
 
 #include <viskores/thirdparty/diy/diy.h>
+
+#include <algorithm>
+#include <cmath>
+#include <functional>
+#include <limits>
+#include <numeric>
+#include <set>
 
 #ifdef VISKORES_ENABLE_MPI
 #include <mpi.h>
@@ -53,8 +62,11 @@ void BoundsMap::Init(const std::vector<viskores::cont::DataSet>& dataSets,
     comm, locMinId, globalMinId, viskoresdiy::mpi::minimum<viskores::Id>{});
   viskoresdiy::mpi::all_reduce(
     comm, locMaxId, globalMaxId, viskoresdiy::mpi::maximum<viskores::Id>{});
-  if (globalMinId != 0 || (globalMaxId - globalMinId) < 1)
-    throw viskores::cont::ErrorFilterExecution("Invalid block ids");
+  if (globalMinId < 0)
+  {
+    throw viskores::cont::ErrorFilterExecution(
+      "Invalid block ids. IDs must be non-negative and dense in [0, N).");
+  }
 
   //2. Find out how many blocks everyone has.
   std::vector<viskores::Id> locBlockCounts(comm.size(), 0), globalBlockCounts(comm.size(), 0);
@@ -99,15 +111,26 @@ void BoundsMap::Init(const std::vector<viskores::cont::DataSet>& dataSets,
   //6. there might be duplicates, so count number of UNIQUE blocks.
   std::set<viskores::Id> globalUniqueBlockIds;
   globalUniqueBlockIds.insert(globalBlockIds.begin(), globalBlockIds.end());
-  this->TotalNumBlocks = globalUniqueBlockIds.size();
+  if (!globalUniqueBlockIds.empty())
+  {
+    // The synthetic locator cells built below use their cell id directly as the
+    // global block id. That requires block ids to be dense in [0, N).
+    const viskores::Id minId = *globalUniqueBlockIds.begin();
+    const viskores::Id maxId = *globalUniqueBlockIds.rbegin();
+    const viskores::Id uniqueCount = static_cast<viskores::Id>(globalUniqueBlockIds.size());
+    const viskores::Id expectedDenseCount = maxId - minId + 1;
+    if (minId != 0 || expectedDenseCount != uniqueCount)
+    {
+      throw viskores::cont::ErrorFilterExecution(
+        "Invalid block ids. IDs must be non-negative and dense in [0, N).");
+    }
+  }
+  this->TotalNumBlocks = static_cast<viskores::Id>(globalUniqueBlockIds.size());
 
-  //Build a vector of :  blockIdsToRank[blockId] = {ranks that have this blockId}
-  std::vector<std::vector<viskores::Id>> blockIdsToRank(this->TotalNumBlocks);
   for (int rank = 0; rank < comm.size(); rank++)
   {
     for (const auto& bid : rankToBlockIds[rank])
     {
-      blockIdsToRank[bid].push_back(rank);
       this->BlockToRankMap[bid].push_back(rank);
     }
   }
@@ -135,9 +158,6 @@ void BoundsMap::Init(const std::vector<viskores::cont::DataSet>& dataSets)
 
 void BoundsMap::Build(const std::vector<viskores::cont::DataSet>& dataSets)
 {
-  std::vector<viskores::Float64> vals(static_cast<std::size_t>(this->TotalNumBlocks * 6), 0);
-  std::vector<viskores::Float64> vals2(vals.size());
-
   std::vector<viskores::Float64> localMins((this->TotalNumBlocks * 3),
                                            std::numeric_limits<viskores::Float64>::max());
   std::vector<viskores::Float64> localMaxs((this->TotalNumBlocks * 3),
@@ -189,6 +209,181 @@ void BoundsMap::Build(const std::vector<viskores::cont::DataSet>& dataSets)
     this->GlobalBounds.Include(block);
     idx += 3;
   }
+
+  this->BuildLocator();
+}
+
+viskores::Id3 BoundsMap::GetLocatorDims() const
+{
+  if (this->TotalNumBlocks <= 0)
+    return viskores::Id3{ 1, 1, 1 };
+
+  const viskores::Float64 ex = this->GlobalBounds.X.Length();
+  const viskores::Float64 ey = this->GlobalBounds.Y.Length();
+  const viskores::Float64 ez = this->GlobalBounds.Z.Length();
+
+  // Keep the number of bins close to the number of block cells while respecting box aspect ratio.
+  const viskores::Float64 volume = ex * ey * ez;
+  viskores::Id3 dims{ 1, 1, 1 };
+  if (volume > viskores::Float64{ 0 })
+  {
+    const viskores::Float64 targetBins =
+      std::max(viskores::Float64{ 1 }, static_cast<viskores::Float64>(this->TotalNumBlocks));
+    const viskores::Float64 scale = std::cbrt(targetBins / volume);
+    dims[0] = std::max<viskores::Id>(1, static_cast<viskores::Id>(std::ceil(ex * scale)));
+    dims[1] = std::max<viskores::Id>(1, static_cast<viskores::Id>(std::ceil(ey * scale)));
+    dims[2] = std::max<viskores::Id>(1, static_cast<viskores::Id>(std::ceil(ez * scale)));
+  }
+  else
+  {
+    const viskores::Id n =
+      std::max<viskores::Id>(1,
+                             static_cast<viskores::Id>(std::ceil(
+                               std::cbrt(static_cast<viskores::Float64>(this->TotalNumBlocks)))));
+    dims = viskores::Id3{ n, n, n };
+    if (ex == viskores::Float64{ 0 })
+      dims[0] = 1;
+    if (ey == viskores::Float64{ 0 })
+      dims[1] = 1;
+    if (ez == viskores::Float64{ 0 })
+      dims[2] = 1;
+  }
+
+  return dims;
+}
+
+void BoundsMap::BuildLocator()
+{
+  if (this->TotalNumBlocks <= 0)
+  {
+    this->Locator = viskores::cont::CellLocatorUniformBins{};
+    this->Locator.SetDims(viskores::Id3{ 1, 1, 1 });
+    return;
+  }
+
+  std::vector<viskores::Vec3f> points;
+  std::vector<viskores::UInt8> shapes;
+  std::vector<viskores::IdComponent> numIndices;
+  std::vector<viskores::Id> connectivity;
+
+  points.reserve(static_cast<std::size_t>(this->TotalNumBlocks * 8));
+  shapes.reserve(static_cast<std::size_t>(this->TotalNumBlocks));
+  numIndices.reserve(static_cast<std::size_t>(this->TotalNumBlocks));
+  connectivity.reserve(static_cast<std::size_t>(this->TotalNumBlocks * 8));
+
+  // Each block bound is represented as one synthetic cell. Later flow worklets
+  // can query the locator with CountAllCells/FindAllCellIds and use the returned
+  // cell ids directly as global block ids.
+  for (const auto& b : this->BlockBounds)
+  {
+    const viskores::Float64 xmin = b.X.Min;
+    const viskores::Float64 xmax = b.X.Max;
+    const viskores::Float64 ymin = b.Y.Min;
+    const viskores::Float64 ymax = b.Y.Max;
+    const viskores::Float64 zmin = b.Z.Min;
+    const viskores::Float64 zmax = b.Z.Max;
+
+    const bool varyX = (xmax - xmin) > viskores::Float64{ 0 };
+    const bool varyY = (ymax - ymin) > viskores::Float64{ 0 };
+    const bool varyZ = (zmax - zmin) > viskores::Float64{ 0 };
+
+    auto pushPoint = [&points](viskores::Float64 x, viskores::Float64 y, viskores::Float64 z)
+    {
+      // CellLocatorUniformBins execution queries use Vec3f positions, so keep
+      // the locator geometry in the same coordinate type.
+      points.emplace_back(static_cast<viskores::FloatDefault>(x),
+                          static_cast<viskores::FloatDefault>(y),
+                          static_cast<viskores::FloatDefault>(z));
+      return static_cast<viskores::Id>(points.size() - 1);
+    };
+
+    if (varyX && varyY && varyZ)
+    {
+      const viskores::Id p0 = pushPoint(xmin, ymin, zmin);
+      const viskores::Id p1 = pushPoint(xmax, ymin, zmin);
+      const viskores::Id p2 = pushPoint(xmax, ymax, zmin);
+      const viskores::Id p3 = pushPoint(xmin, ymax, zmin);
+      const viskores::Id p4 = pushPoint(xmin, ymin, zmax);
+      const viskores::Id p5 = pushPoint(xmax, ymin, zmax);
+      const viskores::Id p6 = pushPoint(xmax, ymax, zmax);
+      const viskores::Id p7 = pushPoint(xmin, ymax, zmax);
+      shapes.push_back(static_cast<viskores::UInt8>(viskores::CELL_SHAPE_HEXAHEDRON));
+      numIndices.push_back(8);
+      connectivity.insert(connectivity.end(), { p0, p1, p2, p3, p4, p5, p6, p7 });
+    }
+    else if (varyX && varyY)
+    {
+      const viskores::Id p0 = pushPoint(xmin, ymin, zmin);
+      const viskores::Id p1 = pushPoint(xmax, ymin, zmin);
+      const viskores::Id p2 = pushPoint(xmax, ymax, zmin);
+      const viskores::Id p3 = pushPoint(xmin, ymax, zmin);
+      shapes.push_back(static_cast<viskores::UInt8>(viskores::CELL_SHAPE_QUAD));
+      numIndices.push_back(4);
+      connectivity.insert(connectivity.end(), { p0, p1, p2, p3 });
+    }
+    else if (varyX && varyZ)
+    {
+      const viskores::Id p0 = pushPoint(xmin, ymin, zmin);
+      const viskores::Id p1 = pushPoint(xmax, ymin, zmin);
+      const viskores::Id p2 = pushPoint(xmax, ymin, zmax);
+      const viskores::Id p3 = pushPoint(xmin, ymin, zmax);
+      shapes.push_back(static_cast<viskores::UInt8>(viskores::CELL_SHAPE_QUAD));
+      numIndices.push_back(4);
+      connectivity.insert(connectivity.end(), { p0, p1, p2, p3 });
+    }
+    else if (varyY && varyZ)
+    {
+      const viskores::Id p0 = pushPoint(xmin, ymin, zmin);
+      const viskores::Id p1 = pushPoint(xmin, ymax, zmin);
+      const viskores::Id p2 = pushPoint(xmin, ymax, zmax);
+      const viskores::Id p3 = pushPoint(xmin, ymin, zmax);
+      shapes.push_back(static_cast<viskores::UInt8>(viskores::CELL_SHAPE_QUAD));
+      numIndices.push_back(4);
+      connectivity.insert(connectivity.end(), { p0, p1, p2, p3 });
+    }
+    else if (varyX)
+    {
+      const viskores::Id p0 = pushPoint(xmin, ymin, zmin);
+      const viskores::Id p1 = pushPoint(xmax, ymin, zmin);
+      shapes.push_back(static_cast<viskores::UInt8>(viskores::CELL_SHAPE_LINE));
+      numIndices.push_back(2);
+      connectivity.insert(connectivity.end(), { p0, p1 });
+    }
+    else if (varyY)
+    {
+      const viskores::Id p0 = pushPoint(xmin, ymin, zmin);
+      const viskores::Id p1 = pushPoint(xmin, ymax, zmin);
+      shapes.push_back(static_cast<viskores::UInt8>(viskores::CELL_SHAPE_LINE));
+      numIndices.push_back(2);
+      connectivity.insert(connectivity.end(), { p0, p1 });
+    }
+    else if (varyZ)
+    {
+      const viskores::Id p0 = pushPoint(xmin, ymin, zmin);
+      const viskores::Id p1 = pushPoint(xmin, ymin, zmax);
+      shapes.push_back(static_cast<viskores::UInt8>(viskores::CELL_SHAPE_LINE));
+      numIndices.push_back(2);
+      connectivity.insert(connectivity.end(), { p0, p1 });
+    }
+    else
+    {
+      const viskores::Id p0 = pushPoint(xmin, ymin, zmin);
+      shapes.push_back(static_cast<viskores::UInt8>(viskores::CELL_SHAPE_VERTEX));
+      numIndices.push_back(1);
+      connectivity.push_back(p0);
+    }
+  }
+
+  auto boundsDS =
+    viskores::cont::DataSetBuilderExplicit::Create(points, shapes, numIndices, connectivity);
+
+  this->Locator = viskores::cont::CellLocatorUniformBins{};
+  this->Locator.SetDims(this->GetLocatorDims());
+  this->Locator.SetCellSet(boundsDS.GetCellSet());
+  this->Locator.SetCoordinates(boundsDS.GetCoordinateSystem());
+  // The locator acceleration structure is built lazily when it is prepared for
+  // the selected device. The current flow filters still use FindBlocks on the host,
+  // so do not force device work for every BoundsMap construction.
 }
 
 }

--- a/viskores/filter/flow/internal/BoundsMap.h
+++ b/viskores/filter/flow/internal/BoundsMap.h
@@ -20,12 +20,13 @@
 #define viskores_filter_flow_internal_BoundsMap_h
 
 #include <viskores/Bounds.h>
+#include <viskores/cont/CellLocatorUniformBins.h>
 #include <viskores/cont/DataSet.h>
 #include <viskores/cont/Field.h>
 #include <viskores/cont/PartitionedDataSet.h>
+#include <viskores/filter/flow/viskores_filter_flow_export.h>
 
-#include <algorithm>
-#include <set>
+#include <map>
 #include <vector>
 
 namespace viskores
@@ -37,7 +38,7 @@ namespace flow
 namespace internal
 {
 
-class VISKORES_ALWAYS_EXPORT BoundsMap
+class VISKORES_FILTER_FLOW_EXPORT BoundsMap
 {
 public:
   VISKORES_CONT BoundsMap() {}
@@ -80,11 +81,14 @@ public:
     return this->LocalIDs[static_cast<std::size_t>(idx)];
   }
 
-  VISKORES_CONT std::vector<int> FindRank(viskores::Id blockId) const
+  VISKORES_CONT const std::vector<viskores::Int32>& FindRank(viskores::Id blockId) const
   {
     auto it = this->BlockToRankMap.find(blockId);
     if (it == this->BlockToRankMap.end())
-      return {};
+    {
+      static const std::vector<viskores::Int32> Empty;
+      return Empty;
+    }
 
     return it->second;
   }
@@ -122,6 +126,10 @@ public:
 
   VISKORES_CONT viskores::Id GetTotalNumBlocks() const { return this->TotalNumBlocks; }
   VISKORES_CONT viskores::Id GetLocalNumBlocks() const { return this->LocalNumBlocks; }
+  VISKORES_CONT const viskores::cont::CellLocatorUniformBins& GetLocator() const
+  {
+    return this->Locator;
+  }
 
 private:
   VISKORES_CONT void Init(const std::vector<viskores::cont::DataSet>& dataSets,
@@ -130,6 +138,8 @@ private:
   VISKORES_CONT void Init(const std::vector<viskores::cont::DataSet>& dataSets);
 
   VISKORES_CONT void Build(const std::vector<viskores::cont::DataSet>& dataSets);
+  VISKORES_CONT void BuildLocator();
+  VISKORES_CONT viskores::Id3 GetLocatorDims() const;
 
   viskores::Id LocalNumBlocks = 0;
   std::vector<viskores::Id> LocalIDs;
@@ -137,6 +147,7 @@ private:
   viskores::Id TotalNumBlocks = 0;
   std::vector<viskores::Bounds> BlockBounds;
   viskores::Bounds GlobalBounds;
+  viskores::cont::CellLocatorUniformBins Locator;
 };
 
 }

--- a/viskores/filter/flow/internal/DataSetIntegrator.h
+++ b/viskores/filter/flow/internal/DataSetIntegrator.h
@@ -221,7 +221,7 @@ VISKORES_CONT inline void DataSetIntegrator<Derived, ParticleType>::ClassifyPart
           for (auto idit = newIDs.begin(); idit != newIDs.end(); idit++)
           {
             viskores::Id bid = *idit;
-            auto ranks = dsiInfo.BoundsMap.FindRank(bid);
+            const auto& ranks = dsiInfo.BoundsMap.FindRank(bid);
             if (std::find(ranks.begin(), ranks.end(), this->Rank) != ranks.end())
             {
               newIDs.erase(idit);

--- a/viskores/filter/flow/testing/CMakeLists.txt
+++ b/viskores/filter/flow/testing/CMakeLists.txt
@@ -24,6 +24,7 @@ set(filter_unit_tests
   UnitTestStreamSurfaceFilter.cxx
   )
 set(worklet_unit_tests
+  UnitTestBoundsMap.cxx
   UnitTestWorkletParticleAdvection.cxx
   UnitTestWorkletTemporalAdvection.cxx
   UnitTestStreamSurfaceWorklet.cxx

--- a/viskores/filter/flow/testing/UnitTestBoundsMap.cxx
+++ b/viskores/filter/flow/testing/UnitTestBoundsMap.cxx
@@ -1,0 +1,282 @@
+//============================================================================
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//============================================================================
+
+//============================================================================
+//  Copyright (c) Kitware, Inc.
+//  All rights reserved.
+//  See LICENSE.txt for details.
+//
+//  This software is distributed WITHOUT ANY WARRANTY; without even
+//  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+//  PURPOSE.  See the above copyright notice for more information.
+//============================================================================
+
+#include <viskores/CellShape.h>
+#include <viskores/cont/ArrayCopy.h>
+#include <viskores/cont/ArrayHandleGroupVecVariable.h>
+#include <viskores/cont/ConvertNumComponentsToOffsets.h>
+#include <viskores/cont/DataSetBuilderExplicit.h>
+#include <viskores/cont/ErrorFilterExecution.h>
+#include <viskores/cont/Invoker.h>
+#include <viskores/cont/testing/Testing.h>
+#include <viskores/filter/flow/internal/BoundsMap.h>
+#include <viskores/worklet/WorkletMapField.h>
+
+#include <algorithm>
+
+namespace
+{
+
+struct LocatedCellIds
+{
+  viskores::IdComponent Count = 0;
+  std::vector<viskores::Id> Ids;
+};
+
+viskores::cont::DataSet CreateBoundsBox(const viskores::Bounds& bounds)
+{
+  std::vector<viskores::Vec3f> points = { { static_cast<viskores::FloatDefault>(bounds.X.Min),
+                                            static_cast<viskores::FloatDefault>(bounds.Y.Min),
+                                            static_cast<viskores::FloatDefault>(bounds.Z.Min) },
+                                          { static_cast<viskores::FloatDefault>(bounds.X.Max),
+                                            static_cast<viskores::FloatDefault>(bounds.Y.Min),
+                                            static_cast<viskores::FloatDefault>(bounds.Z.Min) },
+                                          { static_cast<viskores::FloatDefault>(bounds.X.Max),
+                                            static_cast<viskores::FloatDefault>(bounds.Y.Max),
+                                            static_cast<viskores::FloatDefault>(bounds.Z.Min) },
+                                          { static_cast<viskores::FloatDefault>(bounds.X.Min),
+                                            static_cast<viskores::FloatDefault>(bounds.Y.Max),
+                                            static_cast<viskores::FloatDefault>(bounds.Z.Min) },
+                                          { static_cast<viskores::FloatDefault>(bounds.X.Min),
+                                            static_cast<viskores::FloatDefault>(bounds.Y.Min),
+                                            static_cast<viskores::FloatDefault>(bounds.Z.Max) },
+                                          { static_cast<viskores::FloatDefault>(bounds.X.Max),
+                                            static_cast<viskores::FloatDefault>(bounds.Y.Min),
+                                            static_cast<viskores::FloatDefault>(bounds.Z.Max) },
+                                          { static_cast<viskores::FloatDefault>(bounds.X.Max),
+                                            static_cast<viskores::FloatDefault>(bounds.Y.Max),
+                                            static_cast<viskores::FloatDefault>(bounds.Z.Max) },
+                                          { static_cast<viskores::FloatDefault>(bounds.X.Min),
+                                            static_cast<viskores::FloatDefault>(bounds.Y.Max),
+                                            static_cast<viskores::FloatDefault>(bounds.Z.Max) } };
+  std::vector<viskores::UInt8> shapes = { viskores::CELL_SHAPE_HEXAHEDRON };
+  std::vector<viskores::IdComponent> numIndices = { 8 };
+  std::vector<viskores::Id> connectivity = { 0, 1, 2, 3, 4, 5, 6, 7 };
+
+  return viskores::cont::DataSetBuilderExplicit::Create(points, shapes, numIndices, connectivity);
+}
+
+viskores::cont::PartitionedDataSet CreatePartitionedDataSet(
+  const std::vector<viskores::Bounds>& bounds)
+{
+  viskores::cont::PartitionedDataSet pds;
+  for (const auto& blockBounds : bounds)
+    pds.AppendPartition(CreateBoundsBox(blockBounds));
+
+  return pds;
+}
+
+class CountBoundsMapCellsWorklet : public viskores::worklet::WorkletMapField
+{
+public:
+  using ControlSignature = void(FieldIn points, ExecObject locator, FieldOut count);
+  using ExecutionSignature = void(_1, _2, _3);
+
+  template <typename LocatorType>
+  VISKORES_EXEC void operator()(const viskores::Vec3f& point,
+                                const LocatorType& locator,
+                                viskores::Id& count) const
+  {
+    count = locator.CountAllCells(point);
+  }
+};
+
+class FindBoundsMapCellIdsWorklet : public viskores::worklet::WorkletMapField
+{
+public:
+  using ControlSignature = void(FieldIn points, ExecObject locator, FieldOut cellIds);
+  using ExecutionSignature = void(_1, _2, _3);
+
+  template <typename LocatorType, typename CellIdVecType>
+  VISKORES_EXEC void operator()(const viskores::Vec3f& point,
+                                const LocatorType& locator,
+                                CellIdVecType& cellIds) const
+  {
+    locator.FindAllCellIds(point, cellIds);
+  }
+};
+
+std::vector<LocatedCellIds> FindBoundsMapCellIds(
+  const viskores::filter::flow::internal::BoundsMap& boundsMap,
+  const std::vector<viskores::Vec3f>& points)
+{
+  auto pointsAH = viskores::cont::make_ArrayHandle(points, viskores::CopyFlag::On);
+
+  viskores::cont::Invoker invoker;
+  viskores::cont::ArrayHandle<viskores::Id> cellCounts;
+  invoker(CountBoundsMapCellsWorklet{}, pointsAH, boundsMap.GetLocator(), cellCounts);
+
+  viskores::Id totalCells = 0;
+  auto cellCountsPortal = cellCounts.ReadPortal();
+  for (viskores::Id i = 0; i < cellCounts.GetNumberOfValues(); ++i)
+    totalCells += cellCountsPortal.Get(i);
+
+  viskores::cont::ArrayHandle<viskores::Id> allCellIds;
+  allCellIds.AllocateAndFill(totalCells, viskores::Id{ -1 });
+  auto offsets = viskores::cont::ConvertNumComponentsToOffsets(cellCounts);
+  auto allCellIdsVec = viskores::cont::make_ArrayHandleGroupVecVariable(allCellIds, offsets);
+  invoker(FindBoundsMapCellIdsWorklet{}, pointsAH, boundsMap.GetLocator(), allCellIdsVec);
+
+  std::vector<LocatedCellIds> cellIds;
+  cellIds.reserve(points.size());
+  auto cellIdsPortal = allCellIdsVec.ReadPortal();
+  for (viskores::Id i = 0; i < static_cast<viskores::Id>(points.size()); ++i)
+  {
+    LocatedCellIds result;
+    result.Count = static_cast<viskores::IdComponent>(cellCountsPortal.Get(i));
+
+    auto idsForPoint = cellIdsPortal.Get(i);
+    for (viskores::IdComponent j = 0; j < idsForPoint.GetNumberOfComponents(); ++j)
+    {
+      const viskores::Id id = idsForPoint[j];
+      if (id >= 0)
+        result.Ids.emplace_back(id);
+    }
+    std::sort(result.Ids.begin(), result.Ids.end());
+    cellIds.emplace_back(std::move(result));
+  }
+
+  return cellIds;
+}
+
+void ValidateCellIds(const LocatedCellIds& actual,
+                     std::initializer_list<viskores::Id> expected,
+                     const std::string& message)
+{
+  std::vector<viskores::Id> expectedVec(expected);
+  std::sort(expectedVec.begin(), expectedVec.end());
+
+  VISKORES_TEST_ASSERT(actual.Count == static_cast<viskores::IdComponent>(expectedVec.size()),
+                       message + ": CountAllCells returned wrong number of ids");
+  VISKORES_TEST_ASSERT(actual.Ids.size() == expectedVec.size(),
+                       message + ": FindAllCellIds returned wrong number of ids");
+  for (std::size_t i = 0; i < expectedVec.size(); ++i)
+    VISKORES_TEST_ASSERT(actual.Ids[i] == expectedVec[i], message + ": wrong id");
+}
+
+void TestBoundsMapLocatorFindsBlockIds()
+{
+  // BoundsMap should return every block containing a point, including
+  // overlapping blocks and blocks that share a boundary.
+  const std::vector<viskores::Bounds> bounds = { viskores::Bounds(0, 4, 0, 4, 0, 4),
+                                                 viskores::Bounds(4, 8, 0, 4, 0, 4),
+                                                 viskores::Bounds(2, 6, 0, 4, 0, 4) };
+
+  viskores::filter::flow::internal::BoundsMap boundsMap(CreatePartitionedDataSet(bounds));
+  auto cellIds = FindBoundsMapCellIds(boundsMap,
+                                      { viskores::Vec3f(1.0f, 2.0f, 2.0f),
+                                        viskores::Vec3f(3.0f, 2.0f, 2.0f),
+                                        viskores::Vec3f(4.0f, 2.0f, 2.0f),
+                                        viskores::Vec3f(7.0f, 2.0f, 2.0f),
+                                        viskores::Vec3f(9.0f, 2.0f, 2.0f) });
+
+  ValidateCellIds(cellIds[0], { 0 }, "BoundsMap locator failed for first block");
+  ValidateCellIds(cellIds[1], { 0, 2 }, "BoundsMap locator failed for overlapping blocks");
+  ValidateCellIds(cellIds[2], { 0, 1, 2 }, "BoundsMap locator failed on shared boundary");
+  ValidateCellIds(cellIds[3], { 1 }, "BoundsMap locator failed for second block");
+  ValidateCellIds(cellIds[4], {}, "BoundsMap locator failed outside all blocks");
+}
+
+void TestBoundsMapLocatorHandlesDegenerateBounds()
+{
+  // Lower-dimensional block bounds should still produce valid locator cells so
+  // 2D/1D datasets can participate in id-only block lookup. This covers each
+  // degenerate shape branch in BoundsMap::BuildLocator.
+  const std::vector<viskores::Bounds> bounds = {
+    viskores::Bounds(0, 2, 0, 2, 0, 0),   // XY quad
+    viskores::Bounds(4, 6, 0, 0, 0, 2),   // XZ quad
+    viskores::Bounds(8, 8, 0, 2, 0, 2),   // YZ quad
+    viskores::Bounds(12, 14, 0, 0, 0, 0), // X line
+    viskores::Bounds(16, 16, 0, 2, 0, 0), // Y line
+    viskores::Bounds(20, 20, 0, 0, 0, 2), // Z line
+    viskores::Bounds(24, 24, 0, 0, 0, 0)  // vertex
+  };
+
+  viskores::filter::flow::internal::BoundsMap boundsMap(CreatePartitionedDataSet(bounds));
+  VISKORES_TEST_ASSERT(boundsMap.GetLocator().GetCellSet().GetNumberOfCells() ==
+                         static_cast<viskores::Id>(bounds.size()),
+                       "BoundsMap locator has the wrong number of cells.");
+
+  auto cellIds = FindBoundsMapCellIds(boundsMap,
+                                      { viskores::Vec3f(1.0f, 1.0f, 0.0f),
+                                        viskores::Vec3f(5.0f, 0.0f, 1.0f),
+                                        viskores::Vec3f(8.0f, 1.0f, 1.0f),
+                                        viskores::Vec3f(13.0f, 0.0f, 0.0f),
+                                        viskores::Vec3f(16.0f, 1.0f, 0.0f),
+                                        viskores::Vec3f(20.0f, 0.0f, 1.0f) });
+
+  ValidateCellIds(cellIds[0], { 0 }, "BoundsMap locator failed for XY bounds");
+  ValidateCellIds(cellIds[1], { 1 }, "BoundsMap locator failed for XZ bounds");
+  ValidateCellIds(cellIds[2], { 2 }, "BoundsMap locator failed for YZ bounds");
+  ValidateCellIds(cellIds[3], { 3 }, "BoundsMap locator failed for X line bounds");
+  ValidateCellIds(cellIds[4], { 4 }, "BoundsMap locator failed for Y line bounds");
+  ValidateCellIds(cellIds[5], { 5 }, "BoundsMap locator failed for Z line bounds");
+}
+
+void TestBoundsMapBlockIdValidation()
+{
+  // Locator cell ids are used directly as block ids, so sparse block ids would
+  // require an explicit remapping layer and are rejected for this foundation MR.
+  const std::vector<viskores::Bounds> bounds = { viskores::Bounds(0, 4, 0, 4, 0, 4),
+                                                 viskores::Bounds(4, 8, 0, 4, 0, 4) };
+  auto pds = CreatePartitionedDataSet(bounds);
+
+  viskores::filter::flow::internal::BoundsMap denseBoundsMap(pds, { 0, 1 });
+  VISKORES_TEST_ASSERT(denseBoundsMap.GetTotalNumBlocks() == 2, "Dense block ids failed.");
+  const auto& denseRank0 = denseBoundsMap.FindRank(0);
+  VISKORES_TEST_ASSERT(denseRank0.size() == std::size_t{ 1 } && denseRank0[0] == 0,
+                       "Dense block id 0 should be owned by rank 0.");
+  const auto& unknownRank = denseBoundsMap.FindRank(2);
+  VISKORES_TEST_ASSERT(unknownRank.empty(), "Unknown block id should have no rank.");
+
+  // Reordered dense ids should preserve the global block id returned by
+  // FindAllCellIds rather than exposing local partition order.
+  viskores::filter::flow::internal::BoundsMap reorderedBoundsMap(pds, { 1, 0 });
+  auto reorderedCellIds = FindBoundsMapCellIds(
+    reorderedBoundsMap, { viskores::Vec3f(2.0f, 2.0f, 2.0f), viskores::Vec3f(6.0f, 2.0f, 2.0f) });
+  ValidateCellIds(reorderedCellIds[0], { 1 }, "Reordered block ids failed for first partition");
+  ValidateCellIds(reorderedCellIds[1], { 0 }, "Reordered block ids failed for second partition");
+  const auto& reorderedRank1 = reorderedBoundsMap.FindRank(1);
+  VISKORES_TEST_ASSERT(reorderedRank1.size() == std::size_t{ 1 } && reorderedRank1[0] == 0,
+                       "Reordered block id should map to rank 0.");
+
+  bool threw = false;
+  try
+  {
+    viskores::filter::flow::internal::BoundsMap sparseBoundsMap(pds, { 0, 2 });
+  }
+  catch (const viskores::cont::ErrorFilterExecution&)
+  {
+    threw = true;
+  }
+  VISKORES_TEST_ASSERT(threw, "Sparse block ids should throw.");
+}
+
+void TestBoundsMap()
+{
+  TestBoundsMapLocatorFindsBlockIds();
+  TestBoundsMapLocatorHandlesDegenerateBounds();
+  TestBoundsMapBlockIdValidation();
+}
+
+} // namespace
+
+int UnitTestBoundsMap(int argc, char* argv[])
+{
+  return viskores::cont::testing::Testing::Run(TestBoundsMap, argc, argv);
+}


### PR DESCRIPTION
Adds a CellLocatorUniformBins-based block-bounds locator to BoundsMap for flow filters.

Updated the tests as well.
#258 was getting too large, so I'm splitting this into multiple MRs.