### PR TITLE
Improve testing coverage gaps

### DIFF
--- a/viskores/testing/UnitTestArrayPortalValueReference.cxx
+++ b/viskores/testing/UnitTestArrayPortalValueReference.cxx
@@ -106,13 +106,17 @@ void TryOperatorsInt(viskores::Id index,
   VISKORES_TEST_ASSERT((ref & expected) == (expected & expected));
   VISKORES_TEST_ASSERT((expected & ref) == (expected & expected));
 
-  VISKORES_TEST_ASSERT((ref << ref) == (expected << expected));
-  VISKORES_TEST_ASSERT((ref << expected) == (expected << expected));
-  VISKORES_TEST_ASSERT((expected << ref) == (expected << expected));
+  // TestValue can be larger than the integer bit width, so use a controlled
+  // right-hand side for shift operators.
+  const ValueType shift = ValueType(1);
+  scratch = shift;
+  VISKORES_TEST_ASSERT((ref >> scratch) == (expected >> shift));
+  VISKORES_TEST_ASSERT((ref >> shift) == (expected >> shift));
+  VISKORES_TEST_ASSERT((expected >> scratch) == (expected >> shift));
 
-  VISKORES_TEST_ASSERT((ref << ref) == (expected << expected));
-  VISKORES_TEST_ASSERT((ref << expected) == (expected << expected));
-  VISKORES_TEST_ASSERT((expected << ref) == (expected << expected));
+  VISKORES_TEST_ASSERT((ref << scratch) == (expected << shift));
+  VISKORES_TEST_ASSERT((ref << shift) == (expected << shift));
+  VISKORES_TEST_ASSERT((expected << scratch) == (expected << shift));
 
   VISKORES_TEST_ASSERT(~ref == ~expected);
 

--- a/viskores/testing/UnitTestLowerBound.cxx
+++ b/viskores/testing/UnitTestLowerBound.cxx
@@ -47,25 +47,46 @@ struct TestLowerBound
     }
   };
 
-  static void Run()
+  static void Check(const IdArray& needles,
+                    const IdArray& haystack,
+                    const std::vector<viskores::Id>& expected)
   {
-    IdArray needles =
-      viskores::cont::make_ArrayHandle<viskores::Id>({ -4, -3, -2, -1, 0, 1, 2, 3, 4, 5 });
-    IdArray haystack =
-      viskores::cont::make_ArrayHandle<viskores::Id>({ -3, -2, -2, -2, 0, 0, 1, 1, 1, 4, 4 });
+    VISKORES_TEST_ASSERT(needles.GetNumberOfValues() == static_cast<viskores::Id>(expected.size()));
+
     IdArray results;
-
-    std::vector<viskores::Id> expected{ 0, 0, 1, 4, 4, 6, 9, 9, 9, 11 };
-
     viskores::cont::Invoker invoke;
     invoke(Impl{}, needles, haystack, results);
 
-    // Verify:
     auto resultsPortal = results.ReadPortal();
+    VISKORES_TEST_ASSERT(results.GetNumberOfValues() == needles.GetNumberOfValues());
     for (viskores::Id i = 0; i < needles.GetNumberOfValues(); ++i)
     {
       VISKORES_TEST_ASSERT(resultsPortal.Get(i) == expected[static_cast<size_t>(i)]);
     }
+  }
+
+  static void Run()
+  {
+    // Needles query positions before, inside, and after the sorted haystack range.
+    IdArray needles =
+      viskores::cont::make_ArrayHandle<viskores::Id>({ -4, -3, -2, -1, 0, 1, 2, 3, 4, 5 });
+    // Haystack includes duplicates to exercise lower-bound insertion before equal values.
+    IdArray haystack =
+      viskores::cont::make_ArrayHandle<viskores::Id>({ -3, -2, -2, -2, 0, 0, 1, 1, 1, 4, 4 });
+    std::vector<viskores::Id> expected{ 0, 0, 1, 4, 4, 6, 9, 9, 9, 11 };
+    Check(needles, haystack, expected);
+
+    IdArray emptyHaystack;
+    emptyHaystack.Allocate(0);
+    std::vector<viskores::Id> emptyHaystackExpected(
+      static_cast<size_t>(needles.GetNumberOfValues()), 0);
+    // All lower-bound results in an empty haystack should point to the beginning.
+    Check(needles, emptyHaystack, emptyHaystackExpected);
+
+    IdArray emptyNeedles;
+    emptyNeedles.Allocate(0);
+    // An empty input domain should produce an empty output array.
+    Check(emptyNeedles, haystack, std::vector<viskores::Id>{});
   }
 };
 

--- a/viskores/testing/UnitTestNewtonsMethod.cxx
+++ b/viskores/testing/UnitTestNewtonsMethod.cxx
@@ -92,6 +92,8 @@ void TestNewtonsMethodTemplate()
         auto result = viskores::NewtonsMethod(
           EvaluateJacobian<T>(), EvaluateFunctions<T>(), desiredOutput, initialGuess, T(1e-6));
 
+        VISKORES_TEST_ASSERT(result.Valid, "Newton's method returned an invalid result.");
+        VISKORES_TEST_ASSERT(result.Converged, "Newton's method did not report convergence.");
         VISKORES_TEST_ASSERT(test_equal(result.Solution, expected1) ||
                                test_equal(result.Solution, expected2),
                              "Newton's method did not converge to expected result.");

--- a/viskores/testing/UnitTestUpperBound.cxx
+++ b/viskores/testing/UnitTestUpperBound.cxx
@@ -47,25 +47,46 @@ struct TestUpperBound
     }
   };
 
-  static void Run()
+  static void Check(const IdArray& needles,
+                    const IdArray& haystack,
+                    const std::vector<viskores::Id>& expected)
   {
-    IdArray needles =
-      viskores::cont::make_ArrayHandle<viskores::Id>({ -4, -3, -2, -1, 0, 1, 2, 3, 4, 5 });
-    IdArray haystack =
-      viskores::cont::make_ArrayHandle<viskores::Id>({ -3, -2, -2, -2, 0, 0, 1, 1, 1, 4, 4 });
+    VISKORES_TEST_ASSERT(needles.GetNumberOfValues() == static_cast<viskores::Id>(expected.size()));
+
     IdArray results;
-
-    std::vector<viskores::Id> expected{ 0, 1, 4, 4, 6, 9, 9, 9, 11, 11 };
-
     viskores::cont::Invoker invoke;
     invoke(Impl{}, needles, haystack, results);
 
-    // Verify:
     auto resultsPortal = results.ReadPortal();
+    VISKORES_TEST_ASSERT(results.GetNumberOfValues() == needles.GetNumberOfValues());
     for (viskores::Id i = 0; i < needles.GetNumberOfValues(); ++i)
     {
       VISKORES_TEST_ASSERT(resultsPortal.Get(i) == expected[static_cast<size_t>(i)]);
     }
+  }
+
+  static void Run()
+  {
+    // Needles query positions before, inside, and after the sorted haystack range.
+    IdArray needles =
+      viskores::cont::make_ArrayHandle<viskores::Id>({ -4, -3, -2, -1, 0, 1, 2, 3, 4, 5 });
+    // Haystack includes duplicates to exercise upper-bound insertion after equal values.
+    IdArray haystack =
+      viskores::cont::make_ArrayHandle<viskores::Id>({ -3, -2, -2, -2, 0, 0, 1, 1, 1, 4, 4 });
+    std::vector<viskores::Id> expected{ 0, 1, 4, 4, 6, 9, 9, 9, 11, 11 };
+    Check(needles, haystack, expected);
+
+    IdArray emptyHaystack;
+    emptyHaystack.Allocate(0);
+    std::vector<viskores::Id> emptyHaystackExpected(
+      static_cast<size_t>(needles.GetNumberOfValues()), 0);
+    // All upper-bound results in an empty haystack should point to the beginning.
+    Check(needles, emptyHaystack, emptyHaystackExpected);
+
+    IdArray emptyNeedles;
+    emptyNeedles.Allocate(0);
+    // An empty input domain should produce an empty output array.
+    Check(emptyNeedles, haystack, std::vector<viskores::Id>{});
   }
 };
 


### PR DESCRIPTION
Improves coverage in several `viskores/testing` unit tests.

## Changes

- Fixes duplicate shift-operator coverage in `UnitTestArrayPortalValueReference` by replacing the repeated binary `<<` checks with binary `>>` checks.
- Adds explicit `Valid` and `Converged` assertions to `UnitTestNewtonsMethod`.
- Adds empty-input coverage for `LowerBound` and `UpperBound`:
  - non-empty needles with an empty haystack
  - empty needles with a non-empty haystack
- Refactors lower/upper bound verification into a small shared helper inside each test.
