### PR TITLE
ci: add VTK contract test jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -150,6 +150,7 @@
 stages:
   - build
   - test
+  - contract
 
 .use_minimum_supported_cmake:
   variables:
@@ -277,3 +278,5 @@ include:
   - local: '/.gitlab/ci/ubuntu2004.yml'
   - local: '/.gitlab/ci/ubuntu2204.yml'
   - local: '/.gitlab/ci/ubuntu2404.yml'
+  - local: '/.gitlab/ci/vtk-contract.yml'
+

--- a/.gitlab/ci/config/vtk_contract.sh
+++ b/.gitlab/ci/config/vtk_contract.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+##============================================================================
+##  The contents of this file are covered by the Viskores license. See
+##  LICENSE.txt for details.
+##
+##  By contributing to this file, all contributors agree to the Developer
+##  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+##============================================================================
+
+set -xe
+
+# Viskores is pre-built by an upstream job and passed as an artifact tarball.
+readonly viskores_install_dir="${CI_PROJECT_DIR}/viskores-install"
+tar xf "${CI_PROJECT_DIR}/viskores-install.tar.gz" -C "${CI_PROJECT_DIR}"
+
+readonly vtk_version="v9.6.2"
+readonly vtk_fix_commit="d8c01e95d1524fdb0faf49bd451907d8882de098"
+readonly vtk_repo="https://gitlab.kitware.com/vtk/vtk.git"
+readonly vtk_source_dir="$HOME/vtk-source"
+readonly vtk_build_dir="$HOME/vtk-build"
+readonly vtk_install_dir="$HOME/vtk-install"
+
+# Clone VTK at the pinned tag then cherry-pick the upstream fix for
+# Viskores device source marking (PR #161 compat). Drop the cherry-pick
+# once a VTK release containing vtk_add_viskores_device_target_information()
+# is used.
+git clone --branch "$vtk_version" "$vtk_repo" "$vtk_source_dir"
+git -C "$vtk_source_dir" fetch origin "$vtk_fix_commit"
+git -C "$vtk_source_dir" config user.email "viskores-ci@viskores.org"
+git -C "$vtk_source_dir" config user.name "Viskores CI"
+git -C "$vtk_source_dir" cherry-pick -Xtheirs -m1 "$vtk_fix_commit"
+
+# Configure VTK with minimal build options and Viskores
+cmake -GNinja \
+  -S "$vtk_source_dir" \
+  -B "$vtk_build_dir" \
+  -DBUILD_SHARED_LIBS=ON \
+  -DVTK_BUILD_TESTING=OFF \
+  -DVTK_BUILD_EXAMPLES=OFF \
+  -DVTK_ENABLE_WRAPPING=OFF \
+  -DVTK_ENABLE_REMOTE_MODULES=OFF \
+  -DVTK_ENABLE_VISKORES_OVERRIDES=ON \
+  -DVTK_GROUP_ENABLE_StandAlone=WANT \
+  -DVTK_GROUP_ENABLE_Rendering=DONT_WANT \
+  -DVTK_GROUP_ENABLE_Imaging=DONT_WANT \
+  -DVTK_GROUP_ENABLE_MPI=NO \
+  -DVTK_GROUP_ENABLE_Qt=NO \
+  -DVTK_GROUP_ENABLE_Tk=NO \
+  -DVTK_GROUP_ENABLE_Web=NO \
+  -DVTK_MODULE_USE_EXTERNAL_VTK_vtkviskores=ON \
+  -DVTK_MODULE_ENABLE_VTK_AcceleratorsVTKmFilters:STRING=YES \
+  -DViskores_ROOT="$viskores_install_dir" \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+  -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+  -DCMAKE_INSTALL_PREFIX="$vtk_install_dir" \
+  ${CMAKE_ARGS:-}
+
+# Build VTK
+cmake --build "$vtk_build_dir" --parallel
+
+# Install VTK (optional, but good for verification)
+cmake --install "$vtk_build_dir"
+
+echo "VTK contract test build completed successfully"

--- a/.gitlab/ci/ubuntu2404.yml
+++ b/.gitlab/ci/ubuntu2404.yml
@@ -42,11 +42,20 @@ ubuntu2404_gcc14:
   variables:
     CC: "gcc-14"
     CXX: "g++-14"
-    VISKORES_SETTINGS: "ccache+openmp+shared+examples"
+    VISKORES_SETTINGS: "ccache+openmp+shared+examples+vtk_types"
     # Restrict OpenMP number of threads since multiple test stages
     # execute on the same hardware concurrently
     OMP_NUM_THREADS: 3
     CTEST_EXCLUSIONS: "UnitTestArrayPortalValueReference"
+  after_script:
+    - export PATH="${PWD}/.gitlab/ccache:${PATH}"
+    - ccache -s
+    - cmake --install /tmp/build --prefix "${CI_PROJECT_DIR}/viskores-install"
+    - tar czf viskores-install.tar.gz viskores-install/
+  artifacts:
+    expire_in: 24 hours
+    paths:
+      - viskores-install.tar.gz
 
 ubuntu2404_gcc14_cuda130:
   extends:
@@ -58,5 +67,14 @@ ubuntu2404_gcc14_cuda130:
     CC: "gcc-14"
     CXX: "g++-14"
     CUDAHOSTCXX: "g++-14"
-    VISKORES_SETTINGS: "no_testing+cuda+turing+tbb+examples+shared+ccache"
+    VISKORES_SETTINGS: "no_testing+cuda+turing+tbb+examples+shared+ccache+vtk_types"
     NO_TESTING: "ON"
+  after_script:
+    - export PATH="${PWD}/.gitlab/ccache:${PATH}"
+    - ccache -s
+    - cmake --install /tmp/build --prefix "${CI_PROJECT_DIR}/viskores-install"
+    - tar czf viskores-install.tar.gz viskores-install/
+  artifacts:
+    expire_in: 24 hours
+    paths:
+      - viskores-install.tar.gz

--- a/.gitlab/ci/vtk-contract.yml
+++ b/.gitlab/ci/vtk-contract.yml
@@ -1,0 +1,60 @@
+##============================================================================
+##  The contents of this file are covered by the Viskores license. See
+##  LICENSE.txt for details.
+##
+##  By contributing to this file, all contributors agree to the Developer
+##  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+##============================================================================
+
+.vtk_contract_base:
+  stage: contract
+  timeout: 2 hours
+  interruptible: true
+  variables:
+    CCACHE_BASEDIR:       "$CI_PROJECT_DIR"
+    CCACHE_COMPILERCHECK: "content"
+    CCACHE_IGNOREOPTIONS: "-isystem=*"
+    CCACHE_NOHASHDIR:     "true"
+  before_script:
+    - .gitlab/ci/config/cmake.sh
+    - export PATH=$PWD/.gitlab/cmake/bin:$PATH
+    - cmake --version
+    - "cmake -VV -P .gitlab/ci/config/ninja.cmake"
+    - export PATH="${PWD}/.gitlab:${PATH}"
+    - "CCACHE_INSTALL_DIR=${PWD}/.gitlab cmake -V -P .gitlab/ci/config/ccache.cmake"
+    - export PATH="${PWD}/.gitlab/ccache:${PATH}"
+    - ccache -z
+  script:
+    - .gitlab/ci/config/vtk_contract.sh
+  after_script:
+    - export PATH="${PWD}/.gitlab/ccache:${PATH}"
+    - ccache -v -s
+    - ccache -z
+  allow_failure: false
+
+# Build VTK against a CPU-only Viskores installation
+vtk_serial:
+  extends:
+    - .vtk_contract_base
+    - .ubuntu2204
+    - .run_automatically
+    - .uo_cpu_tags
+  variables:
+    CCACHE_RESHARE: "true"
+  needs:
+    - job: ubuntu2404_gcc14
+      artifacts: true
+
+# Build VTK against a CUDA-enabled Viskores installation
+vtk_cuda:
+  extends:
+    - .vtk_contract_base
+    - .ubuntu2404_cuda130
+    - .run_automatically
+    - .uo_cpu_tags
+  variables:
+    CCACHE_RESHARE: "true"
+    CMAKE_ARGS: "-DVTK_USE_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=75"
+  needs:
+    - job: ubuntu2404_gcc14_cuda130
+      artifacts: true


### PR DESCRIPTION
Fixes #190

Add a `contract` stage with two jobs that build VTK 9.6.2 against a pre-built Viskores install to verify `AcceleratorsVTKmFilters` compiles on every PR and main commit.

- `vtk_serial`: uses the `ubuntu2404_gcc14` artifact (CPU-only).
- `vtk_cuda`: uses the `ubuntu2404_gcc14_cuda130` artifact (CUDA 13.0, sm_75).

Both build jobs gain an `after_script` that installs Viskores and packages it as `viskores-install.tar.gz`, with `vtk_types` added to `VISKORES_SETTINGS` for VTK type compatibility.

VTK 9.6.2 needs a cherry-pick of `d8c01e95d15` to be compatible with the device-source guard introduced in Viskores PR #161.