### PR TITLE
Workletize flow seed block routing

### DIFF
--- a/docs/changelog/flow-workletize-seed-routing.md
+++ b/docs/changelog/flow-workletize-seed-routing.md
@@ -1,0 +1,8 @@
+## Route flow seeds with BoundsMap locator worklets
+
+Flow particle seeds are now mapped to candidate blocks with the BoundsMap
+cell-id locator from worklets. Candidate ordering, first-block selection, rank
+ownership filtering, and compaction remain in ArrayHandles until the existing
+host queue handoff. Locator results are checked against the original Float64
+block bounds on the device so coordinate narrowing cannot change seed
+ownership.

--- a/viskores/exec/CellLocatorUniformBins.h
+++ b/viskores/exec/CellLocatorUniformBins.h
@@ -432,7 +432,12 @@ private:
     {
       VISKORES_RETURN_ON_ERROR(viskores::exec::WorldCoordinatesToParametricCoordinates(
         cellPoints, point, cellShape, pCoords));
-      inside = viskores::exec::CellInside(pCoords, cellShape);
+      // A vertex has no interior, so CellInside always returns false for it. The
+      // world-space bounds check above is the containment test for a vertex cell.
+      if (cellShape.Id == viskores::CELL_SHAPE_VERTEX)
+        inside = true;
+      else
+        inside = viskores::exec::CellInside(pCoords, cellShape);
     }
     else
     {

--- a/viskores/filter/flow/internal/AdvectAlgorithm.h
+++ b/viskores/filter/flow/internal/AdvectAlgorithm.h
@@ -23,12 +23,18 @@
 #include <viskores/cont/PartitionedDataSet.h>
 #include <viskores/filter/flow/internal/BoundsMap.h>
 #include <viskores/filter/flow/internal/DataSetIntegrator.h>
+#include <viskores/filter/flow/internal/ParticleBlockIds.h>
 #ifdef VISKORES_ENABLE_MPI
 #include <viskores/filter/flow/internal/AdvectAlgorithmTerminator.h>
 #include <viskores/filter/flow/internal/ParticleExchanger.h>
 #include <viskores/thirdparty/diy/diy.h>
 #include <viskores/thirdparty/diy/mpi-cast.h>
 #endif
+
+#include <cstdlib>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 namespace viskores
 {
@@ -85,26 +91,33 @@ public:
   {
     this->ClearParticles();
 
-    viskores::Id n = seeds.GetNumberOfValues();
-    auto portal = seeds.ReadPortal();
+    // Route the seeds to blocks before creating the host-side work queues:
+    // 1. Locate, validate, and order the candidate blocks for each seed.
+    // 2. Select the primary block and rank responsible for each seed.
+    // 3. Keep seeds owned by this rank and compact the results into ArrayHandles.
+    auto routedSeeds =
+      viskores::filter::flow::internal::RouteSeedsToBlocks(seeds, this->BoundsMap, this->Rank);
+    const viskores::Id numSeeds = routedSeeds.Particles.GetNumberOfValues();
+    auto seedPortal = routedSeeds.Particles.ReadPortal();
+    auto candidateBlockIdsPortal = routedSeeds.CandidateBlockIds.ReadPortal();
 
+    // Convert the compacted routing results to the existing host-side queue representation.
     std::vector<std::vector<viskores::Id>> blockIDs;
     std::vector<ParticleType> particles;
-    for (viskores::Id i = 0; i < n; i++)
+    blockIDs.reserve(static_cast<std::size_t>(numSeeds));
+    particles.reserve(static_cast<std::size_t>(numSeeds));
+    for (viskores::Id i = 0; i < numSeeds; ++i)
     {
-      const ParticleType p = portal.Get(i);
-      std::vector<viskores::Id> ids = this->BoundsMap.FindBlocks(p.GetPosition());
+      auto candidateBlockIds = candidateBlockIdsPortal.Get(i);
+      VISKORES_ASSERT(candidateBlockIds.GetNumberOfComponents() > 0);
 
-      //Note: For duplicate blocks, this will give the seeds to the rank that are first in the list.
-      if (!ids.empty())
-      {
-        const auto& ranks = this->BoundsMap.FindRank(ids[0]);
-        if (!ranks.empty() && this->Rank == ranks[0])
-        {
-          particles.emplace_back(p);
-          blockIDs.emplace_back(ids);
-        }
-      }
+      std::vector<viskores::Id> ids;
+      ids.reserve(static_cast<std::size_t>(candidateBlockIds.GetNumberOfComponents()));
+      for (viskores::IdComponent j = 0; j < candidateBlockIds.GetNumberOfComponents(); ++j)
+        ids.emplace_back(candidateBlockIds[j]);
+
+      particles.emplace_back(seedPortal.Get(i));
+      blockIDs.emplace_back(std::move(ids));
     }
     this->SetSeedArray(particles, blockIDs);
   }

--- a/viskores/filter/flow/internal/CMakeLists.txt
+++ b/viskores/filter/flow/internal/CMakeLists.txt
@@ -28,6 +28,7 @@ set(headers
   FilterParticleAdvectionUnsteadyStateImpl.h
   GridMetaData.h
   LagrangianStructureHelpers.h
+  ParticleBlockIds.h
   ParticleAdvector.h
   ParticleExchanger.h
   )

--- a/viskores/filter/flow/internal/ParticleBlockIds.h
+++ b/viskores/filter/flow/internal/ParticleBlockIds.h
@@ -1,0 +1,341 @@
+//============================================================================
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//============================================================================
+
+#ifndef viskores_filter_flow_internal_ParticleBlockIds_h
+#define viskores_filter_flow_internal_ParticleBlockIds_h
+
+#include <viskores/cont/Algorithm.h>
+#include <viskores/cont/ArrayHandle.h>
+#include <viskores/cont/ArrayHandleGroupVecVariable.h>
+#include <viskores/cont/ArrayHandleIndex.h>
+#include <viskores/cont/ArrayHandlePermutation.h>
+#include <viskores/cont/ConvertNumComponentsToOffsets.h>
+#include <viskores/cont/Invoker.h>
+#include <viskores/filter/flow/internal/BoundsMap.h>
+#include <viskores/worklet/WorkletMapField.h>
+
+#include <utility>
+#include <vector>
+
+namespace viskores
+{
+namespace filter
+{
+namespace flow
+{
+namespace internal
+{
+
+using BlockIdArrayHandle = viskores::cont::ArrayHandle<viskores::Id>;
+
+// Variable-length candidate block IDs for seeds. Each value is the group of block IDs
+// associated with one seed, backed by flat block ID storage and an offsets array.
+using CandidateBlockIdArrayHandle =
+  viskores::cont::ArrayHandleGroupVecVariable<BlockIdArrayHandle, BlockIdArrayHandle>;
+
+// A view of the candidate groups selected for this rank. The permutation keeps the
+// selected groups in seed order without copying their variable-length block ID storage.
+using SelectedCandidateBlockIdArrayHandle =
+  viskores::cont::ArrayHandlePermutation<BlockIdArrayHandle, CandidateBlockIdArrayHandle>;
+
+// Routing data for the seeds retained by this rank. The arrays are index-aligned,
+// and each particle's nonempty candidate group starts with its primary block ID.
+template <typename ParticleType>
+struct SeedBlockRoutingResult
+{
+  viskores::cont::ArrayHandle<ParticleType> Particles;
+  SelectedCandidateBlockIdArrayHandle CandidateBlockIds;
+};
+
+namespace detail
+{
+
+class CountParticleBlockIdsWorklet : public viskores::worklet::WorkletMapField
+{
+public:
+  using ControlSignature = void(FieldIn particles, ExecObject locator, FieldOut count);
+  using ExecutionSignature = void(_1, _2, _3);
+
+  template <typename ParticleType, typename LocatorType>
+  VISKORES_EXEC void operator()(const ParticleType& particle,
+                                const LocatorType& locator,
+                                viskores::IdComponent& count) const
+  {
+    count = locator.CountAllCells(particle.GetPosition());
+  }
+};
+
+class FindParticleBlockIdsWorklet : public viskores::worklet::WorkletMapField
+{
+public:
+  using ControlSignature = void(FieldIn particles, ExecObject locator, FieldOut blockIds);
+  using ExecutionSignature = void(_1, _2, _3);
+
+  template <typename ParticleType, typename LocatorType, typename BlockIdVecType>
+  VISKORES_EXEC void operator()(const ParticleType& particle,
+                                const LocatorType& locator,
+                                BlockIdVecType& blockIds) const
+  {
+    locator.FindAllCellIds(particle.GetPosition(), blockIds);
+  }
+};
+
+// Counts the blocks whose bounding boxes contain each particle. Because block
+// bounding boxes can overlap, a particle can be a candidate for multiple blocks.
+class CountExactParticleBlockIdsWorklet : public viskores::worklet::WorkletMapField
+{
+public:
+  using ControlSignature = void(FieldIn particle,
+                                FieldIn candidateBlockIds,
+                                WholeArrayIn blockBounds,
+                                FieldOut count);
+  using ExecutionSignature = void(_1, _2, _3, _4);
+  using InputDomain = _1;
+
+  template <typename ParticleType, typename CandidateBlockIdsType, typename BlockBoundsPortalType>
+  VISKORES_EXEC void operator()(const ParticleType& particle,
+                                const CandidateBlockIdsType& candidateBlockIds,
+                                const BlockBoundsPortalType& blockBounds,
+                                viskores::IdComponent& count) const
+  {
+    count = 0;
+    const auto position = particle.GetPosition();
+    const viskores::IdComponent numCandidates = candidateBlockIds.GetNumberOfComponents();
+    for (viskores::IdComponent i = 0; i < numCandidates; ++i)
+    {
+      const viskores::Id blockId = candidateBlockIds[i];
+      if (blockBounds.Get(blockId).Contains(position))
+        ++count;
+    }
+  }
+};
+
+// Writes the candidate block IDs that pass the original block-bounds check.
+class FindExactParticleBlockIdsWorklet : public viskores::worklet::WorkletMapField
+{
+public:
+  using ControlSignature = void(FieldIn particle,
+                                FieldIn candidateBlockIds,
+                                WholeArrayIn blockBounds,
+                                FieldInOut blockIds);
+  using ExecutionSignature = void(_1, _2, _3, _4);
+  using InputDomain = _1;
+
+  template <typename ParticleType,
+            typename CandidateBlockIdsType,
+            typename BlockBoundsPortalType,
+            typename BlockIdsType>
+  VISKORES_EXEC void operator()(const ParticleType& particle,
+                                const CandidateBlockIdsType& candidateBlockIds,
+                                const BlockBoundsPortalType& blockBounds,
+                                BlockIdsType& blockIds) const
+  {
+    const auto position = particle.GetPosition();
+    const viskores::IdComponent numCandidates = candidateBlockIds.GetNumberOfComponents();
+    viskores::IdComponent outputIndex = 0;
+    for (viskores::IdComponent i = 0; i < numCandidates; ++i)
+    {
+      const viskores::Id blockId = candidateBlockIds[i];
+      if (blockBounds.Get(blockId).Contains(position))
+        blockIds[outputIndex++] = blockId;
+    }
+    VISKORES_ASSERT(outputIndex == blockIds.GetNumberOfComponents());
+  }
+};
+
+// Sorts each particle's candidate block IDs into ascending order.
+class SortParticleBlockIdsWorklet : public viskores::worklet::WorkletMapField
+{
+public:
+  using ControlSignature = void(FieldInOut blockIds);
+  using ExecutionSignature = void(_1);
+  using InputDomain = _1;
+
+  template <typename BlockIdVecType>
+  VISKORES_EXEC void operator()(BlockIdVecType& blockIds) const
+  {
+    const viskores::IdComponent numIds = blockIds.GetNumberOfComponents();
+    // Sort each particle's candidate block IDs in place with an insertion sort.
+    // Candidate lists are expected to be short. If large lists become common,
+    // consider a segmented sort, such as sorting composite (particle, block) keys.
+    for (viskores::IdComponent i = 1; i < numIds; ++i)
+    {
+      const viskores::Id value = blockIds[i];
+      viskores::IdComponent j = i;
+      while (j > 0 && blockIds[j - 1] > value)
+      {
+        blockIds[j] = blockIds[j - 1];
+        --j;
+      }
+      blockIds[j] = value;
+    }
+  }
+};
+
+// Marks seeds whose first candidate block is owned by the current rank.
+class KeepSeedOnRankWorklet : public viskores::worklet::WorkletMapField
+{
+public:
+  VISKORES_CONT KeepSeedOnRankWorklet(viskores::Id rank)
+    : Rank(rank)
+  {
+  }
+
+  using ControlSignature = void(FieldIn candidateBlockIds,
+                                WholeArrayIn blockPrimaryRanks,
+                                FieldOut keep);
+  using ExecutionSignature = void(_1, _2, _3);
+  using InputDomain = _1;
+
+  template <typename CandidateBlockIdsType, typename PrimaryRankPortalType>
+  VISKORES_EXEC void operator()(const CandidateBlockIdsType& candidateBlockIds,
+                                const PrimaryRankPortalType& blockPrimaryRanks,
+                                bool& keep) const
+  {
+    keep = false;
+    if (candidateBlockIds.GetNumberOfComponents() == 0)
+      return;
+
+    const viskores::Id blockId = candidateBlockIds[0];
+    keep = blockPrimaryRanks.Get(blockId) == this->Rank;
+  }
+
+private:
+  viskores::Id Rank;
+};
+
+} // namespace detail
+
+template <typename ParticleType, typename StorageType>
+VISKORES_CONT CandidateBlockIdArrayHandle
+FindParticleBlockIds(const viskores::cont::ArrayHandle<ParticleType, StorageType>& particles,
+                     const viskores::filter::flow::internal::BoundsMap& boundsMap)
+{
+  // An empty bounds map cannot contain any particles. Return one empty block-ID group per particle.
+  if (boundsMap.GetTotalNumBlocks() == 0)
+  {
+    BlockIdArrayHandle offsets;
+    offsets.AllocateAndFill(particles.GetNumberOfValues() + 1, viskores::Id{ 0 });
+    return viskores::cont::make_ArrayHandleGroupVecVariable(BlockIdArrayHandle{}, offsets);
+  }
+
+  // A particle can be inside multiple overlapping blocks. Count first so the
+  // variable-length block id groups can be allocated exactly, then fill them.
+  viskores::cont::Invoker invoker;
+  viskores::cont::ArrayHandle<viskores::IdComponent> blockCounts;
+  invoker(detail::CountParticleBlockIdsWorklet{}, particles, boundsMap.GetLocator(), blockCounts);
+
+  viskores::Id totalCandidateIds = 0;
+  auto candidateOffsets =
+    viskores::cont::ConvertNumComponentsToOffsets(blockCounts, totalCandidateIds);
+
+  BlockIdArrayHandle candidateIds;
+  candidateIds.Allocate(totalCandidateIds);
+  auto groupedCandidateIds =
+    viskores::cont::make_ArrayHandleGroupVecVariable(candidateIds, candidateOffsets);
+
+  if (totalCandidateIds > 0)
+    invoker(detail::FindParticleBlockIdsWorklet{},
+            particles,
+            boundsMap.GetLocator(),
+            groupedCandidateIds);
+
+  if (totalCandidateIds == 0)
+    return groupedCandidateIds;
+
+  // CellLocatorUniformBins uses FloatDefault coordinates during execution.
+  // Treat it as a broad phase, then check its candidates against the original
+  // Float64 BoundsMap values so narrowing cannot change seed ownership.
+  const viskores::Id numBlocks = boundsMap.GetTotalNumBlocks();
+  std::vector<viskores::Bounds> blockBounds;
+  blockBounds.reserve(static_cast<std::size_t>(numBlocks));
+  for (viskores::Id blockId = 0; blockId < numBlocks; ++blockId)
+  {
+    blockBounds.emplace_back(boundsMap.GetBlockBounds(blockId));
+  }
+  auto blockBoundsAH = viskores::cont::make_ArrayHandleMove(std::move(blockBounds));
+
+  viskores::cont::ArrayHandle<viskores::IdComponent> exactBlockCounts;
+  invoker(detail::CountExactParticleBlockIdsWorklet{},
+          particles,
+          groupedCandidateIds,
+          blockBoundsAH,
+          exactBlockCounts);
+
+  viskores::Id totalBlockIds = 0;
+  auto exactOffsets =
+    viskores::cont::ConvertNumComponentsToOffsets(exactBlockCounts, totalBlockIds);
+  BlockIdArrayHandle blockIds;
+  blockIds.Allocate(totalBlockIds);
+  auto groupedBlockIds = viskores::cont::make_ArrayHandleGroupVecVariable(blockIds, exactOffsets);
+
+  if (totalBlockIds > 0)
+  {
+    invoker(detail::FindExactParticleBlockIdsWorklet{},
+            particles,
+            groupedCandidateIds,
+            blockBoundsAH,
+            groupedBlockIds);
+    invoker(detail::SortParticleBlockIdsWorklet{}, groupedBlockIds);
+  }
+  return groupedBlockIds;
+}
+
+template <typename ParticleType, typename StorageType>
+VISKORES_CONT SeedBlockRoutingResult<ParticleType> RouteSeedsToBlocks(
+  const viskores::cont::ArrayHandle<ParticleType, StorageType>& particles,
+  const viskores::filter::flow::internal::BoundsMap& boundsMap,
+  viskores::Id rank)
+{
+  // Find every block whose bounds contain each seed. The candidate groups
+  // are ordered so that their first block can be used as a deterministic owner.
+  auto candidateBlockIds = FindParticleBlockIds(particles, boundsMap);
+
+  // BoundsMap stores block ownership on the host. Build a dense block-to-primary-rank
+  // lookup and place it in an ArrayHandle for the ownership worklet.
+  const viskores::Id numBlocks = boundsMap.GetTotalNumBlocks();
+  std::vector<viskores::Id> blockPrimaryRanks(static_cast<std::size_t>(numBlocks),
+                                              viskores::Id{ -1 });
+  for (viskores::Id blockId = 0; blockId < numBlocks; ++blockId)
+  {
+    const auto& ranks = boundsMap.FindRank(blockId);
+    if (!ranks.empty())
+      blockPrimaryRanks[static_cast<std::size_t>(blockId)] = ranks[0];
+  }
+  auto blockPrimaryRanksAH = viskores::cont::make_ArrayHandleMove(std::move(blockPrimaryRanks));
+
+  // Keep a seed only on the primary rank of its first candidate block. This assigns
+  // each seed to one rank even when its position is inside overlapping block bounds.
+  // Seeds outside all blocks have empty candidate groups and are discarded.
+  viskores::cont::Invoker invoker;
+  viskores::cont::ArrayHandle<bool> keepMask;
+  invoker(detail::KeepSeedOnRankWorklet{ rank }, candidateBlockIds, blockPrimaryRanksAH, keepMask);
+
+  // Collect the original indices of the seeds retained by this rank. CopyIf preserves
+  // their order, so these indices align with the compacted particle array.
+  viskores::cont::ArrayHandle<viskores::Id> selectedSeedIndices;
+  viskores::cont::Algorithm::CopyIf(
+    viskores::cont::ArrayHandleIndex(keepMask.GetNumberOfValues()), keepMask, selectedSeedIndices);
+
+  // Compact the particles. CopyIf preserves their input order.
+  SeedBlockRoutingResult<ParticleType> result;
+  viskores::cont::Algorithm::CopyIf(particles, keepMask, result.Particles);
+
+  // ArrayHandleGroupVecVariable cannot be resized by CopyIf. Use a permutation view to
+  // select complete candidate groups without rebuilding their offsets or copying block IDs.
+  // The view retains the underlying grouped array and presents one group per retained seed.
+  result.CandidateBlockIds =
+    viskores::cont::make_ArrayHandlePermutation(selectedSeedIndices, candidateBlockIds);
+  return result;
+}
+}
+}
+}
+} // namespace viskores::filter::flow::internal
+
+#endif //viskores_filter_flow_internal_ParticleBlockIds_h

--- a/viskores/filter/flow/testing/UnitTestBoundsMap.cxx
+++ b/viskores/filter/flow/testing/UnitTestBoundsMap.cxx
@@ -17,6 +17,7 @@
 //============================================================================
 
 #include <viskores/CellShape.h>
+#include <viskores/Particle.h>
 #include <viskores/cont/ArrayCopy.h>
 #include <viskores/cont/ArrayHandleGroupVecVariable.h>
 #include <viskores/cont/ConvertNumComponentsToOffsets.h>
@@ -25,9 +26,11 @@
 #include <viskores/cont/Invoker.h>
 #include <viskores/cont/testing/Testing.h>
 #include <viskores/filter/flow/internal/BoundsMap.h>
+#include <viskores/filter/flow/internal/ParticleBlockIds.h>
 #include <viskores/worklet/WorkletMapField.h>
 
 #include <algorithm>
+#include <cmath>
 
 namespace
 {
@@ -38,37 +41,29 @@ struct LocatedCellIds
   std::vector<viskores::Id> Ids;
 };
 
-viskores::cont::DataSet CreateBoundsBox(const viskores::Bounds& bounds)
+template <typename T>
+viskores::cont::DataSet CreateBoundsBoxForType(const viskores::Bounds& bounds)
 {
-  std::vector<viskores::Vec3f> points = { { static_cast<viskores::FloatDefault>(bounds.X.Min),
-                                            static_cast<viskores::FloatDefault>(bounds.Y.Min),
-                                            static_cast<viskores::FloatDefault>(bounds.Z.Min) },
-                                          { static_cast<viskores::FloatDefault>(bounds.X.Max),
-                                            static_cast<viskores::FloatDefault>(bounds.Y.Min),
-                                            static_cast<viskores::FloatDefault>(bounds.Z.Min) },
-                                          { static_cast<viskores::FloatDefault>(bounds.X.Max),
-                                            static_cast<viskores::FloatDefault>(bounds.Y.Max),
-                                            static_cast<viskores::FloatDefault>(bounds.Z.Min) },
-                                          { static_cast<viskores::FloatDefault>(bounds.X.Min),
-                                            static_cast<viskores::FloatDefault>(bounds.Y.Max),
-                                            static_cast<viskores::FloatDefault>(bounds.Z.Min) },
-                                          { static_cast<viskores::FloatDefault>(bounds.X.Min),
-                                            static_cast<viskores::FloatDefault>(bounds.Y.Min),
-                                            static_cast<viskores::FloatDefault>(bounds.Z.Max) },
-                                          { static_cast<viskores::FloatDefault>(bounds.X.Max),
-                                            static_cast<viskores::FloatDefault>(bounds.Y.Min),
-                                            static_cast<viskores::FloatDefault>(bounds.Z.Max) },
-                                          { static_cast<viskores::FloatDefault>(bounds.X.Max),
-                                            static_cast<viskores::FloatDefault>(bounds.Y.Max),
-                                            static_cast<viskores::FloatDefault>(bounds.Z.Max) },
-                                          { static_cast<viskores::FloatDefault>(bounds.X.Min),
-                                            static_cast<viskores::FloatDefault>(bounds.Y.Max),
-                                            static_cast<viskores::FloatDefault>(bounds.Z.Max) } };
+  std::vector<viskores::Vec<T, 3>> points = {
+    { static_cast<T>(bounds.X.Min), static_cast<T>(bounds.Y.Min), static_cast<T>(bounds.Z.Min) },
+    { static_cast<T>(bounds.X.Max), static_cast<T>(bounds.Y.Min), static_cast<T>(bounds.Z.Min) },
+    { static_cast<T>(bounds.X.Max), static_cast<T>(bounds.Y.Max), static_cast<T>(bounds.Z.Min) },
+    { static_cast<T>(bounds.X.Min), static_cast<T>(bounds.Y.Max), static_cast<T>(bounds.Z.Min) },
+    { static_cast<T>(bounds.X.Min), static_cast<T>(bounds.Y.Min), static_cast<T>(bounds.Z.Max) },
+    { static_cast<T>(bounds.X.Max), static_cast<T>(bounds.Y.Min), static_cast<T>(bounds.Z.Max) },
+    { static_cast<T>(bounds.X.Max), static_cast<T>(bounds.Y.Max), static_cast<T>(bounds.Z.Max) },
+    { static_cast<T>(bounds.X.Min), static_cast<T>(bounds.Y.Max), static_cast<T>(bounds.Z.Max) }
+  };
   std::vector<viskores::UInt8> shapes = { viskores::CELL_SHAPE_HEXAHEDRON };
   std::vector<viskores::IdComponent> numIndices = { 8 };
   std::vector<viskores::Id> connectivity = { 0, 1, 2, 3, 4, 5, 6, 7 };
 
   return viskores::cont::DataSetBuilderExplicit::Create(points, shapes, numIndices, connectivity);
+}
+
+viskores::cont::DataSet CreateBoundsBox(const viskores::Bounds& bounds)
+{
+  return CreateBoundsBoxForType<viskores::FloatDefault>(bounds);
 }
 
 viskores::cont::PartitionedDataSet CreatePartitionedDataSet(
@@ -154,6 +149,35 @@ std::vector<LocatedCellIds> FindBoundsMapCellIds(
   return cellIds;
 }
 
+std::vector<LocatedCellIds> FindParticleBlockIds(
+  const viskores::filter::flow::internal::BoundsMap& boundsMap,
+  const std::vector<viskores::Particle>& particles)
+{
+  auto particlesAH = viskores::cont::make_ArrayHandle(particles, viskores::CopyFlag::On);
+  auto particleBlockIds =
+    viskores::filter::flow::internal::FindParticleBlockIds(particlesAH, boundsMap);
+
+  std::vector<LocatedCellIds> blockIds;
+  blockIds.reserve(particles.size());
+  auto blockIdsPortal = particleBlockIds.ReadPortal();
+  for (viskores::Id i = 0; i < static_cast<viskores::Id>(particles.size()); ++i)
+  {
+    LocatedCellIds result;
+
+    auto idsForParticle = blockIdsPortal.Get(i);
+    result.Count = idsForParticle.GetNumberOfComponents();
+    for (viskores::IdComponent j = 0; j < idsForParticle.GetNumberOfComponents(); ++j)
+    {
+      const viskores::Id id = idsForParticle[j];
+      if (id >= 0)
+        result.Ids.emplace_back(id);
+    }
+    blockIds.emplace_back(std::move(result));
+  }
+
+  return blockIds;
+}
+
 void ValidateCellIds(const LocatedCellIds& actual,
                      std::initializer_list<viskores::Id> expected,
                      const std::string& message)
@@ -192,6 +216,179 @@ void TestBoundsMapLocatorFindsBlockIds()
   ValidateCellIds(cellIds[4], {}, "BoundsMap locator failed outside all blocks");
 }
 
+void TestParticleBlockIdsFindsSeedBlocks()
+{
+  // The seed-routing helper should query the BoundsMap locator with particles,
+  // not raw points, and preserve the same overlapping/boundary block ids.
+  const std::vector<viskores::Bounds> bounds = { viskores::Bounds(0, 4, 0, 4, 0, 4),
+                                                 viskores::Bounds(4, 8, 0, 4, 0, 4),
+                                                 viskores::Bounds(2, 6, 0, 4, 0, 4) };
+
+  viskores::filter::flow::internal::BoundsMap boundsMap(CreatePartitionedDataSet(bounds));
+  auto blockIds = FindParticleBlockIds(boundsMap,
+                                       {
+                                         viskores::Particle(viskores::Vec3f(1.0f, 2.0f, 2.0f), 0),
+                                         viskores::Particle(viskores::Vec3f(3.0f, 2.0f, 2.0f), 1),
+                                         viskores::Particle(viskores::Vec3f(4.0f, 2.0f, 2.0f), 2),
+                                         viskores::Particle(viskores::Vec3f(9.0f, 2.0f, 2.0f), 3),
+                                       });
+
+  ValidateCellIds(blockIds[0], { 0 }, "Particle block ids failed for first block");
+  ValidateCellIds(blockIds[1], { 0, 2 }, "Particle block ids failed for overlapping blocks");
+  ValidateCellIds(blockIds[2], { 0, 1, 2 }, "Particle block ids failed on shared boundary");
+  ValidateCellIds(blockIds[3], {}, "Particle block ids failed outside all blocks");
+}
+
+void TestParticleBlockIdsHandlesEmptyAndOutsideSeeds()
+{
+  // Empty seed arrays and seeds outside every block should both produce empty
+  // groups without allocating bogus block ids.
+  const std::vector<viskores::Bounds> bounds = { viskores::Bounds(0, 4, 0, 4, 0, 4),
+                                                 viskores::Bounds(4, 8, 0, 4, 0, 4) };
+
+  viskores::filter::flow::internal::BoundsMap boundsMap(CreatePartitionedDataSet(bounds));
+  std::vector<viskores::Particle> noParticles;
+  auto emptyBlockIds = FindParticleBlockIds(boundsMap, noParticles);
+  VISKORES_TEST_ASSERT(emptyBlockIds.empty(),
+                       "Empty particle input should produce no block id groups.");
+
+  auto noParticlesAH = viskores::cont::make_ArrayHandle(noParticles, viskores::CopyFlag::On);
+  auto emptyRouting = viskores::filter::flow::internal::RouteSeedsToBlocks(
+    noParticlesAH, boundsMap, viskores::Id{ 0 });
+  VISKORES_TEST_ASSERT(emptyRouting.Particles.GetNumberOfValues() == 0 &&
+                         emptyRouting.CandidateBlockIds.GetNumberOfValues() == 0,
+                       "Empty particle input should produce an empty routing result.");
+
+  auto outsideBlockIds =
+    FindParticleBlockIds(boundsMap,
+                         {
+                           viskores::Particle(viskores::Vec3f(-1.0f, 2.0f, 2.0f), 0),
+                           viskores::Particle(viskores::Vec3f(9.0f, 2.0f, 2.0f), 1),
+                         });
+
+  ValidateCellIds(outsideBlockIds[0], {}, "Particle block ids failed before first block");
+  ValidateCellIds(outsideBlockIds[1], {}, "Particle block ids failed after last block");
+}
+
+void TestParticleBlockIdsSortsCandidateGroups()
+{
+  auto blockIds = viskores::cont::make_ArrayHandle({ viskores::Id{ 2 },
+                                                     viskores::Id{ 0 },
+                                                     viskores::Id{ 1 },
+                                                     viskores::Id{ 5 },
+                                                     viskores::Id{ 3 } });
+  auto counts = viskores::cont::make_ArrayHandle({ viskores::Id{ 3 }, viskores::Id{ 2 } });
+  auto groupedBlockIds = viskores::cont::make_ArrayHandleGroupVecVariable(
+    blockIds, viskores::cont::ConvertNumComponentsToOffsets(counts));
+
+  viskores::cont::Invoker invoker;
+  invoker(viskores::filter::flow::internal::detail::SortParticleBlockIdsWorklet{}, groupedBlockIds);
+
+  auto portal = groupedBlockIds.ReadPortal();
+  LocatedCellIds firstGroup;
+  auto first = portal.Get(0);
+  firstGroup.Count = first.GetNumberOfComponents();
+  for (viskores::IdComponent i = 0; i < first.GetNumberOfComponents(); ++i)
+    firstGroup.Ids.emplace_back(first[i]);
+  ValidateCellIds(firstGroup, { 0, 1, 2 }, "Candidate group sorting failed");
+
+  LocatedCellIds secondGroup;
+  auto second = portal.Get(1);
+  secondGroup.Count = second.GetNumberOfComponents();
+  for (viskores::IdComponent i = 0; i < second.GetNumberOfComponents(); ++i)
+    secondGroup.Ids.emplace_back(second[i]);
+  ValidateCellIds(secondGroup, { 3, 5 }, "Second candidate group sorting failed");
+}
+
+void TestParticleBlockIdsHandlesNoBlocks()
+{
+  viskores::cont::PartitionedDataSet emptyData;
+  viskores::filter::flow::internal::BoundsMap boundsMap(emptyData);
+  const std::vector<viskores::Particle> particles = {
+    viskores::Particle(viskores::Vec3f(0.0f, 0.0f, 0.0f), 0),
+    viskores::Particle(viskores::Vec3f(1.0f, 1.0f, 1.0f), 1)
+  };
+
+  auto blockIds = FindParticleBlockIds(boundsMap, particles);
+  VISKORES_TEST_ASSERT(blockIds.size() == particles.size(),
+                       "Every particle should have an empty block id group.");
+  ValidateCellIds(blockIds[0], {}, "Zero-block routing failed for first particle");
+  ValidateCellIds(blockIds[1], {}, "Zero-block routing failed for second particle");
+
+  auto particlesAH = viskores::cont::make_ArrayHandle(particles, viskores::CopyFlag::On);
+  auto routed =
+    viskores::filter::flow::internal::RouteSeedsToBlocks(particlesAH, boundsMap, viskores::Id{ 0 });
+  VISKORES_TEST_ASSERT(routed.Particles.GetNumberOfValues() == 0,
+                       "Zero-block routing should discard all particles.");
+  VISKORES_TEST_ASSERT(routed.CandidateBlockIds.GetNumberOfValues() == 0,
+                       "Zero-block routing should produce no candidate groups.");
+}
+
+void TestSeedRoutingProducesCompactedArrayHandles()
+{
+  const std::vector<viskores::Bounds> bounds = { viskores::Bounds(0, 4, 0, 4, 0, 4),
+                                                 viskores::Bounds(4, 8, 0, 4, 0, 4),
+                                                 viskores::Bounds(2, 6, 0, 4, 0, 4) };
+  viskores::filter::flow::internal::BoundsMap boundsMap(CreatePartitionedDataSet(bounds));
+  const std::vector<viskores::Particle> particles = {
+    viskores::Particle(viskores::Vec3f(4.0f, 2.0f, 2.0f), 10),
+    viskores::Particle(viskores::Vec3f(9.0f, 2.0f, 2.0f), 11),
+    viskores::Particle(viskores::Vec3f(7.0f, 2.0f, 2.0f), 12)
+  };
+  auto particlesAH = viskores::cont::make_ArrayHandle(particles, viskores::CopyFlag::On);
+
+  auto routed =
+    viskores::filter::flow::internal::RouteSeedsToBlocks(particlesAH, boundsMap, viskores::Id{ 0 });
+  VISKORES_TEST_ASSERT(routed.Particles.GetNumberOfValues() == 2,
+                       "Routing should compact out particles outside every block.");
+  VISKORES_TEST_ASSERT(routed.CandidateBlockIds.GetNumberOfValues() == 2,
+                       "Candidate block ids should mirror compacted particles.");
+
+  auto routedParticles = routed.Particles.ReadPortal();
+  auto candidateBlockIds = routed.CandidateBlockIds.ReadPortal();
+  VISKORES_TEST_ASSERT(routedParticles.Get(0).GetID() == 10 && routedParticles.Get(1).GetID() == 12,
+                       "Routing should preserve particle order during compaction.");
+
+  LocatedCellIds firstCandidates;
+  auto firstCandidateGroup = candidateBlockIds.Get(0);
+  firstCandidates.Count = firstCandidateGroup.GetNumberOfComponents();
+  for (viskores::IdComponent i = 0; i < firstCandidateGroup.GetNumberOfComponents(); ++i)
+    firstCandidates.Ids.emplace_back(firstCandidateGroup[i]);
+  ValidateCellIds(firstCandidates, { 0, 1, 2 }, "Routing did not preserve sorted candidates");
+
+  LocatedCellIds secondCandidates;
+  auto secondCandidateGroup = candidateBlockIds.Get(1);
+  secondCandidates.Count = secondCandidateGroup.GetNumberOfComponents();
+  for (viskores::IdComponent i = 0; i < secondCandidateGroup.GetNumberOfComponents(); ++i)
+    secondCandidates.Ids.emplace_back(secondCandidateGroup[i]);
+  ValidateCellIds(secondCandidates, { 1 }, "Routing produced the wrong final candidate group");
+
+  auto wrongRank =
+    viskores::filter::flow::internal::RouteSeedsToBlocks(particlesAH, boundsMap, viskores::Id{ 1 });
+  VISKORES_TEST_ASSERT(wrongRank.Particles.GetNumberOfValues() == 0 &&
+                         wrongRank.CandidateBlockIds.GetNumberOfValues() == 0,
+                       "Only the primary owning rank should retain a seed.");
+}
+
+void TestParticleBlockIdsPreservesFloat64Bounds()
+{
+  const viskores::Float64 xmin = 1.00000001;
+  const viskores::Bounds bounds(xmin, 2.0, 0.0, 1.0, 0.0, 1.0);
+  viskores::cont::PartitionedDataSet pds;
+  pds.AppendPartition(CreateBoundsBoxForType<viskores::Float64>(bounds));
+  viskores::filter::flow::internal::BoundsMap boundsMap(pds);
+
+  const viskores::Vec3f belowBound(1.0f, 0.5f, 0.5f);
+  const viskores::Vec3f insideBound(std::nextafter(1.0f, 2.0f), 0.5f, 0.5f);
+  VISKORES_TEST_ASSERT(boundsMap.FindBlocks(belowBound).empty(),
+                       "Host bounds lookup should reject the point below the Float64 bound.");
+
+  auto blockIds = FindParticleBlockIds(
+    boundsMap, { viskores::Particle(belowBound, 0), viskores::Particle(insideBound, 1) });
+  ValidateCellIds(blockIds[0], {}, "Locator narrowed the Float64 lower bound");
+  ValidateCellIds(blockIds[1], { 0 }, "Locator rejected a point inside the Float64 bounds");
+}
+
 void TestBoundsMapLocatorHandlesDegenerateBounds()
 {
   // Lower-dimensional block bounds should still produce valid locator cells so
@@ -218,7 +415,9 @@ void TestBoundsMapLocatorHandlesDegenerateBounds()
                                         viskores::Vec3f(8.0f, 1.0f, 1.0f),
                                         viskores::Vec3f(13.0f, 0.0f, 0.0f),
                                         viskores::Vec3f(16.0f, 1.0f, 0.0f),
-                                        viskores::Vec3f(20.0f, 0.0f, 1.0f) });
+                                        viskores::Vec3f(20.0f, 0.0f, 1.0f),
+                                        viskores::Vec3f(24.0f, 0.0f, 0.0f),
+                                        viskores::Vec3f(24.0f, 0.0f, 1.0f) });
 
   ValidateCellIds(cellIds[0], { 0 }, "BoundsMap locator failed for XY bounds");
   ValidateCellIds(cellIds[1], { 1 }, "BoundsMap locator failed for XZ bounds");
@@ -226,6 +425,15 @@ void TestBoundsMapLocatorHandlesDegenerateBounds()
   ValidateCellIds(cellIds[3], { 3 }, "BoundsMap locator failed for X line bounds");
   ValidateCellIds(cellIds[4], { 4 }, "BoundsMap locator failed for Y line bounds");
   ValidateCellIds(cellIds[5], { 5 }, "BoundsMap locator failed for Z line bounds");
+  ValidateCellIds(cellIds[6], { 6 }, "BoundsMap locator failed for vertex bounds");
+  ValidateCellIds(cellIds[7], {}, "BoundsMap locator accepted a point outside vertex bounds");
+
+  auto blockIds =
+    FindParticleBlockIds(boundsMap,
+                         { viskores::Particle(viskores::Vec3f(24.0f, 0.0f, 0.0f), 0),
+                           viskores::Particle(viskores::Vec3f(24.0f, 0.0f, 1.0f), 1) });
+  ValidateCellIds(blockIds[0], { 6 }, "Particle block lookup failed for vertex bounds");
+  ValidateCellIds(blockIds[1], {}, "Particle block lookup accepted a point outside vertex bounds");
 }
 
 void TestBoundsMapBlockIdValidation()
@@ -270,6 +478,12 @@ void TestBoundsMapBlockIdValidation()
 void TestBoundsMap()
 {
   TestBoundsMapLocatorFindsBlockIds();
+  TestParticleBlockIdsFindsSeedBlocks();
+  TestParticleBlockIdsHandlesEmptyAndOutsideSeeds();
+  TestParticleBlockIdsSortsCandidateGroups();
+  TestParticleBlockIdsHandlesNoBlocks();
+  TestSeedRoutingProducesCompactedArrayHandles();
+  TestParticleBlockIdsPreservesFloat64Bounds();
   TestBoundsMapLocatorHandlesDegenerateBounds();
   TestBoundsMapBlockIdValidation();
 }


### PR DESCRIPTION
`AdvectAlgorithm::SetSeeds` previously performed a host-side bounds scan for every seed and immediately stored the results in nested `std::vector`s. This moves candidate discovery, validation, ordering, ownership filtering, and compaction to Viskores worklets and algorithms while preserving the current host-side queue interface.

Main changes include:
- route flow seeds to candidate blocks with `BoundsMap` locator worklets
- validate locator candidates against the original `Float64` block bounds
- deterministically order overlapping candidates and filter seeds by primary-rank ownership
- keep compacted particles and candidate groups in `ArrayHandle` representations until the existing host queue handoff
- add coverage for overlapping bounds, empty seeds, zero blocks, compaction, sorting, and coordinate precision

Note: this is a change that will be part of a multi-PR effort to workletize the streamline code.


