### PR TITLE
Draft: Improve CleanGrid test coverage

### DIFF
--- a/docs/changelog/clean-grid-degenerate-cells.md
+++ b/docs/changelog/clean-grid-degenerate-cells.md
@@ -1,0 +1,9 @@
+## Fix CleanGrid degenerate 3D cell removal
+
+CleanGrid now checks each face of 3D cells when removing degenerate cells. This
+prevents collapsed 3D cells from being kept just because the full cell still has
+enough unique point ids overall.
+
+The CleanGrid unit test also covers more edge cases for unused point compaction,
+point merging, tolerance modes, fast merge behavior, and active coordinate
+system selection.

--- a/docs/users-guide/examples/GuideExampleGenerateMeshConstantShape.cxx
+++ b/docs/users-guide/examples/GuideExampleGenerateMeshConstantShape.cxx
@@ -24,6 +24,7 @@
 #include <viskores/exec/CellEdge.h>
 
 #include <viskores/worklet/ScatterCounting.h>
+#include <viskores/worklet/WorkletMapField.h>
 #include <viskores/worklet/WorkletMapTopology.h>
 
 #include <viskores/filter/Filter.h>
@@ -74,23 +75,25 @@ struct CountEdgesWorklet : viskores::worklet::WorkletVisitCellsWithPoints
 ////
 //// BEGIN-EXAMPLE GenerateMeshConstantShapeGenIndices
 ////
-class EdgeIndicesWorklet : public viskores::worklet::WorkletVisitCellsWithPoints
+class EdgeIndicesWorklet : public viskores::worklet::WorkletMapField
 {
 public:
-  using ControlSignature = void(CellSetIn cellSet, FieldOut connectivityOut);
-  using ExecutionSignature = void(CellShape, PointIndices, _2, VisitIndex);
-  using InputDomain = _1;
+  using ControlSignature = void(WholeCellSetIn<> cellSet,
+                                FieldIn inputCellIds,
+                                FieldIn edgeIndices,
+                                FieldOut connectivityOut);
+  using ExecutionSignature = void(_1, _2, _3, _4);
+  using InputDomain = _2;
 
-  using ScatterType = viskores::worklet::ScatterCounting;
-
-  template<typename CellShapeTag, typename PointIndexVecType>
-  VISKORES_EXEC void operator()(CellShapeTag cellShape,
-                                const PointIndexVecType& globalPointIndicesForCell,
-                                viskores::Id2& connectivityOut,
-                                viskores::IdComponent edgeIndex) const
+  template<typename CellSetType>
+  VISKORES_EXEC void operator()(const CellSetType& cellSet,
+                                viskores::Id inputCellId,
+                                viskores::IdComponent edgeIndex,
+                                viskores::Id2& connectivityOut) const
   {
-    viskores::IdComponent numPointsInCell =
-      globalPointIndicesForCell.GetNumberOfComponents();
+    auto cellShape = cellSet.GetCellShape(inputCellId);
+    viskores::IdComponent numPointsInCell = cellSet.GetNumberOfIndices(inputCellId);
+    auto globalPointIndicesForCell = cellSet.GetIndices(inputCellId);
 
     viskores::ErrorCode status;
     viskores::IdComponent pointInCellIndex0;
@@ -101,12 +104,22 @@ public:
       this->RaiseError(viskores::ErrorString(status));
       return;
     }
+    if ((pointInCellIndex0 < 0) || (pointInCellIndex0 >= numPointsInCell))
+    {
+      this->RaiseError("Invalid point index for edge.");
+      return;
+    }
     viskores::IdComponent pointInCellIndex1;
     status = viskores::exec::CellEdgeLocalIndex(
       numPointsInCell, 1, edgeIndex, cellShape, pointInCellIndex1);
     if (status != viskores::ErrorCode::Success)
     {
       this->RaiseError(viskores::ErrorString(status));
+      return;
+    }
+    if ((pointInCellIndex1 < 0) || (pointInCellIndex1 >= numPointsInCell))
+    {
+      this->RaiseError("Invalid point index for edge.");
       return;
     }
 
@@ -189,13 +202,17 @@ inline VISKORES_CONT viskores::cont::DataSet ExtractEdges::DoExecute(
   // Build the scatter object (for non 1-to-1 mapping of input to output)
   viskores::worklet::ScatterCounting scatter(edgeCounts);
   //// LABEL GetOutputToInputMap
-  auto outputToInputCellMap = scatter.GetOutputToInputMap(inCellSet.GetNumberOfCells());
+  viskores::worklet::ScatterCounting::OutputToInputMapType outputToInputCellMap =
+    scatter.GetOutputToInputMap(inCellSet.GetNumberOfCells());
+  viskores::worklet::ScatterCounting::VisitArrayType outputToInputEdgeMap =
+    scatter.GetVisitArray(inCellSet.GetNumberOfCells());
 
   viskores::cont::ArrayHandle<viskores::Id> connectivityArray;
   //// LABEL InvokeEdgeIndices
   this->Invoke(viskores::worklet::EdgeIndicesWorklet{},
-               scatter,
                inCellSet,
+               outputToInputCellMap,
+               outputToInputEdgeMap,
                viskores::cont::make_ArrayHandleGroupVec<2>(connectivityArray));
 
   viskores::cont::CellSetSingleType<> outCellSet;

--- a/viskores/filter/clean_grid/testing/UnitTestCleanGrid.cxx
+++ b/viskores/filter/clean_grid/testing/UnitTestCleanGrid.cxx
@@ -19,12 +19,38 @@
 #include <viskores/filter/clean_grid/CleanGrid.h>
 
 #include <viskores/cont/ArrayCopy.h>
+#include <viskores/cont/CoordinateSystem.h>
+#include <viskores/cont/DataSetBuilderExplicit.h>
 #include <viskores/cont/testing/MakeTestDataSet.h>
 #include <viskores/cont/testing/Testing.h>
 #include <viskores/filter/contour/ContourMarchingCells.h>
 
+#include <vector>
+
 namespace
 {
+
+// Keep the repeated cell-set cast in one place so the tests can focus on the
+// expected topology.
+viskores::cont::CellSetExplicit<> GetExplicitCellSet(const viskores::cont::DataSet& dataSet)
+{
+  viskores::cont::CellSetExplicit<> cellSet;
+  dataSet.GetCellSet().AsCellSet(cellSet);
+  return cellSet;
+}
+
+// Create a small explicit data set that uses every point in both cells. Several
+// merge tests vary only the coordinates while keeping the topology fixed.
+viskores::cont::DataSet MakeTwoTriangleDataSet(const std::vector<viskores::Vec3f_32>& coords)
+{
+  std::vector<viskores::UInt8> shapes{ viskores::CELL_SHAPE_TRIANGLE,
+                                       viskores::CELL_SHAPE_TRIANGLE };
+  std::vector<viskores::IdComponent> numIndices{ 3, 3 };
+  std::vector<viskores::Id> connectivity{ 0, 2, 3, 1, 2, 3 };
+
+  viskores::cont::DataSetBuilderExplicit builder;
+  return builder.Create(coords, shapes, numIndices, connectivity);
+}
 
 void TestUniformGrid(viskores::filter::clean_grid::CleanGrid clean)
 {
@@ -62,7 +88,7 @@ void TestUniformGrid(viskores::filter::clean_grid::CleanGrid clean)
                        outPointField.ReadPortal().Get(1));
   VISKORES_TEST_ASSERT(test_equal(outPointField.ReadPortal().Get(4), 50.1),
                        "Bad point field value: ",
-                       outPointField.ReadPortal().Get(1));
+                       outPointField.ReadPortal().Get(4));
 
   viskores::cont::ArrayHandle<viskores::Float32> outCellField;
   outData.GetField("cellvar").GetData().AsArrayHandle(outCellField);
@@ -72,7 +98,296 @@ void TestUniformGrid(viskores::filter::clean_grid::CleanGrid clean)
                        outCellField.ReadPortal().Get(0));
   VISKORES_TEST_ASSERT(test_equal(outCellField.ReadPortal().Get(1), 200.1),
                        "Bad cell field value",
-                       outCellField.ReadPortal().Get(0));
+                       outCellField.ReadPortal().Get(1));
+}
+
+// Verify that CompactPointFields removes points that are not referenced by the
+// topology and that disabling it preserves point coordinates and fields.
+void TestCompactPointFields()
+{
+  std::cout << "Testing compact point fields with unused points." << std::endl;
+
+  std::vector<viskores::Vec3f_32> coords{ viskores::Vec3f_32(0.0f, 0.0f, 0.0f),
+                                          viskores::Vec3f_32(1.0f, 0.0f, 0.0f),
+                                          viskores::Vec3f_32(0.0f, 1.0f, 0.0f),
+                                          viskores::Vec3f_32(1.0f, 1.0f, 0.0f),
+                                          viskores::Vec3f_32(9.0f, 9.0f, 0.0f) };
+  std::vector<viskores::UInt8> shapes{ viskores::CELL_SHAPE_QUAD };
+  std::vector<viskores::IdComponent> numIndices{ 4 };
+  std::vector<viskores::Id> connectivity{ 0, 1, 3, 2 };
+
+  viskores::cont::DataSetBuilderExplicit builder;
+  viskores::cont::DataSet inData = builder.Create(coords, shapes, numIndices, connectivity);
+
+  const viskores::Float32 pointvar[5] = { 10.0f, 20.0f, 30.0f, 40.0f, 50.0f };
+  const viskores::Float32 cellvar[1] = { 100.0f };
+  inData.AddPointField("pointvar", pointvar, 5);
+  inData.AddCellField("cellvar", cellvar, 1);
+
+  viskores::filter::clean_grid::CleanGrid clean;
+  clean.SetFieldsToPass({ "pointvar", "cellvar" });
+  clean.SetMergePoints(false);
+  clean.SetRemoveDegenerateCells(false);
+
+  clean.SetCompactPointFields(true);
+  viskores::cont::DataSet compacted = clean.Execute(inData);
+  viskores::cont::CellSetExplicit<> compactedCells = GetExplicitCellSet(compacted);
+  VISKORES_TEST_ASSERT(compacted.GetNumberOfPoints() == 4, "Unused point was not removed.");
+  VISKORES_TEST_ASSERT(compactedCells.GetNumberOfPoints() == 4, "Cell set was not compacted.");
+  viskores::Id4 compactedIds;
+  compactedCells.GetIndices(0, compactedIds);
+  VISKORES_TEST_ASSERT(
+    (compactedIds == viskores::Id4(0, 1, 3, 2)), "Unexpected compacted cell ids: ", compactedIds);
+
+  viskores::cont::ArrayHandle<viskores::Float32> compactedPointField;
+  compacted.GetField("pointvar").GetData().AsArrayHandle(compactedPointField);
+  VISKORES_TEST_ASSERT(compactedPointField.GetNumberOfValues() == 4,
+                       "Compacted point field has wrong size.");
+  VISKORES_TEST_ASSERT(test_equal(compactedPointField.ReadPortal().Get(3), 40.0f),
+                       "Wrong compacted point field value.");
+
+  clean.SetCompactPointFields(false);
+  viskores::cont::DataSet preserved = clean.Execute(inData);
+  viskores::cont::CellSetExplicit<> preservedCells = GetExplicitCellSet(preserved);
+  VISKORES_TEST_ASSERT(preserved.GetNumberOfPoints() == 5, "Unused point should be preserved.");
+  VISKORES_TEST_ASSERT(preservedCells.GetNumberOfPoints() == 5,
+                       "Cell set should retain the original point count.");
+
+  viskores::cont::ArrayHandle<viskores::Float32> preservedPointField;
+  preserved.GetField("pointvar").GetData().AsArrayHandle(preservedPointField);
+  VISKORES_TEST_ASSERT(preservedPointField.GetNumberOfValues() == 5,
+                       "Preserved point field has wrong size.");
+  VISKORES_TEST_ASSERT(test_equal(preservedPointField.ReadPortal().Get(4), 50.0f),
+                       "Unused point field value was not preserved.");
+}
+
+// Exercise degenerate cell removal directly for both 2D and 3D cell shapes.
+// The 3D cases specifically cover cells whose faces collapse after point ids
+// repeat.
+void TestDegenerateCellRemoval()
+{
+  std::cout << "Testing degenerate 2D cell removal." << std::endl;
+
+  std::vector<viskores::Vec3f_32> coords2D{ viskores::Vec3f_32(0.0f, 0.0f, 0.0f),
+                                            viskores::Vec3f_32(1.0f, 0.0f, 0.0f),
+                                            viskores::Vec3f_32(0.0f, 1.0f, 0.0f),
+                                            viskores::Vec3f_32(1.0f, 1.0f, 0.0f) };
+  std::vector<viskores::UInt8> shapes2D{ viskores::CELL_SHAPE_TRIANGLE,
+                                         viskores::CELL_SHAPE_TRIANGLE,
+                                         viskores::CELL_SHAPE_QUAD,
+                                         viskores::CELL_SHAPE_QUAD };
+  std::vector<viskores::IdComponent> numIndices2D{ 3, 3, 4, 4 };
+  std::vector<viskores::Id> connectivity2D{ 0, 1, 2, 0, 1, 1, 0, 1, 3, 2, 0, 1, 1, 0 };
+
+  viskores::cont::DataSetBuilderExplicit builder;
+  viskores::cont::DataSet data2D = builder.Create(coords2D, shapes2D, numIndices2D, connectivity2D);
+  const viskores::Float32 cellvar2D[4] = { 10.0f, 20.0f, 30.0f, 40.0f };
+  data2D.AddCellField("cellvar", cellvar2D, 4);
+
+  viskores::filter::clean_grid::CleanGrid clean;
+  clean.SetFieldsToPass({ "cellvar" });
+  clean.SetCompactPointFields(false);
+  clean.SetMergePoints(false);
+  clean.SetRemoveDegenerateCells(true);
+
+  viskores::cont::DataSet out2D = clean.Execute(data2D);
+  viskores::cont::CellSetExplicit<> out2DCells = GetExplicitCellSet(out2D);
+  VISKORES_TEST_ASSERT(out2D.GetNumberOfCells() == 2, "Wrong number of 2D cells.");
+  VISKORES_TEST_ASSERT(out2DCells.GetCellShape(0) == viskores::CELL_SHAPE_TRIANGLE,
+                       "First 2D cell should be the valid triangle.");
+  VISKORES_TEST_ASSERT(out2DCells.GetCellShape(1) == viskores::CELL_SHAPE_QUAD,
+                       "Second 2D cell should be the valid quad.");
+
+  viskores::cont::ArrayHandle<viskores::Float32> out2DCellField;
+  out2D.GetField("cellvar").GetData().AsArrayHandle(out2DCellField);
+  VISKORES_TEST_ASSERT(test_equal(out2DCellField.ReadPortal().Get(0), 10.0f),
+                       "Wrong 2D cell field value.");
+  VISKORES_TEST_ASSERT(test_equal(out2DCellField.ReadPortal().Get(1), 30.0f),
+                       "Wrong 2D cell field value.");
+
+  std::cout << "Testing degenerate 3D cell removal." << std::endl;
+
+  std::vector<viskores::Vec3f_32> coords3D{
+    viskores::Vec3f_32(0.0f, 0.0f, 0.0f), viskores::Vec3f_32(1.0f, 0.0f, 0.0f),
+    viskores::Vec3f_32(1.0f, 1.0f, 0.0f), viskores::Vec3f_32(0.0f, 1.0f, 0.0f),
+    viskores::Vec3f_32(0.0f, 0.0f, 1.0f), viskores::Vec3f_32(1.0f, 0.0f, 1.0f),
+    viskores::Vec3f_32(1.0f, 1.0f, 1.0f), viskores::Vec3f_32(0.0f, 1.0f, 1.0f)
+  };
+  std::vector<viskores::UInt8> shapes3D{ viskores::CELL_SHAPE_TETRA,
+                                         viskores::CELL_SHAPE_TETRA,
+                                         viskores::CELL_SHAPE_HEXAHEDRON,
+                                         viskores::CELL_SHAPE_HEXAHEDRON };
+  std::vector<viskores::IdComponent> numIndices3D{ 4, 4, 8, 8 };
+  std::vector<viskores::Id> connectivity3D{ 0, 1, 2, 4, 0, 1, 2, 2, 0, 1, 2, 3,
+                                            4, 5, 6, 7, 0, 1, 2, 3, 0, 1, 2, 3 };
+
+  viskores::cont::DataSet data3D = builder.Create(coords3D, shapes3D, numIndices3D, connectivity3D);
+  const viskores::Float32 cellvar3D[4] = { 11.0f, 22.0f, 33.0f, 44.0f };
+  data3D.AddCellField("cellvar", cellvar3D, 4);
+
+  viskores::cont::DataSet out3D = clean.Execute(data3D);
+  viskores::cont::CellSetExplicit<> out3DCells = GetExplicitCellSet(out3D);
+  VISKORES_TEST_ASSERT(out3D.GetNumberOfCells() == 2, "Wrong number of 3D cells.");
+  VISKORES_TEST_ASSERT(out3DCells.GetCellShape(0) == viskores::CELL_SHAPE_TETRA,
+                       "First 3D cell should be the valid tetra.");
+  VISKORES_TEST_ASSERT(out3DCells.GetCellShape(1) == viskores::CELL_SHAPE_HEXAHEDRON,
+                       "Second 3D cell should be the valid hexahedron.");
+
+  viskores::cont::ArrayHandle<viskores::Float32> out3DCellField;
+  out3D.GetField("cellvar").GetData().AsArrayHandle(out3DCellField);
+  VISKORES_TEST_ASSERT(test_equal(out3DCellField.ReadPortal().Get(0), 11.0f),
+                       "Wrong 3D cell field value.");
+  VISKORES_TEST_ASSERT(test_equal(out3DCellField.ReadPortal().Get(1), 33.0f),
+                       "Wrong 3D cell field value.");
+}
+
+// Check more than output sizes when points merge: merged topology, averaged
+// point fields, and merged coordinates all need to remain consistent.
+void TestPointMergeDetails()
+{
+  std::cout << "Testing point merge coordinates, connectivity, and fields." << std::endl;
+
+  std::vector<viskores::Vec3f_32> coords{ viskores::Vec3f_32(0.0f, 0.0f, 0.0f),
+                                          viskores::Vec3f_32(0.0f, 0.0f, 0.0f),
+                                          viskores::Vec3f_32(1.0f, 0.0f, 0.0f),
+                                          viskores::Vec3f_32(0.0f, 1.0f, 0.0f) };
+  viskores::cont::DataSet inData = MakeTwoTriangleDataSet(coords);
+  const viskores::Float32 pointvar[4] = { 10.0f, 30.0f, 100.0f, 200.0f };
+  const viskores::Float32 cellvar[2] = { 7.0f, 8.0f };
+  inData.AddPointField("pointvar", pointvar, 4);
+  inData.AddCellField("cellvar", cellvar, 2);
+
+  viskores::filter::clean_grid::CleanGrid clean;
+  clean.SetFieldsToPass({ "pointvar", "cellvar" });
+  clean.SetCompactPointFields(false);
+  clean.SetMergePoints(true);
+  clean.SetFastMerge(false);
+  clean.SetToleranceIsAbsolute(true);
+  clean.SetTolerance(0.01);
+  clean.SetRemoveDegenerateCells(false);
+
+  viskores::cont::DataSet outData = clean.Execute(inData);
+  VISKORES_TEST_ASSERT(outData.GetNumberOfPoints() == 3, "Duplicate points were not merged.");
+
+  viskores::cont::CellSetExplicit<> outCellSet = GetExplicitCellSet(outData);
+  VISKORES_TEST_ASSERT(outCellSet.GetNumberOfCells() == 2, "Wrong number of cells after merge.");
+  viskores::Id3 cellIds;
+  outCellSet.GetIndices(0, cellIds);
+  VISKORES_TEST_ASSERT((cellIds == viskores::Id3(0, 1, 2)), "Bad merged cell ids: ", cellIds);
+  outCellSet.GetIndices(1, cellIds);
+  VISKORES_TEST_ASSERT((cellIds == viskores::Id3(0, 1, 2)), "Bad merged cell ids: ", cellIds);
+
+  viskores::cont::ArrayHandle<viskores::Float32> outPointField;
+  outData.GetField("pointvar").GetData().AsArrayHandle(outPointField);
+  VISKORES_TEST_ASSERT(test_equal(outPointField.ReadPortal().Get(0), 20.0f),
+                       "Merged point field should be averaged.");
+  VISKORES_TEST_ASSERT(test_equal(outPointField.ReadPortal().Get(1), 100.0f),
+                       "Wrong point field value after merge.");
+  VISKORES_TEST_ASSERT(test_equal(outPointField.ReadPortal().Get(2), 200.0f),
+                       "Wrong point field value after merge.");
+
+  viskores::cont::ArrayHandle<viskores::Vec3f> outCoords;
+  outData.GetCoordinateSystem().GetData().AsArrayHandle(outCoords);
+  VISKORES_TEST_ASSERT(test_equal(outCoords.ReadPortal().Get(0), viskores::Vec3f(0.0f)),
+                       "Wrong merged coordinate.");
+}
+
+// Use the same coordinates with relative and absolute tolerance settings. The
+// large bounds diagonal makes the default relative tolerance merge points that
+// the same absolute tolerance should keep separate.
+void TestToleranceModes()
+{
+  std::cout << "Testing relative and absolute tolerances." << std::endl;
+
+  std::vector<viskores::Vec3f_32> coords{ viskores::Vec3f_32(0.0f, 0.0f, 0.0f),
+                                          viskores::Vec3f_32(0.5f, 0.0f, 0.0f),
+                                          viskores::Vec3f_32(1000000.0f, 0.0f, 0.0f),
+                                          viskores::Vec3f_32(0.0f, 10.0f, 0.0f) };
+
+  viskores::filter::clean_grid::CleanGrid relativeTolerance;
+  relativeTolerance.SetCompactPointFields(false);
+  relativeTolerance.SetMergePoints(true);
+  relativeTolerance.SetFastMerge(false);
+  relativeTolerance.SetRemoveDegenerateCells(false);
+  relativeTolerance.SetTolerance(1.0e-6);
+  relativeTolerance.SetToleranceIsAbsolute(false);
+
+  viskores::cont::DataSet relativeOut = relativeTolerance.Execute(MakeTwoTriangleDataSet(coords));
+  VISKORES_TEST_ASSERT(relativeOut.GetNumberOfPoints() == 3,
+                       "Relative tolerance should scale with the bounds diagonal.");
+
+  viskores::filter::clean_grid::CleanGrid absoluteTolerance = relativeTolerance;
+  absoluteTolerance.SetToleranceIsAbsolute(true);
+  viskores::cont::DataSet absoluteOut = absoluteTolerance.Execute(MakeTwoTriangleDataSet(coords));
+  VISKORES_TEST_ASSERT(absoluteOut.GetNumberOfPoints() == 4,
+                       "Absolute tolerance should not scale with the bounds diagonal.");
+}
+
+// Place two close points on opposite sides of a merge bin boundary. Non-fast
+// merge should find them with shifted bins; fast merge should not do that extra
+// pass.
+void TestFastMergeBoundary()
+{
+  std::cout << "Testing non-fast merge across a bin boundary." << std::endl;
+
+  std::vector<viskores::Vec3f_32> coords{ viskores::Vec3f_32(0.19f, 0.0f, 0.0f),
+                                          viskores::Vec3f_32(0.21f, 0.0f, 0.0f),
+                                          viskores::Vec3f_32(1.0f, 0.0f, 0.0f),
+                                          viskores::Vec3f_32(0.0f, 1.0f, 0.0f) };
+
+  viskores::filter::clean_grid::CleanGrid clean;
+  clean.SetCompactPointFields(false);
+  clean.SetMergePoints(true);
+  clean.SetRemoveDegenerateCells(false);
+  clean.SetToleranceIsAbsolute(true);
+  clean.SetTolerance(0.1);
+
+  clean.SetFastMerge(false);
+  viskores::cont::DataSet nonFastOut = clean.Execute(MakeTwoTriangleDataSet(coords));
+  VISKORES_TEST_ASSERT(nonFastOut.GetNumberOfPoints() == 3,
+                       "Non-fast merge should find points straddling a bin boundary.");
+
+  clean.SetFastMerge(true);
+  viskores::cont::DataSet fastOut = clean.Execute(MakeTwoTriangleDataSet(coords));
+  VISKORES_TEST_ASSERT(fastOut.GetNumberOfPoints() == 4,
+                       "Fast merge should not run shifted-bin passes.");
+}
+
+// Use two coordinate systems with different duplicate-point structure to verify
+// that CleanGrid merges according to the selected active coordinate system.
+void TestActiveCoordinateSystem()
+{
+  std::cout << "Testing active coordinate system for point merging." << std::endl;
+
+  std::vector<viskores::Vec3f_32> coords{ viskores::Vec3f_32(0.0f, 0.0f, 0.0f),
+                                          viskores::Vec3f_32(1.0f, 0.0f, 0.0f),
+                                          viskores::Vec3f_32(2.0f, 0.0f, 0.0f),
+                                          viskores::Vec3f_32(0.0f, 1.0f, 0.0f) };
+  viskores::cont::DataSet inData = MakeTwoTriangleDataSet(coords);
+
+  std::vector<viskores::Vec3f_32> mergeCoords{ viskores::Vec3f_32(0.0f, 0.0f, 0.0f),
+                                               viskores::Vec3f_32(0.0f, 0.0f, 0.0f),
+                                               viskores::Vec3f_32(2.0f, 0.0f, 0.0f),
+                                               viskores::Vec3f_32(0.0f, 1.0f, 0.0f) };
+  inData.AddCoordinateSystem(viskores::cont::CoordinateSystem(
+    "mergecoords", viskores::cont::make_ArrayHandle(mergeCoords, viskores::CopyFlag::On)));
+
+  viskores::filter::clean_grid::CleanGrid clean;
+  clean.SetCompactPointFields(false);
+  clean.SetMergePoints(true);
+  clean.SetFastMerge(false);
+  clean.SetRemoveDegenerateCells(false);
+  clean.SetToleranceIsAbsolute(true);
+  clean.SetTolerance(0.01);
+
+  viskores::cont::DataSet defaultCoordsOut = clean.Execute(inData);
+  VISKORES_TEST_ASSERT(defaultCoordsOut.GetNumberOfPoints() == 4,
+                       "Default coordinate system should not merge points.");
+
+  clean.SetActiveCoordinateSystem(1);
+  viskores::cont::DataSet mergeCoordsOut = clean.Execute(inData);
+  VISKORES_TEST_ASSERT(mergeCoordsOut.GetNumberOfPoints() == 3,
+                       "Active coordinate system was not used for point merging.");
 }
 
 void TestPointMerging()
@@ -186,6 +501,24 @@ void RunTest()
 
   std::cout << "*** Test point merging" << std::endl;
   TestPointMerging();
+
+  std::cout << "*** Test compact point fields" << std::endl;
+  TestCompactPointFields();
+
+  std::cout << "*** Test degenerate cell removal" << std::endl;
+  TestDegenerateCellRemoval();
+
+  std::cout << "*** Test detailed point merging" << std::endl;
+  TestPointMergeDetails();
+
+  std::cout << "*** Test tolerance modes" << std::endl;
+  TestToleranceModes();
+
+  std::cout << "*** Test fast merge boundary" << std::endl;
+  TestFastMergeBoundary();
+
+  std::cout << "*** Test active coordinate system" << std::endl;
+  TestActiveCoordinateSystem();
 }
 
 } // anonymous namespace

--- a/viskores/filter/clean_grid/worklet/RemoveDegenerateCells.h
+++ b/viskores/filter/clean_grid/worklet/RemoveDegenerateCells.h
@@ -29,6 +29,7 @@
 #include <viskores/worklet/CellDeepCopy.h>
 
 #include <viskores/CellTraits.h>
+#include <viskores/VecVariable.h>
 
 #include <viskores/exec/CellFace.h>
 
@@ -91,9 +92,23 @@ struct RemoveDegenerateCells
       viskores::Id numValidFaces = 0;
       for (viskores::IdComponent faceId = 0; faceId < numFaces; ++faceId)
       {
+        // Check each face independently. A collapsed 3D cell can still have
+        // enough unique point ids overall even when some faces lose
+        // dimensionality.
+        viskores::IdComponent numFacePoints = 0;
+        viskores::exec::CellFaceNumberOfPoints(faceId, shape, numFacePoints);
+
+        viskores::VecVariable<viskores::Id, 4> facePointIds;
+        for (viskores::IdComponent facePointId = 0; facePointId < numFacePoints; ++facePointId)
+        {
+          viskores::IdComponent localPointId = 0;
+          viskores::exec::CellFaceLocalIndex(facePointId, faceId, shape, localPointId);
+          facePointIds.Append(pointIds[localPointId]);
+        }
+
         if (this->CheckForDimensionality(viskores::CellTopologicalDimensionsTag<2>(),
                                          viskores::CellShapeTagPolygon(),
-                                         pointIds))
+                                         facePointIds))
         {
           ++numValidFaces;
           if (numValidFaces > 2)


### PR DESCRIPTION
Improves CleanGrid coverage and fixes degenerate 3D cell detection.

## Changes

- Adds explicit CleanGrid tests for:
  - unused point compaction on/off
  - 2D and 3D degenerate cell removal
  - merged point connectivity, coordinates, and averaged point fields
  - relative vs absolute merge tolerance
  - fast vs non-fast merge behavior across bin boundaries
  - active coordinate system selection
- Adds comments explaining the intent of the new test cases.
- Fixes 3D degenerate-cell detection to check each face's point ids instead of checking the full cell point list repeatedly.
- Fixes two existing assertion diagnostic values in `UnitTestCleanGrid`.