### PR TITLE
Add ANARI device load function

### DIFF
--- a/.gitlab/ci/ubuntu2004.yml
+++ b/.gitlab/ci/ubuntu2004.yml
@@ -28,6 +28,7 @@ ubuntu2004_kokkos37:
     CMAKE_BUILD_TYPE: RelWithDebInfo
     CMAKE_PREFIX_PATH: "/opt/anari"
     VISKORES_SETTINGS: "kokkos+shared+64bit_floats+rendering+anari+ccache"
+    VISKORES_TEST_ANARI_LIBRARY: "helide"
 
 ubuntu2004_gcc9:
   extends:

--- a/docs/changelog/anari-device.md
+++ b/docs/changelog/anari-device.md
@@ -6,6 +6,12 @@ portable, accelerated ANARI device that will be available in HPC systems
 regardless of vendor support. We hope this will help jumpstart the support of
 ANARI for scientific visualization applications at HPC centers.
 
+The ANARI interop library now contains a function named `ANARILoadDevice` that
+loads an ANARI device. This function has a special mode for the device named
+"viskores" such that it will load the device from the library directly, thereby
+circumventing any configuration to find the library at runtime. This provides a
+fallback that is always available.
+
 This device is still in its experimental phase. Although functional, it is
 missing many features that applications will expect to be supported. The
 inclusion of the device into Viskores in this early phase should help promote

--- a/viskores/interop/anari/ANARILoadDevice.cxx
+++ b/viskores/interop/anari/ANARILoadDevice.cxx
@@ -1,0 +1,94 @@
+//============================================================================
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//============================================================================
+
+#include <viskores/interop/anari/ANARILoadDevice.h>
+
+#include <viskores/cont/Logging.h>
+
+#include <viskores/rendering/anari-device/ViskoresDevice.h>
+
+namespace
+{
+
+static void AnariStatusFunc(const void* viskoresNotUsed(userData),
+                            ANARIDevice viskoresNotUsed(device),
+                            ANARIObject source,
+                            ANARIDataType viskoresNotUsed(sourceType),
+                            ANARIStatusSeverity severity,
+                            ANARIStatusCode viskoresNotUsed(code),
+                            const char* message)
+{
+  viskores::cont::LogLevel level;
+  switch (severity)
+  {
+    case ANARI_SEVERITY_FATAL_ERROR:
+      level = viskores::cont::LogLevel::Fatal;
+      break;
+    case ANARI_SEVERITY_ERROR:
+      level = viskores::cont::LogLevel::Error;
+      break;
+    case ANARI_SEVERITY_WARNING:
+    case ANARI_SEVERITY_PERFORMANCE_WARNING:
+      level = viskores::cont::LogLevel::Warn;
+      break;
+    case ANARI_SEVERITY_INFO:
+      level = viskores::cont::LogLevel::Info;
+      break;
+    case ANARI_SEVERITY_DEBUG:
+    default:
+      level = viskores::cont::LogLevel::UserVerboseFirst;
+      break;
+  }
+
+  VISKORES_LOG_S(level, "[ANARI Object " << source << "] " << message);
+}
+
+} // anonymous namespace
+
+namespace viskores
+{
+namespace interop
+{
+namespace anari
+{
+
+anari_cpp::Device ANARILoadDevice(const std::string& libraryName)
+{
+  if (libraryName == "viskores")
+  {
+    VISKORES_LOG_F(viskores::cont::LogLevel::Info,
+                   "Directly loading internal ANARI device named `viskores`");
+    return reinterpret_cast<anari_cpp::Device>(
+      new viskores_device::ViskoresDevice(AnariStatusFunc, nullptr));
+  }
+  else
+  {
+    VISKORES_LOG_S(viskores::cont::LogLevel::Info,
+                   "Loading ANARI library named `" << libraryName << "`");
+    anari_cpp::Library library =
+      anari_cpp::loadLibrary(libraryName.c_str(), AnariStatusFunc, nullptr);
+    if (library == nullptr)
+    {
+      VISKORES_LOG_S(viskores::cont::LogLevel::Info,
+                     "Failed to load ANARI library named `" << libraryName << "`");
+      return nullptr;
+    }
+    anari_cpp::Device device = anari_cpp::newDevice(library, "default");
+    anari_cpp::unloadLibrary(library);
+    if (device == nullptr)
+    {
+      VISKORES_LOG_S(viskores::cont::LogLevel::Info,
+                     "Failed to load ANARI device from library named `" << libraryName << "`");
+    }
+    return device;
+  }
+}
+
+}
+}
+} // namespace viskores::interop::anari

--- a/viskores/interop/anari/ANARILoadDevice.h
+++ b/viskores/interop/anari/ANARILoadDevice.h
@@ -1,0 +1,52 @@
+//============================================================================
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//============================================================================
+
+#ifndef viskores_interop_anari_ANARILoadDevice_h
+#define viskores_interop_anari_ANARILoadDevice_h
+
+#include <viskores/interop/anari/ViskoresANARITypes.h>
+#include <viskores/interop/anari/viskores_anari_export.h>
+
+namespace viskores
+{
+namespace interop
+{
+namespace anari
+{
+
+/// @brief Loads an ANARI device from the library of the provided name.
+///
+/// Given the name of an ANARI device library, attempts to find the associated
+/// library (named `anari_library_` plus the provided `libraryName` with the
+/// standard shared object library prefix and extension for the current system),
+/// opens it, and returns an ANARI device object. This is a convenience function
+/// that essentially uses `anari::loadLibrary` to open the library and
+/// `anari::newDevice` to create the device.
+///
+/// An additional feature of this method is that if you provide the string
+/// `viskores` for `libraryName`, this function will be able to load the device
+/// without having to find the device on the system. Typically, to find the
+/// library you need an environment variable such as `LD_LIBRARY_PATH` or an
+/// internal library rpath pointing to the directory containing the library. For
+/// the "viskores" library, the device will be loaded directly regardless of its
+/// location.
+///
+/// This method will also link the ANARI device's logging to the Viskores logging
+/// so the ANARI logging can be controlled through Viskores' configuration.
+///
+/// @param libraryName The name of the library to load.
+/// @return An open ANARI device or `nullptr` if the library cannot be opened.
+VISKORES_ANARI_EXPORT VISKORES_CONT anari_cpp::Device ANARILoadDevice(
+  const std::string& libraryName);
+
+}
+}
+} // namespace viskores::interop::anari
+
+
+#endif //viskores_interop_anari_ANARILoadDevice_h

--- a/viskores/interop/anari/CMakeLists.txt
+++ b/viskores/interop/anari/CMakeLists.txt
@@ -20,6 +20,7 @@ find_package(anari 0.8.0 REQUIRED)
 
 set(headers
   ANARIActor.h
+  ANARILoadDevice.h
   ANARIMapper.h
   ANARIMapperGlyphs.h
   ANARIMapperPoints.h
@@ -31,6 +32,7 @@ set(headers
 
 set(sources
   ANARIActor.cxx
+  ANARILoadDevice.cxx
   ANARIMapper.cxx
   ANARIScene.cxx
   ViskoresANARITypes.cxx

--- a/viskores/interop/anari/testing/ANARITestCommon.h
+++ b/viskores/interop/anari/testing/ANARITestCommon.h
@@ -21,50 +21,13 @@
 
 // viskores
 #include <viskores/cont/DataSetBuilderUniform.h>
+#include <viskores/interop/anari/ANARILoadDevice.h>
 #include <viskores/interop/anari/ANARIMapper.h>
 #include <viskores/rendering/testing/Testing.h>
 #include <viskores/testing/Testing.h>
 
 namespace
 {
-
-static void StatusFunc(const void* userData,
-                       ANARIDevice /*device*/,
-                       ANARIObject source,
-                       ANARIDataType /*sourceType*/,
-                       ANARIStatusSeverity severity,
-                       ANARIStatusCode /*code*/,
-                       const char* message)
-{
-  bool verbose = *(bool*)userData;
-  if (!verbose)
-    return;
-
-  if (severity == ANARI_SEVERITY_FATAL_ERROR)
-  {
-    fprintf(stderr, "[FATAL][%p] %s\n", source, message);
-  }
-  else if (severity == ANARI_SEVERITY_ERROR)
-  {
-    fprintf(stderr, "[ERROR][%p] %s\n", source, message);
-  }
-  else if (severity == ANARI_SEVERITY_WARNING)
-  {
-    fprintf(stderr, "[WARN ][%p] %s\n", source, message);
-  }
-  else if (severity == ANARI_SEVERITY_PERFORMANCE_WARNING)
-  {
-    fprintf(stderr, "[PERF ][%p] %s\n", source, message);
-  }
-  else if (severity == ANARI_SEVERITY_INFO)
-  {
-    fprintf(stderr, "[INFO ][%p] %s\n", source, message);
-  }
-  else if (severity == ANARI_SEVERITY_DEBUG)
-  {
-    fprintf(stderr, "[DEBUG][%p] %s\n", source, message);
-  }
-}
 
 static void setColorMap(anari_cpp::Device d, viskores::interop::anari::ANARIMapper& mapper)
 {
@@ -90,11 +53,7 @@ static anari_cpp::Device loadANARIDevice()
 {
   viskores::testing::FloatingPointExceptionTrapDisable();
   auto* libraryName = std::getenv("VISKORES_TEST_ANARI_LIBRARY");
-  static bool verbose = std::getenv("VISKORES_TEST_ANARI_VERBOSE") != nullptr;
-  auto lib = anari_cpp::loadLibrary(libraryName ? libraryName : "helide", StatusFunc, &verbose);
-  auto d = anari_cpp::newDevice(lib, "default");
-  anari_cpp::unloadLibrary(lib);
-  return d;
+  return viskores::interop::anari::ANARILoadDevice(libraryName ? libraryName : "viskores");
 }
 
 static void renderTestANARIImage(anari_cpp::Device d,

--- a/viskores/interop/anari/viskores.module
+++ b/viskores/interop/anari/viskores.module
@@ -7,6 +7,8 @@ DEPENDS
   viskores_filter_vector_analysis
   viskores_rendering
   viskores_worklet
+PRIVATE_DEPENDS
+  anari_library_viskores
 TEST_DEPENDS
   viskores_filter_vector_analysis
   viskores_filter_contour

--- a/viskores/rendering/anari-device/CMakeLists.txt
+++ b/viskores/rendering/anari-device/CMakeLists.txt
@@ -55,7 +55,7 @@ viskores_library(
   )
 
 target_link_libraries(anari_library_viskores
-PRIVATE
+PUBLIC
   anari::helium
   )
 

--- a/viskores/rendering/anari-device/ViskoresDevice.h
+++ b/viskores/rendering/anari-device/ViskoresDevice.h
@@ -16,10 +16,12 @@
 
 #include "Object.h"
 
+#include <viskores/rendering/anari-device/anari_library_viskores_export.h>
+
 namespace viskores_device
 {
 
-struct ViskoresDevice : public helium::BaseDevice
+struct ANARI_LIBRARY_VISKORES_EXPORT ViskoresDevice : public helium::BaseDevice
 {
   /////////////////////////////////////////////////////////////////////////////
   // Main interface to accepting API calls


### PR DESCRIPTION
The ANARI interop library now contains a function named `ANARILoadDevice` that finds an ANARI library of a given name and loads its device. It also has a special feature that detects when loading the "viskores" library and creates the device from direct linking.