### PR TITLE
Add ANARIDevice management object

### DIFF
--- a/.gitlab/ci/ubuntu2004.yml
+++ b/.gitlab/ci/ubuntu2004.yml
@@ -28,6 +28,7 @@ ubuntu2004_kokkos37:
     CMAKE_BUILD_TYPE: RelWithDebInfo
     CMAKE_PREFIX_PATH: "/opt/anari"
     VISKORES_SETTINGS: "kokkos+shared+64bit_floats+rendering+anari+ccache"
+    VISKORES_TEST_ANARI_LIBRARY: "helide"
 
 ubuntu2004_gcc9:
   extends:

--- a/docs/changelog/anari-device.md
+++ b/docs/changelog/anari-device.md
@@ -6,6 +6,11 @@ portable, accelerated ANARI device that will be available in HPC systems
 regardless of vendor support. We hope this will help jumpstart the support of
 ANARI for scientific visualization applications at HPC centers.
 
+The anari interop library now contains a class named `ANARIDevice` that manages
+an ANARI device. In addition to making sure resources get created and destroyed
+correctly, it can find the built in Viskores device without having to rely on
+the user's environment.
+
 This device is still in its experimental phase. Although functional, it is
 missing many features that applications will expect to be supported. The
 inclusion of the device into Viskores in this early phase should help promote

--- a/viskores/interop/anari/ANARIDevice.cxx
+++ b/viskores/interop/anari/ANARIDevice.cxx
@@ -1,0 +1,142 @@
+//============================================================================
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//============================================================================
+
+#include <viskores/interop/anari/ANARIDevice.h>
+
+#include <viskores/cont/ErrorBadDevice.h>
+#include <viskores/cont/Logging.h>
+
+#include <viskores/rendering/anari-device/ViskoresDevice.h>
+
+namespace
+{
+
+static void AnariStatusFunc(const void* viskoresNotUsed(userData),
+                            ANARIDevice viskoresNotUsed(device),
+                            ANARIObject source,
+                            ANARIDataType viskoresNotUsed(sourceType),
+                            ANARIStatusSeverity severity,
+                            ANARIStatusCode viskoresNotUsed(code),
+                            const char* message)
+{
+  viskores::cont::LogLevel level;
+  switch (severity)
+  {
+    case ANARI_SEVERITY_FATAL_ERROR:
+      level = viskores::cont::LogLevel::Fatal;
+      break;
+    case ANARI_SEVERITY_ERROR:
+      level = viskores::cont::LogLevel::Error;
+      break;
+    case ANARI_SEVERITY_WARNING:
+    case ANARI_SEVERITY_PERFORMANCE_WARNING:
+      level = viskores::cont::LogLevel::Warn;
+      break;
+    case ANARI_SEVERITY_INFO:
+      level = viskores::cont::LogLevel::Info;
+      break;
+    case ANARI_SEVERITY_DEBUG:
+    default:
+      level = viskores::cont::LogLevel::UserVerboseFirst;
+      break;
+  }
+
+  VISKORES_LOG_S(level, "[ANARI Object " << source << "] " << message);
+}
+
+} // anonymous namespace
+
+namespace viskores
+{
+namespace interop
+{
+namespace anari
+{
+
+void ANARIDevice::SetDeviceName(const std::string& deviceName)
+{
+  if (deviceName != this->DeviceName)
+  {
+    this->Unload();
+    this->DeviceName = deviceName;
+  }
+  else
+  {
+    // NoOp
+  }
+}
+
+bool ANARIDevice::IsValid()
+{
+  this->AttemptLoad();
+  return this->IsLoaded();
+}
+
+void ANARIDevice::EnsureLoad()
+{
+  this->AttemptLoad();
+  if (!this->IsLoaded())
+  {
+    throw viskores::cont::ErrorBadDevice("Failed to load ANARI device named " + this->DeviceName);
+  }
+}
+
+void ANARIDevice::Reload()
+{
+  this->Unload();
+  this->EnsureLoad();
+}
+
+void ANARIDevice::Unload()
+{
+  this->Device.reset();
+}
+
+void ANARIDevice::AttemptLoad()
+{
+  if (this->IsLoaded())
+  {
+    return;
+  }
+
+  if (this->DeviceName == "viskores")
+  {
+    VISKORES_LOG_F(viskores::cont::LogLevel::Info,
+                   "Directly loading internal ANARI device named `viskores`");
+    this->Device.reset(reinterpret_cast<anari_cpp::Device>(
+      new viskores_device::ViskoresDevice(AnariStatusFunc, nullptr)));
+  }
+  else
+  {
+    VISKORES_LOG_S(viskores::cont::LogLevel::Info,
+                   "Loading ANARI library named `" << this->DeviceName << "`");
+    anari_cpp::Library library =
+      anari_cpp::loadLibrary(this->DeviceName.c_str(), AnariStatusFunc, nullptr);
+    if (library == nullptr)
+    {
+      VISKORES_LOG_S(viskores::cont::LogLevel::Info,
+                     "Failed to load ANARI library named `" << this->DeviceName << "`");
+      return;
+    }
+    anari_cpp::Device device = anari_cpp::newDevice(library, "default");
+    anari_cpp::unloadLibrary(library);
+    if (device != nullptr)
+    {
+      this->Device.reset(device);
+    }
+    else
+    {
+      VISKORES_LOG_S(viskores::cont::LogLevel::Info,
+                     "Failed to load ANARI device from library named `" << this->DeviceName << "`");
+    }
+  }
+}
+
+}
+}
+} // namespace viskores::interop::anari

--- a/viskores/interop/anari/ANARIDevice.h
+++ b/viskores/interop/anari/ANARIDevice.h
@@ -1,0 +1,116 @@
+//============================================================================
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//============================================================================
+
+#ifndef viskores_interop_anari_ANARILoadLibrary_h
+#define viskores_interop_anari_ANARILoadLibrary_h
+
+#include <viskores/Assert.h>
+#include <viskores/interop/anari/ViskoresANARITypes.h>
+#include <viskores/interop/anari/viskores_anari_export.h>
+
+#include <memory>
+#include <type_traits>
+
+namespace viskores
+{
+namespace interop
+{
+namespace anari
+{
+
+/// @brief A management object for an ANARI device.
+///
+/// This class provides a convenience wrapper around an ANARI device object
+/// (`anari::Device`). It provides two main functions.
+///
+/// First, this object behaves as a reference management for the ANARI device
+/// object. The ANARI device will be held as long as it is referenced, and it
+/// will be deleted once it is no longer used.
+///
+/// Second, this object will automatically load the ANARI device by name. By
+/// default, it will load the device compiled with Viskores, but it can find
+/// other libraries by name. As the library is loaded, it will connect its
+/// logging to Viskores' logging.
+///
+/// By default, `ANARIDevice` will load the `viskores` device. However, you can
+/// use this class to load other ANARI devices by name.
+///
+/// This class can be used in place of an `anari::Device` object. When passed
+/// to a function that expects an `anari::Device`, the object will get
+/// automatically converted.
+///
+class VISKORES_ANARI_EXPORT ANARIDevice
+{
+  std::shared_ptr<std::remove_pointer_t<anari_cpp::Device>> Device;
+  std::string DeviceName = "viskores";
+
+public:
+  ANARIDevice() = default;
+
+  /// @brief Sets the name of the device to load.
+  ///
+  /// If a device of a different name is already loaded, it will be unloaded.
+  void SetDeviceName(const std::string& deviceName);
+
+  /// @brief Returns the name of the device loaded or to be loaded.
+  std::string GetDeviceName() const { return this->DeviceName; }
+
+  /// @brief Returns the currently loaded device.
+  ///
+  /// If the device has not already been loaded, it will be loaded first. If it
+  /// fails to load the device, it will throw `viskores::cont::ErrorBadDevice`.
+  ///
+  /// @return An ANARI device object.
+  anari_cpp::Device GetDevice()
+  {
+    if (!this->IsLoaded())
+    {
+      this->EnsureLoad();
+    }
+    VISKORES_ASSERT(this->Device);
+    return this->Device.get();
+  }
+
+  /// @brief Automatically convert this object to an ANARI device.
+  operator anari_cpp::Device() { return this->GetDevice(); }
+
+  /// @brief Returns whether the ANARI device is already loaded.
+  bool IsLoaded() const { return static_cast<bool>(this->Device); }
+
+  /// @brief Returns whether the ANARI device is valid.
+  ///
+  /// If the device is not already loaded, this method will attempt to load it.
+  /// No exception will be thrown if the device fails to load.
+  bool IsValid();
+
+  /// @brief Ensure that the ANARI device is loaded.
+  ///
+  /// This method will attempt to load the ANARI device if it is not already
+  /// loaded. If the device fails to load, it will throw
+  /// `viskores::cont::ErrorBadDevice`.
+  void EnsureLoad();
+
+  /// @brief Reloads the ANARI device.
+  ///
+  /// This method will unload any currently loaded device and attempt to load the
+  /// device. If the device fails to load, it will throw
+  /// `viskores::cont::ErrorBadDevice`.
+  void Reload();
+
+  /// @brief Frees the current device.
+  void Unload();
+
+private:
+  void AttemptLoad();
+};
+
+}
+}
+} // namespace viskores::interop::anari
+
+#endif //viskores_interop_anari_ANARILoadLibrary_h

--- a/viskores/interop/anari/ANARIMapper.cxx
+++ b/viskores/interop/anari/ANARIMapper.cxx
@@ -25,7 +25,7 @@ namespace interop
 namespace anari
 {
 
-ANARIMapper::ANARIMapper(anari_cpp::Device device,
+ANARIMapper::ANARIMapper(viskores::interop::anari::ANARIDevice device,
                          const ANARIActor& actor,
                          const std::string& name,
                          const viskores::cont::ColorTable& colorTable)
@@ -35,10 +35,9 @@ ANARIMapper::ANARIMapper(anari_cpp::Device device,
 {
   this->Handles = std::make_shared<ANARIHandles>();
   this->Handles->Device = device;
-  anari_cpp::retain(device, device);
 }
 
-anari_cpp::Device ANARIMapper::GetDevice() const
+viskores::interop::anari::ANARIDevice ANARIMapper::GetDevice() const
 {
   return this->Handles->Device;
 }
@@ -201,7 +200,6 @@ ANARIMapper::ANARIHandles::~ANARIHandles()
 {
   anari_cpp::release(this->Device, this->Group);
   anari_cpp::release(this->Device, this->Instance);
-  anari_cpp::release(this->Device, this->Device);
 }
 
 } // namespace anari

--- a/viskores/interop/anari/ANARIMapper.h
+++ b/viskores/interop/anari/ANARIMapper.h
@@ -22,6 +22,7 @@
 // viskores
 #include <viskores/cont/ColorTable.h>
 #include <viskores/interop/anari/ANARIActor.h>
+#include <viskores/interop/anari/ANARIDevice.h>
 
 #include <viskores/interop/anari/viskores_anari_export.h>
 
@@ -45,13 +46,13 @@ inline void NoopANARIDeleter(const void*, const void*) {}
 struct VISKORES_ANARI_EXPORT ANARIMapper
 {
   ANARIMapper(
-    anari_cpp::Device device,
+    viskores::interop::anari::ANARIDevice device,
     const ANARIActor& actor = {},
     const std::string& name = "<noname>",
     const viskores::cont::ColorTable& colorTable = viskores::cont::ColorTable::Preset::Default);
   virtual ~ANARIMapper() = default;
 
-  anari_cpp::Device GetDevice() const;
+  viskores::interop::anari::ANARIDevice GetDevice() const;
   const ANARIActor& GetActor() const;
   const char* GetName() const;
   const viskores::cont::ColorTable& GetColorTable() const;
@@ -128,7 +129,7 @@ protected:
 private:
   struct ANARIHandles
   {
-    anari_cpp::Device Device{ nullptr };
+    viskores::interop::anari::ANARIDevice Device;
     anari_cpp::Group Group{ nullptr };
     anari_cpp::Instance Instance{ nullptr };
     ~ANARIHandles();

--- a/viskores/interop/anari/ANARIMapperGlyphs.cxx
+++ b/viskores/interop/anari/ANARIMapperGlyphs.cxx
@@ -144,7 +144,7 @@ static GlyphArrays MakeGlyphs(viskores::cont::Field gradients,
 
 // ANARIMapperGlyphs definitions //////////////////////////////////////////////
 
-ANARIMapperGlyphs::ANARIMapperGlyphs(anari_cpp::Device device,
+ANARIMapperGlyphs::ANARIMapperGlyphs(viskores::interop::anari::ANARIDevice device,
                                      const ANARIActor& actor,
                                      const char* name,
                                      const viskores::cont::ColorTable& colorTable)
@@ -152,7 +152,6 @@ ANARIMapperGlyphs::ANARIMapperGlyphs(anari_cpp::Device device,
 {
   this->Handles = std::make_shared<ANARIMapperGlyphs::ANARIHandles>();
   this->Handles->Device = device;
-  anari_cpp::retain(device, device);
 }
 
 ANARIMapperGlyphs::~ANARIMapperGlyphs()
@@ -291,7 +290,6 @@ ANARIMapperGlyphs::ANARIHandles::~ANARIHandles()
   anari_cpp::release(this->Device, this->Surface);
   anari_cpp::release(this->Device, this->Material);
   anari_cpp::release(this->Device, this->Geometry);
-  anari_cpp::release(this->Device, this->Device);
 }
 
 void ANARIMapperGlyphs::ANARIHandles::ReleaseArrays()

--- a/viskores/interop/anari/ANARIMapperGlyphs.h
+++ b/viskores/interop/anari/ANARIMapperGlyphs.h
@@ -59,7 +59,7 @@ struct VISKORES_ANARI_EXPORT ANARIMapperGlyphs : public ANARIMapper
   /// @brief Constructor
   ///
   ANARIMapperGlyphs(
-    anari_cpp::Device device,
+    viskores::interop::anari::ANARIDevice device,
     const ANARIActor& actor = {},
     const char* name = "<glyphs>",
     const viskores::cont::ColorTable& colorTable = viskores::cont::ColorTable::Preset::Default);
@@ -104,7 +104,7 @@ private:
   /// @brief Container of all relevant ANARI scene object handles.
   struct ANARIHandles
   {
-    anari_cpp::Device Device{ nullptr };
+    viskores::interop::anari::ANARIDevice Device;
     anari_cpp::Geometry Geometry{ nullptr };
     anari_cpp::Material Material{ nullptr };
     anari_cpp::Surface Surface{ nullptr };

--- a/viskores/interop/anari/ANARIMapperPoints.cxx
+++ b/viskores/interop/anari/ANARIMapperPoints.cxx
@@ -119,7 +119,7 @@ static PointsArrays UnpackPoints(viskores::cont::ArrayHandle<viskores::Id> point
 
 // ANARIMapperPoints definitions //////////////////////////////////////////////
 
-ANARIMapperPoints::ANARIMapperPoints(anari_cpp::Device device,
+ANARIMapperPoints::ANARIMapperPoints(viskores::interop::anari::ANARIDevice device,
                                      const ANARIActor& actor,
                                      const std::string& name,
                                      const viskores::cont::ColorTable& colorTable)
@@ -129,7 +129,6 @@ ANARIMapperPoints::ANARIMapperPoints(anari_cpp::Device device,
   this->Handles->Device = device;
   auto& attributes = this->Handles->Parameters.Vertex.Attribute;
   std::fill(attributes.begin(), attributes.end(), nullptr);
-  anari_cpp::retain(device, device);
 }
 
 ANARIMapperPoints::~ANARIMapperPoints()
@@ -447,7 +446,6 @@ ANARIMapperPoints::ANARIHandles::~ANARIHandles()
   anari_cpp::release(this->Device, this->Material);
   anari_cpp::release(this->Device, this->Sampler);
   anari_cpp::release(this->Device, this->Geometry);
-  anari_cpp::release(this->Device, this->Device);
 }
 
 void ANARIMapperPoints::ANARIHandles::ReleaseArrays()

--- a/viskores/interop/anari/ANARIMapperPoints.h
+++ b/viskores/interop/anari/ANARIMapperPoints.h
@@ -81,7 +81,7 @@ struct VISKORES_ANARI_EXPORT ANARIMapperPoints : public ANARIMapper
   /// @brief Constructor
   ///
   ANARIMapperPoints(
-    anari_cpp::Device device,
+    viskores::interop::anari::ANARIDevice device,
     const ANARIActor& actor = {},
     const std::string& name = "<points>",
     const viskores::cont::ColorTable& colorTable = viskores::cont::ColorTable::Preset::Default);
@@ -127,7 +127,7 @@ private:
   /// @brief Container of all relevant ANARI scene object handles.
   struct ANARIHandles
   {
-    anari_cpp::Device Device{ nullptr };
+    viskores::interop::anari::ANARIDevice Device;
     anari_cpp::Geometry Geometry{ nullptr };
     anari_cpp::Sampler Sampler{ nullptr };
     anari_cpp::Material Material{ nullptr };

--- a/viskores/interop/anari/ANARIMapperTriangles.cxx
+++ b/viskores/interop/anari/ANARIMapperTriangles.cxx
@@ -286,7 +286,7 @@ static TriangleArrays UnpackTriangles(viskores::cont::ArrayHandle<viskores::Id4>
 
 // ANARIMapperTriangles definitions ///////////////////////////////////////////
 
-ANARIMapperTriangles::ANARIMapperTriangles(anari_cpp::Device device,
+ANARIMapperTriangles::ANARIMapperTriangles(viskores::interop::anari::ANARIDevice device,
                                            const ANARIActor& actor,
                                            const std::string& name,
                                            const viskores::cont::ColorTable& colorTable)
@@ -296,7 +296,6 @@ ANARIMapperTriangles::ANARIMapperTriangles(anari_cpp::Device device,
   this->Handles->Device = device;
   auto& attributes = this->Handles->Parameters.Vertex.Attribute;
   std::fill(attributes.begin(), attributes.end(), nullptr);
-  anari_cpp::retain(device, device);
 }
 
 ANARIMapperTriangles::~ANARIMapperTriangles()
@@ -646,7 +645,6 @@ ANARIMapperTriangles::ANARIHandles::~ANARIHandles()
   anari_cpp::release(this->Device, this->Material);
   anari_cpp::release(this->Device, this->Sampler);
   anari_cpp::release(this->Device, this->Geometry);
-  anari_cpp::release(this->Device, this->Device);
 }
 
 void ANARIMapperTriangles::ANARIHandles::ReleaseArrays()

--- a/viskores/interop/anari/ANARIMapperTriangles.h
+++ b/viskores/interop/anari/ANARIMapperTriangles.h
@@ -82,7 +82,7 @@ struct VISKORES_ANARI_EXPORT ANARIMapperTriangles : public ANARIMapper
   /// @brief Constructor
   ///
   ANARIMapperTriangles(
-    anari_cpp::Device device,
+    viskores::interop::anari::ANARIDevice device,
     const ANARIActor& actor = {},
     const std::string& name = "<triangles>",
     const viskores::cont::ColorTable& colorTable = viskores::cont::ColorTable::Preset::Default);
@@ -133,7 +133,7 @@ private:
   /// @brief Container of all relevant ANARI scene object handles.
   struct ANARIHandles
   {
-    anari_cpp::Device Device{ nullptr };
+    viskores::interop::anari::ANARIDevice Device;
     anari_cpp::Geometry Geometry{ nullptr };
     anari_cpp::Sampler Sampler{ nullptr };
     anari_cpp::Material Material{ nullptr };

--- a/viskores/interop/anari/ANARIMapperVolume.cxx
+++ b/viskores/interop/anari/ANARIMapperVolume.cxx
@@ -28,7 +28,7 @@ namespace interop
 namespace anari
 {
 
-ANARIMapperVolume::ANARIMapperVolume(anari_cpp::Device device,
+ANARIMapperVolume::ANARIMapperVolume(viskores::interop::anari::ANARIDevice device,
                                      const ANARIActor& actor,
                                      const std::string& name,
                                      const viskores::cont::ColorTable& colorTable)
@@ -36,7 +36,6 @@ ANARIMapperVolume::ANARIMapperVolume(anari_cpp::Device device,
 {
   this->Handles = std::make_shared<ANARIMapperVolume::ANARIHandles>();
   this->Handles->Device = device;
-  anari_cpp::retain(device, device);
 }
 
 ANARIMapperVolume::~ANARIMapperVolume()
@@ -414,7 +413,6 @@ ANARIMapperVolume::ANARIHandles::~ANARIHandles()
   this->ReleaseArrays();
   anari_cpp::release(this->Device, this->Volume);
   anari_cpp::release(this->Device, this->SpatialField);
-  anari_cpp::release(this->Device, this->Device);
 }
 
 void ANARIMapperVolume::ANARIHandles::ReleaseArrays()

--- a/viskores/interop/anari/ANARIMapperVolume.h
+++ b/viskores/interop/anari/ANARIMapperVolume.h
@@ -77,7 +77,7 @@ struct VISKORES_ANARI_EXPORT ANARIMapperVolume : public ANARIMapper
   /// @brief Constructor
   ///
   ANARIMapperVolume(
-    anari_cpp::Device device,
+    viskores::interop::anari::ANARIDevice device,
     const ANARIActor& actor = {},
     const std::string& name = "<volume>",
     const viskores::cont::ColorTable& colorTable = viskores::cont::ColorTable::Preset::Default);
@@ -119,7 +119,7 @@ private:
   /// @brief Container of all relevant ANARI scene object handles.
   struct ANARIHandles
   {
-    anari_cpp::Device Device{ nullptr };
+    viskores::interop::anari::ANARIDevice Device;
     anari_cpp::SpatialField SpatialField{ nullptr };
     anari_cpp::Volume Volume{ nullptr };
     StructuredVolumeParameters StructuredParameters;

--- a/viskores/interop/anari/ANARIScene.cxx
+++ b/viskores/interop/anari/ANARIScene.cxx
@@ -27,16 +27,14 @@ namespace interop
 namespace anari
 {
 
-ANARIScene::ANARIScene(anari_cpp::Device device)
+ANARIScene::ANARIScene(viskores::interop::anari::ANARIDevice device)
   : Device(device)
 {
-  anari_cpp::retain(this->Device, this->Device);
 }
 
 ANARIScene::~ANARIScene()
 {
   anari_cpp::release(this->Device, this->World);
-  anari_cpp::release(this->Device, this->Device);
 }
 
 viskores::IdComponent ANARIScene::GetNumberOfMappers() const
@@ -113,7 +111,7 @@ void ANARIScene::RemoveAllMappers()
   this->UpdateWorld();
 }
 
-anari_cpp::Device ANARIScene::GetDevice() const
+viskores::interop::anari::ANARIDevice ANARIScene::GetDevice() const
 {
   return this->Device;
 }

--- a/viskores/interop/anari/ANARIScene.h
+++ b/viskores/interop/anari/ANARIScene.h
@@ -53,7 +53,7 @@ struct VISKORES_ANARI_EXPORT ANARIScene
 {
   /// @brief Constructor
   ///
-  ANARIScene(anari_cpp::Device device);
+  ANARIScene(viskores::interop::anari::ANARIDevice device);
 
   /// @brief Destructor
   ///
@@ -119,7 +119,7 @@ struct VISKORES_ANARI_EXPORT ANARIScene
   /// @brief Get the `ANARIDevice` handle this scene is talking to.
   ///
   /// NOTE: This handle is not retained, so applications should not release it.
-  anari_cpp::Device GetDevice() const;
+  viskores::interop::anari::ANARIDevice GetDevice() const;
 
   /// @brief Get the `ANARIWorld` handle this scene is working on.
   ///
@@ -129,7 +129,7 @@ struct VISKORES_ANARI_EXPORT ANARIScene
 private:
   void UpdateWorld();
 
-  anari_cpp::Device Device{ nullptr };
+  viskores::interop::anari::ANARIDevice Device;
   anari_cpp::World World{ nullptr };
 
   struct SceneMapper

--- a/viskores/interop/anari/CMakeLists.txt
+++ b/viskores/interop/anari/CMakeLists.txt
@@ -20,6 +20,7 @@ find_package(anari 0.8.0 REQUIRED)
 
 set(headers
   ANARIActor.h
+  ANARIDevice.h
   ANARIMapper.h
   ANARIMapperGlyphs.h
   ANARIMapperPoints.h
@@ -31,6 +32,7 @@ set(headers
 
 set(sources
   ANARIActor.cxx
+  ANARIDevice.cxx
   ANARIMapper.cxx
   ANARIScene.cxx
   ViskoresANARITypes.cxx

--- a/viskores/interop/anari/testing/ANARITestCommon.h
+++ b/viskores/interop/anari/testing/ANARITestCommon.h
@@ -21,6 +21,7 @@
 
 // viskores
 #include <viskores/cont/DataSetBuilderUniform.h>
+#include <viskores/interop/anari/ANARIDevice.h>
 #include <viskores/interop/anari/ANARIMapper.h>
 #include <viskores/rendering/testing/Testing.h>
 #include <viskores/testing/Testing.h>
@@ -28,45 +29,8 @@
 namespace
 {
 
-static void StatusFunc(const void* userData,
-                       ANARIDevice /*device*/,
-                       ANARIObject source,
-                       ANARIDataType /*sourceType*/,
-                       ANARIStatusSeverity severity,
-                       ANARIStatusCode /*code*/,
-                       const char* message)
-{
-  bool verbose = *(bool*)userData;
-  if (!verbose)
-    return;
-
-  if (severity == ANARI_SEVERITY_FATAL_ERROR)
-  {
-    fprintf(stderr, "[FATAL][%p] %s\n", source, message);
-  }
-  else if (severity == ANARI_SEVERITY_ERROR)
-  {
-    fprintf(stderr, "[ERROR][%p] %s\n", source, message);
-  }
-  else if (severity == ANARI_SEVERITY_WARNING)
-  {
-    fprintf(stderr, "[WARN ][%p] %s\n", source, message);
-  }
-  else if (severity == ANARI_SEVERITY_PERFORMANCE_WARNING)
-  {
-    fprintf(stderr, "[PERF ][%p] %s\n", source, message);
-  }
-  else if (severity == ANARI_SEVERITY_INFO)
-  {
-    fprintf(stderr, "[INFO ][%p] %s\n", source, message);
-  }
-  else if (severity == ANARI_SEVERITY_DEBUG)
-  {
-    fprintf(stderr, "[DEBUG][%p] %s\n", source, message);
-  }
-}
-
-static void setColorMap(anari_cpp::Device d, viskores::interop::anari::ANARIMapper& mapper)
+static void setColorMap(viskores::interop::anari::ANARIDevice d,
+                        viskores::interop::anari::ANARIMapper& mapper)
 {
   auto colorArray = anari_cpp::newArray1D(d, ANARI_FLOAT32_VEC3, 3);
   auto* colors = anari_cpp::map<viskores::Vec3f_32>(d, colorArray);
@@ -86,18 +50,20 @@ static void setColorMap(anari_cpp::Device d, viskores::interop::anari::ANARIMapp
   mapper.SetANARIColorMapOpacityScale(0.5f);
 }
 
-static anari_cpp::Device loadANARIDevice()
+static viskores::interop::anari::ANARIDevice loadANARIDevice()
 {
   viskores::testing::FloatingPointExceptionTrapDisable();
+  viskores::interop::anari::ANARIDevice device;
   auto* libraryName = std::getenv("VISKORES_TEST_ANARI_LIBRARY");
-  static bool verbose = std::getenv("VISKORES_TEST_ANARI_VERBOSE") != nullptr;
-  auto lib = anari_cpp::loadLibrary(libraryName ? libraryName : "helide", StatusFunc, &verbose);
-  auto d = anari_cpp::newDevice(lib, "default");
-  anari_cpp::unloadLibrary(lib);
-  return d;
+  if (libraryName)
+  {
+    device.SetDeviceName(libraryName);
+  }
+  device.EnsureLoad();
+  return device;
 }
 
-static void renderTestANARIImage(anari_cpp::Device d,
+static void renderTestANARIImage(viskores::interop::anari::ANARIDevice d,
                                  anari_cpp::World w,
                                  viskores::Vec3f_32 cam_pos,
                                  viskores::Vec3f_32 cam_dir,

--- a/viskores/interop/anari/testing/UnitTestANARIMapperGlyphs.cxx
+++ b/viskores/interop/anari/testing/UnitTestANARIMapperGlyphs.cxx
@@ -88,11 +88,6 @@ void RenderTests()
                        viskores::Vec3f_32(0.f, -1.f, 0.f),
                        viskores::Vec3f_32(0.f, 0.f, 1.f),
                        "interop/anari/glyphs.png");
-
-  // Cleanup //////////////////////////////////////////////////////////////////
-
-  anari_cpp::release(d, world);
-  anari_cpp::release(d, d);
 }
 
 } // namespace

--- a/viskores/interop/anari/testing/UnitTestANARIMapperPoints.cxx
+++ b/viskores/interop/anari/testing/UnitTestANARIMapperPoints.cxx
@@ -81,7 +81,6 @@ void RenderTests()
   // Cleanup //////////////////////////////////////////////////////////////////
 
   anari_cpp::release(d, world);
-  anari_cpp::release(d, d);
 }
 
 } // namespace

--- a/viskores/interop/anari/testing/UnitTestANARIMapperTriangles.cxx
+++ b/viskores/interop/anari/testing/UnitTestANARIMapperTriangles.cxx
@@ -82,7 +82,6 @@ void RenderTests()
   // Cleanup //////////////////////////////////////////////////////////////////
 
   anari_cpp::release(d, world);
-  anari_cpp::release(d, d);
 }
 
 } // namespace

--- a/viskores/interop/anari/testing/UnitTestANARIMapperVolume.cxx
+++ b/viskores/interop/anari/testing/UnitTestANARIMapperVolume.cxx
@@ -71,7 +71,6 @@ void RenderTests()
   // Cleanup //////////////////////////////////////////////////////////////////
 
   anari_cpp::release(d, world);
-  anari_cpp::release(d, d);
 }
 
 } // namespace

--- a/viskores/interop/anari/testing/UnitTestANARIScene.cxx
+++ b/viskores/interop/anari/testing/UnitTestANARIScene.cxx
@@ -104,10 +104,6 @@ void RenderTests()
                        viskores::Vec3f_32(0.32, -0.53, -0.79),
                        viskores::Vec3f_32(-0.20, -0.85, 0.49),
                        "interop/anari/scene.png");
-
-  // Cleanup //////////////////////////////////////////////////////////////////
-
-  anari_cpp::release(d, d);
 }
 
 } // namespace

--- a/viskores/interop/anari/viskores.module
+++ b/viskores/interop/anari/viskores.module
@@ -7,6 +7,8 @@ DEPENDS
   viskores_filter_vector_analysis
   viskores_rendering
   viskores_worklet
+PRIVATE_DEPENDS
+  anari_library_viskores
 TEST_DEPENDS
   viskores_filter_vector_analysis
   viskores_filter_contour

--- a/viskores/rendering/anari-device/CMakeLists.txt
+++ b/viskores/rendering/anari-device/CMakeLists.txt
@@ -55,7 +55,7 @@ viskores_library(
   )
 
 target_link_libraries(anari_library_viskores
-PRIVATE
+PUBLIC
   anari::helium
   )
 

--- a/viskores/rendering/anari-device/ViskoresDevice.h
+++ b/viskores/rendering/anari-device/ViskoresDevice.h
@@ -16,10 +16,12 @@
 
 #include "Object.h"
 
+#include <viskores/rendering/anari-device/anari_library_viskores_export.h>
+
 namespace viskores_device
 {
 
-struct ViskoresDevice : public helium::BaseDevice
+struct ANARI_LIBRARY_VISKORES_EXPORT ViskoresDevice : public helium::BaseDevice
 {
   /////////////////////////////////////////////////////////////////////////////
   // Main interface to accepting API calls


### PR DESCRIPTION
The anari interop library now contains a class named `ANARIDevice` that manages an ANARI device. In addition to making sure resources get created and destroyed correctly, it can find the built in Viskores device without having to rely on the user's environment.