### PR TITLE
ci: improve ccache configuration

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,13 +20,15 @@
 
 .docker_image: &docker_image
   variables:
-    CCACHE_BASEDIR: "/tmp"
+    CCACHE_BASEDIR: "$CI_PROJECT_DIR"
     CCACHE_COMPILERCHECK: "content"
-    CCACHE_DIR: "/tmp/.ccache"
-    CCACHE_HASHDIR: "true"
-    CCACHE_NAMESPACE: "${CI_PROJECT_PATH}/${CI_JOB_NAME}"
-    CCACHE_SLOPPINESS: "include_file_mtime,time_macros"
-    CCACHE_MAXSIZE: "250MiB"
+    CCACHE_DIR: "$CI_PROJECT_DIR/.ccache"
+    CCACHE_LOGFILE: "$CI_PROJECT_DIR/ccache.log"
+    CCACHE_MAXSIZE: "500MiB"
+    CCACHE_NAMESPACE: "${CI_PROJECT_PATH}"
+    CCACHE_NOHASHDIR: "true"
+    CCACHE_RESHARE: "true"
+    CCACHE_SLOPPINESS: "include_file_mtime,time_macros,pch_defines"
     CTEST_TIMEOUT: 1200
     GIT_SUBMODULE_STRATEGY: recursive
   image:
@@ -169,15 +171,8 @@ stages:
   stage: build
   timeout:  2 hours
   interruptible: true
-  rules:
-    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
-      variables:
-        GITLAB_CACHE_POLICY: pull-push
-        CCACHE_RESHARE: "true"
-    - if: $CI_COMMIT_BRANCH != $CI_DEFAULT_BRANCH
-      variables:
-        GITLAB_CACHE_POLICY: pull
-        CCACHE_RESHARE: "false"
+  variables:
+    GITLAB_CACHE_POLICY: pull-push
   cache:
     key: "$CI_JOB_NAME-$CI_COMMIT_REF_SLUG"
     policy: $GITLAB_CACHE_POLICY
@@ -188,11 +183,11 @@ stages:
   before_script:
     - *install_cmake
     - "cmake -VV -P .gitlab/ci/config/ninja.cmake"
-    - export PATH="${PWD}/.gitlab:${PATH}"
-    - export CTEST_BINARY_DIRECTORY=/tmp/build
+    - export PATH="${CI_PROJECT_DIR}/.gitlab:${PATH}"
+    - export CTEST_BINARY_DIRECTORY=$CI_PROJECT_DIR/build
     - "cmake -VV -P .gitlab/ci/config/gitlab-bridge-set-vars.cmake"
-    - "CCACHE_INSTALL_DIR=${PWD}/.gitlab cmake -V -P .gitlab/ci/config/ccache.cmake"
-    - export PATH="${PWD}/.gitlab/ccache:${PATH}"
+    - "CCACHE_INSTALL_DIR=${CI_PROJECT_DIR}/.gitlab cmake -V -P .gitlab/ci/config/ccache.cmake"
+    - export PATH="${CI_PROJECT_DIR}/.gitlab/ccache:${PATH}"
     - ccache -z
     - ccache -p
     - ccache -s
@@ -207,8 +202,13 @@ stages:
     - "[ -z $NO_TESTING ] && ctest $CTEST_TIMEOUT -VV -S .gitlab/ci/ctest_test.cmake"
     - cmake -P .gitlab/ci/check_warnings.cmake || exit 47
   after_script:
-    - export PATH="${PWD}/.gitlab/ccache:${PATH}"
+    - export PATH="${CI_PROJECT_DIR}/.gitlab/ccache:${PATH}"
     - ccache -s
+  artifacts:
+    expire_in: 24 hours
+    when: always
+    paths:
+      - ccache.log
   extends:
     - .warning_policy
 

--- a/.gitlab/ci/config/ccache.cmake
+++ b/.gitlab/ci/config/ccache.cmake
@@ -18,37 +18,27 @@
 
 cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 
-set(version 4.6.1)
-set(arch x86_64)
+set(version 4.13.6)
+set(base_url https://github.com/ccache/ccache/releases/download)
 
 if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux")
-  set(sha256sum da1e1781bc1c4b019216fa16391af3e1daaee7e7f49a8ec9b0cdc8a1d05c50e2)
-  set(base_url https://github.com/ccache/ccache/releases/download)
-  set(platform linux)
+  set(sha256sum 508b2a1217dc6e04a23e967c7b95a0fb45d8a7e16fde9e180919698f2e2be060)
+  set(filename "ccache-${version}-linux-x86_64-glibc")
   set(extension tar.xz)
 elseif(CMAKE_HOST_SYSTEM_NAME STREQUAL "Darwin")
-  set(sha256sum 3e36ba8c80fbf7f2b95fe0227b9dd1ca6143d721aab052caf0d5729769138059)
-  set(full_url https://gitlab.kitware.com/utils/ci-utilities/-/package_files/534/download)
-  set(filename ccache)
+  set(sha256sum 0274210ec9c9936ed5711d59b0de3167a51216a588ddde35f6bc828f366fe6d9)
+  set(filename "ccache-${version}-darwin")
   set(extension tar.gz)
 elseif(CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
-  set(sha256sum a6c6311973aa3d2aae22424895f2f968e5d661be003b25f1bd854a5c0cd57563)
-  set(base_url https://github.com/ccache/ccache/releases/download)
-  set(platform windows)
+  set(sha256sum 3d7cebb05850ad704e197b3f1d3f0f924ab6c9fdfc561578e146184fe9d89380)
+  set(filename "ccache-${version}-windows-x86_64")
   set(extension zip)
 else()
   message(FATAL_ERROR "Unrecognized platform ${CMAKE_HOST_SYSTEM_NAME}")
 endif()
 
-if(NOT DEFINED filename)
-  set(filename "ccache-${version}-${platform}-${arch}")
-endif()
-
 set(tarball "${filename}.${extension}")
-
-if(NOT DEFINED full_url)
-  set(full_url "${base_url}/v${version}/${tarball}")
-endif()
+set(full_url "${base_url}/v${version}/${tarball}")
 
 file(DOWNLOAD
   "${full_url}" $ENV{CCACHE_INSTALL_DIR}/${tarball}
@@ -57,7 +47,7 @@ file(DOWNLOAD
   )
 
 execute_process(
-  COMMAND ${CMAKE_COMMAND} -E tar xf ${tarball}
+  COMMAND ${CMAKE_COMMAND} -E tar xf ${tarball} ${filename}/ccache
   WORKING_DIRECTORY $ENV{CCACHE_INSTALL_DIR}
   RESULT_VARIABLE extract_results
   )
@@ -66,4 +56,5 @@ if(extract_results)
   message(FATAL_ERROR "Extracting `${tarball}` failed: ${extract_results}.")
 endif()
 
-file(RENAME $ENV{CCACHE_INSTALL_DIR}/${filename} $ENV{CCACHE_INSTALL_DIR}/ccache)
+file(MAKE_DIRECTORY $ENV{CCACHE_INSTALL_DIR}/ccache)
+file(RENAME $ENV{CCACHE_INSTALL_DIR}/${filename}/ccache $ENV{CCACHE_INSTALL_DIR}/ccache/ccache)

--- a/.gitlab/ci/ubuntu2204.yml
+++ b/.gitlab/ci/ubuntu2204.yml
@@ -20,7 +20,6 @@
 
 .kokkos_rocm_vars: &kokkos_rocm_vars
   variables:
-    CCACHE_BASEDIR:          "$CI_PROJECT_DIR"
     CCACHE_COMPILERCHECK:    "content"
     # -isystem= is not affected by CCACHE_BASEDIR, thus we must ignore it
     CCACHE_IGNOREOPTIONS:    "-isystem=*"
@@ -51,6 +50,7 @@ ubuntu2204_hip_kokkos37:
     VISKORES_SETTINGS:       "benchmarks+kokkos+hip+no_rendering+ccache"
     NO_TESTING:              "ON"
   after_script:
+    - export PATH="${CI_PROJECT_DIR}/.gitlab/ccache:${PATH}"
     - ccache -v -s
     - ccache -z
 
@@ -72,6 +72,7 @@ ubuntu2204_hip_kokkos43:
     VISKORES_SETTINGS:       "benchmarks+kokkos+hip+no_rendering+no_testing+ccache"
     NO_TESTING:              "ON"
   after_script:
+    - export PATH="${CI_PROJECT_DIR}/.gitlab/ccache:${PATH}"
     - ccache -v -s
     - ccache -z
 


### PR DESCRIPTION
Fix three issues reducing cache hit rates across all build jobs.

**CCACHE_HASHDIR vs CCACHE_BASEDIR conflict:** `CCACHE_BASEDIR` normalizes
build paths so cache entries are portable across runs, but `CCACHE_HASHDIR=true`
puts the raw directory back into the hash, undoing the normalization.
Replaced with `CCACHE_NOHASHDIR=true`.

**Per-job namespace:** `CCACHE_NAMESPACE` was scoped to the job name, preventing
jobs that share the same compiler from reusing each other's object entries.
Scoped to the project instead and let ccache's content-based hashing
(`CCACHE_COMPILERCHECK=content`) differentiate entries between compilers.

**PR cache write-back:** PR branches used `policy: pull` (read-only), so
retries and dependent jobs always started cold. Changed to `pull-push` so
repeated runs on the same runner benefit from a warm local cache.

Also adds `pch_defines` to `CCACHE_SLOPPINESS` and bumps ccache from
4.6.1 to 4.13.6.