### PR TITLE
Add quad geometry to ANARI device.

### DIFF
--- a/viskores/interop/anari/testing/CMakeLists.txt
+++ b/viskores/interop/anari/testing/CMakeLists.txt
@@ -22,5 +22,6 @@ SOURCES
   UnitTestANARIMapperPoints.cxx
   UnitTestANARIMapperTriangles.cxx
   UnitTestANARIMapperVolume.cxx
+  UnitTestANARIGeometryQuad.cxx
   UnitTestANARIScene.cxx
   )

--- a/viskores/interop/anari/testing/UnitTestANARIGeometryQuad.cxx
+++ b/viskores/interop/anari/testing/UnitTestANARIGeometryQuad.cxx
@@ -1,0 +1,121 @@
+//============================================================================
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//============================================================================
+
+// viskores
+#include <viskores/cont/testing/Testing.h>
+#include <viskores/io/EncodePNG.h>
+
+#include "ANARITestCommon.h"
+
+namespace
+{
+
+void RenderTests()
+{
+  // Initialize ANARI /////////////////////////////////////////////////////////
+
+  auto d = loadANARIDevice();
+
+  // Create ANARI quad geometry //////////////////////////////////////////////
+
+  auto vertices = anari_cpp::newArray1D(d, ANARI_FLOAT32_VEC3, 8);
+  auto* positions = anari_cpp::map<viskores::Vec3f_32>(d, vertices);
+  positions[0] = viskores::Vec3f_32(-0.6f, -0.6f, -0.6f);
+  positions[1] = viskores::Vec3f_32(0.6f, -0.6f, -0.6f);
+  positions[2] = viskores::Vec3f_32(0.6f, 0.6f, -0.6f);
+  positions[3] = viskores::Vec3f_32(-0.6f, 0.6f, -0.6f);
+  positions[4] = viskores::Vec3f_32(-0.6f, -0.6f, 0.6f);
+  positions[5] = viskores::Vec3f_32(0.6f, -0.6f, 0.6f);
+  positions[6] = viskores::Vec3f_32(0.6f, 0.6f, 0.6f);
+  positions[7] = viskores::Vec3f_32(-0.6f, 0.6f, 0.6f);
+  anari_cpp::unmap(d, vertices);
+
+  auto indices = anari_cpp::newArray1D(d, ANARI_UINT32_VEC4, 6);
+  auto* quads = anari_cpp::map<viskores::Vec4ui_32>(d, indices);
+  quads[0] = viskores::Vec4ui_32(0, 3, 2, 1);
+  quads[1] = viskores::Vec4ui_32(4, 5, 6, 7);
+  quads[2] = viskores::Vec4ui_32(0, 4, 7, 3);
+  quads[3] = viskores::Vec4ui_32(1, 2, 6, 5);
+  quads[4] = viskores::Vec4ui_32(0, 1, 5, 4);
+  quads[5] = viskores::Vec4ui_32(3, 7, 6, 2);
+  anari_cpp::unmap(d, indices);
+
+  auto attributes = anari_cpp::newArray1D(d, ANARI_FLOAT32, 6);
+  auto* faceAttributes = anari_cpp::map<viskores::Float32>(d, attributes);
+  faceAttributes[0] = 0.f;
+  faceAttributes[1] = 0.2f;
+  faceAttributes[2] = 0.4f;
+  faceAttributes[3] = 0.6f;
+  faceAttributes[4] = 0.8f;
+  faceAttributes[5] = 1.f;
+  anari_cpp::unmap(d, attributes);
+
+  auto geometry = anari_cpp::newObject<anari_cpp::Geometry>(d, "quad");
+  anari_cpp::setAndReleaseParameter(d, geometry, "vertex.position", vertices);
+  anari_cpp::setAndReleaseParameter(d, geometry, "primitive.index", indices);
+  anari_cpp::setAndReleaseParameter(d, geometry, "primitive.attribute0", attributes);
+  anari_cpp::commitParameters(d, geometry);
+
+  // Assemble ANARI scene /////////////////////////////////////////////////////
+
+  auto colorArray = anari_cpp::newArray1D(d, ANARI_FLOAT32_VEC4, 6);
+  auto* colors = anari_cpp::map<viskores::Vec4f_32>(d, colorArray);
+  colors[0] = viskores::Vec4f_32(0.95f, 0.15f, 0.1f, 1.f);
+  colors[1] = viskores::Vec4f_32(0.1f, 0.55f, 0.95f, 1.f);
+  colors[2] = viskores::Vec4f_32(0.15f, 0.75f, 0.25f, 1.f);
+  colors[3] = viskores::Vec4f_32(0.95f, 0.85f, 0.1f, 1.f);
+  colors[4] = viskores::Vec4f_32(0.65f, 0.25f, 0.9f, 1.f);
+  colors[5] = viskores::Vec4f_32(0.95f, 0.45f, 0.1f, 1.f);
+  anari_cpp::unmap(d, colorArray);
+
+  auto sampler = anari_cpp::newObject<anari_cpp::Sampler>(d, "image1D");
+  anari_cpp::setAndReleaseParameter(d, sampler, "image", colorArray);
+  anari_cpp::setParameter(d, sampler, "filter", "nearest");
+  anari_cpp::setParameter(d, sampler, "wrapMode", "clampToEdge");
+  anari_cpp::setParameter(d, sampler, "inAttribute", "attribute0");
+  anari_cpp::commitParameters(d, sampler);
+
+  auto material = anari_cpp::newObject<anari_cpp::Material>(d, "matte");
+  anari_cpp::setParameter(d, material, "color", sampler);
+  anari_cpp::commitParameters(d, material);
+  anari_cpp::release(d, sampler);
+
+  auto surface = anari_cpp::newObject<anari_cpp::Surface>(d);
+  anari_cpp::setParameter(d, surface, "geometry", geometry);
+  anari_cpp::setParameter(d, surface, "material", material);
+  anari_cpp::commitParameters(d, surface);
+  anari_cpp::release(d, geometry);
+  anari_cpp::release(d, material);
+
+  auto world = anari_cpp::newObject<anari_cpp::World>(d);
+  anari_cpp::setParameterArray1D(d, world, "surface", &surface, 1);
+  anari_cpp::commitParameters(d, world);
+  anari_cpp::release(d, surface);
+
+  // Render a frame ///////////////////////////////////////////////////////////
+
+  renderTestANARIImage(d,
+                       world,
+                       viskores::Vec3f_32(2.f, 1.5f, 2.5f),
+                       viskores::Vec3f_32(-0.57f, -0.43f, -0.7f),
+                       viskores::Vec3f_32(0.f, 1.f, 0.f),
+                       "interop/anari/quad.png",
+                       viskores::Vec2ui_32(512, 512));
+
+  // Cleanup //////////////////////////////////////////////////////////////////
+
+  anari_cpp::release(d, world);
+  anari_cpp::release(d, d);
+}
+
+} // namespace
+
+int UnitTestANARIGeometryQuad(int argc, char* argv[])
+{
+  return viskores::cont::testing::Testing::Run(RenderTests, argc, argv);
+}

--- a/viskores/rendering/anari-device/CMakeLists.txt
+++ b/viskores/rendering/anari-device/CMakeLists.txt
@@ -43,6 +43,7 @@ set (sources
 set(device_sources
   array/ArrayConversion.cpp
   frame/Frame.cpp
+  scene/surface/geometry/Quad.cpp
   scene/surface/geometry/Sphere.cpp
   scene/surface/geometry/Triangle.cpp
   scene/volume/TransferFunction1D.cpp

--- a/viskores/rendering/anari-device/scene/surface/geometry/Geometry.cpp
+++ b/viskores/rendering/anari-device/scene/surface/geometry/Geometry.cpp
@@ -10,6 +10,7 @@
 
 #include "Geometry.h"
 // subtypes
+#include "Quad.h"
 #include "Sphere.h"
 #include "Triangle.h"
 
@@ -36,6 +37,8 @@ Geometry* Geometry::createInstance(std::string_view subtype, ViskoresDeviceGloba
   // std::cout << "Creating geometry of type " << subtype << "\n";
   if (subtype == "triangle")
     return new Triangle(s);
+  else if (subtype == "quad")
+    return new Quad(s);
   else if (subtype == "sphere")
     return new Sphere(s);
   else

--- a/viskores/rendering/anari-device/scene/surface/geometry/Quad.cpp
+++ b/viskores/rendering/anari-device/scene/surface/geometry/Quad.cpp
@@ -1,0 +1,159 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#include "Quad.h"
+// Viskores
+#include <viskores/CellShape.h>
+#include <viskores/cont/ArrayCopy.h>
+#include <viskores/cont/ArrayHandleRuntimeVec.h>
+#include <viskores/cont/CellSetSingleType.h>
+#include <viskores/rendering/CanvasRayTracer.h>
+#include <viskores/rendering/raytracing/QuadExtractor.h>
+#include <viskores/rendering/raytracing/QuadIntersector.h>
+#include <viskores/rendering/raytracing/RayOperations.h>
+#include <viskores/rendering/raytracing/RayTracer.h>
+// std
+#include <numeric>
+
+namespace viskores_device
+{
+
+Quad::Quad(ViskoresDeviceGlobalState* s)
+  : Geometry(s)
+  , m_index(this)
+{
+  this->m_vertexAttributes.setAttributes(this,
+                                         { "position",
+                                           "normal",
+                                           "tangent",
+                                           "color",
+                                           "attribute0",
+                                           "attribute1",
+                                           "attribute2",
+                                           "attribute3" });
+  this->m_vertexAttributes.setAnariAssociation("vertex");
+  this->m_vertexAttributes.setViskoresAssociation(viskores::cont::Field::Association::Points);
+
+  this->m_faceVaryingAttributes.setAttributes(
+    this, { "normal", "tangent", "color", "attribute0", "attribute1", "attribute2", "attribute3" });
+  this->m_faceVaryingAttributes.setAnariAssociation("faceVarying");
+  this->m_faceVaryingAttributes.setViskoresAssociation(viskores::cont::Field::Association::Cells);
+}
+
+void Quad::commitParameters()
+{
+  this->Geometry::commitParameters();
+
+  this->m_index = getParamObject<Array1D>("primitive.index");
+  this->m_vertexAttributes.commitParameters();
+  this->m_faceVaryingAttributes.commitParameters();
+}
+
+void Quad::finalize()
+{
+  helium::ChangeObserverPtr<Array1D>& positionArray = this->m_vertexAttributes.getParam("position");
+  if (!positionArray)
+  {
+    reportMessage(ANARI_SEVERITY_WARNING, "'quad' geometry missing 'vertex.position' parameter");
+    return;
+  }
+
+  if (!this->m_index)
+  {
+    reportMessage(ANARI_SEVERITY_INFO, "generating 'quad' index array");
+
+    Array1DMemoryDescriptor md;
+    md.appMemory = nullptr;
+    md.deleter = nullptr;
+    md.deleterPtr = nullptr;
+    md.elementType = ANARI_UINT32_VEC4;
+    md.numItems = positionArray->totalSize() / 4;
+
+    this->m_index = new Array1D(this->deviceState(), md);
+    this->m_index->refDec(helium::RefType::PUBLIC); // no public references
+
+    auto* begin = (uint32_t*)this->m_index->map();
+    auto* end = begin + this->m_index->totalSize() * 4;
+    std::iota(begin, end, 0);
+  }
+
+  this->m_dataSet = viskores::cont::DataSet{};
+
+  viskores::cont::ArrayHandleRuntimeVec<viskores::Id> connectionArray(4);
+  viskores::cont::ArrayCopyShallowIfPossible(this->m_index->dataAsViskoresArray(), connectionArray);
+
+  viskores::cont::CellSetSingleType<> cellSet;
+  cellSet.Fill(static_cast<viskores::Id>(positionArray->size()),
+               viskores::CELL_SHAPE_QUAD,
+               4,
+               connectionArray.GetComponentsArray());
+  this->m_dataSet.SetCellSet(cellSet);
+
+  this->Geometry::finalize();
+  this->m_vertexAttributes.setFields(this->m_dataSet);
+  this->m_faceVaryingAttributes.setFields(this->m_dataSet);
+
+  this->m_dataSet.AddCoordinateSystem("position");
+}
+
+void Quad::render(viskores::rendering::Canvas& canvas,
+                  const viskores::rendering::Camera& camera,
+                  const viskores::cont::Field& field,
+                  const viskores::cont::ArrayHandle<viskores::Vec4f_32>& colorMap) const
+{
+  viskores::rendering::raytracing::RayTracer tracer;
+  viskores::rendering::raytracing::QuadExtractor quadExtractor;
+
+  const viskores::cont::DataSet& data = this->getDataSet();
+  viskores::cont::CoordinateSystem coords = data.GetCoordinateSystem();
+
+  viskores::Bounds shapeBounds;
+  viskores::Range scalarRange = field.GetRange().ReadPortal().Get(0);
+
+  quadExtractor.ExtractCells(data.GetCellSet());
+
+  if (quadExtractor.GetNumberOfQuads() > 0)
+  {
+    auto quadIntersector = std::make_shared<viskores::rendering::raytracing::QuadIntersector>();
+    quadIntersector->SetData(coords, quadExtractor.GetQuadIds());
+    tracer.AddShapeIntersector(quadIntersector);
+    shapeBounds.Include(quadIntersector->GetShapeBounds());
+  }
+
+  viskores::Int32 width = (viskores::Int32)canvas.GetWidth();
+  viskores::Int32 height = (viskores::Int32)canvas.GetHeight();
+
+  viskores::rendering::raytracing::Camera rayCamera = camera.CreateRaytracingCamera(width, height);
+
+  viskores::rendering::raytracing::Ray<viskores::Float32> rays;
+  viskores::rendering::CanvasRayTracer* canvasRT =
+    dynamic_cast<viskores::rendering::CanvasRayTracer*>(&canvas);
+  VISKORES_ASSERT(canvasRT != nullptr);
+
+  rayCamera.CreateRays(rays, shapeBounds);
+  tracer.GetCamera() = rayCamera;
+  rays.Buffers.at(0).InitConst(0.f);
+  viskores::rendering::raytracing::RayOperations::MapCanvasToRays(
+    rays, camera.CreateRaytracingCamera(width, height), *canvasRT);
+
+  tracer.SetField(field, scalarRange);
+  tracer.SetColorMap(colorMap);
+  tracer.SetShadingOn(true);
+  tracer.Render(rays);
+
+  canvasRT->WriteToCanvas(rays, rays.Buffers.at(0).Buffer, camera);
+}
+
+bool Quad::isValid() const
+{
+  return this->m_vertexAttributes.getParam("position");
+}
+
+} // namespace viskores_device

--- a/viskores/rendering/anari-device/scene/surface/geometry/Quad.h
+++ b/viskores/rendering/anari-device/scene/surface/geometry/Quad.h
@@ -1,0 +1,39 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#pragma once
+
+#include "Geometry.h"
+
+namespace viskores_device
+{
+
+struct Quad : Geometry
+{
+  Quad(ViskoresDeviceGlobalState* s);
+
+  void commitParameters() override;
+  void finalize() override;
+
+  bool isValid() const override;
+
+  virtual void render(
+    viskores::rendering::Canvas& canvas,
+    const viskores::rendering::Camera& camera,
+    const viskores::cont::Field& field,
+    const viskores::cont::ArrayHandle<viskores::Vec4f_32>& colorMap) const override;
+
+private:
+  helium::ChangeObserverPtr<Array1D> m_index;
+  FieldArrayParameters m_vertexAttributes;
+  FieldArrayParameters m_faceVaryingAttributes;
+};
+
+} // namespace viskores_device

--- a/viskores/rendering/anari-device/viskores_device.json
+++ b/viskores/rendering/anari-device/viskores_device.json
@@ -7,6 +7,7 @@
       "anari_core_objects_base_1_0",
       "khr_camera_orthographic",
       "khr_camera_perspective",
+      "khr_geometry_quad",
       "khr_geometry_triangle",
       "khr_material_matte",
       "khr_sampler_image1d",

--- a/viskores/rendering/raytracing/QuadExtractor.h
+++ b/viskores/rendering/raytracing/QuadExtractor.h
@@ -19,6 +19,7 @@
 #define viskores_rendering_raytracing_Quad_Extractor_h
 
 #include <viskores/cont/DataSet.h>
+#include <viskores/rendering/viskores_rendering_export.h>
 
 namespace viskores
 {
@@ -27,7 +28,7 @@ namespace rendering
 namespace raytracing
 {
 
-class QuadExtractor
+class VISKORES_RENDERING_EXPORT QuadExtractor
 {
 protected:
   viskores::cont::ArrayHandle<viskores::Vec<viskores::Id, 5>> QuadIds;

--- a/viskores/rendering/raytracing/QuadIntersector.h
+++ b/viskores/rendering/raytracing/QuadIntersector.h
@@ -20,6 +20,7 @@
 
 #include <viskores/cont/Algorithm.h>
 #include <viskores/rendering/raytracing/ShapeIntersector.h>
+#include <viskores/rendering/viskores_rendering_export.h>
 
 namespace viskores
 {
@@ -30,7 +31,7 @@ namespace raytracing
 namespace detail
 {
 }
-class QuadIntersector : public ShapeIntersector
+class VISKORES_RENDERING_EXPORT QuadIntersector : public ShapeIntersector
 {
 protected:
   viskores::cont::ArrayHandle<viskores::Vec<viskores::Id, 5>> QuadIds;


### PR DESCRIPTION
This adds a new quad geometry implementation modeled after the existing triangle geometry path. The device now advertises `khr_geometry_quad`, accepts ANARI `quad` geometry with `vertex.position` and optional `primitive.index`, builds a Viskores quad cell set, and renders it through the existing Viskores quad raytracing extractor/intersector.

The change also adds an image-based ANARI quad geometry test. The test renders an indexed cube made from quad faces, with per-face coloring through `primitive.attribute0` and an `image1D` sampler, then compares against a new baseline image in `viskores-data`.
