### PR TITLE
Move raytracer to separate library

### DIFF
--- a/docs/changelog/raytracer-separate-module.md
+++ b/docs/changelog/raytracer-separate-module.md
@@ -1,0 +1,9 @@
+## Raytracing code separated into its own module
+
+The raytracing code, placed in the raytracing subdirectory/namespace under
+rendering is now in its own library (`viskores::rendering_raytracing`) that does
+not depend on the rest of the rendering code (i.e., the `viskores::rendering`
+library). Previously, this code was intertwined and in one library.
+
+This separation will allow more options to implement rendering features using
+other libraries that partially use raytracing (such as the ANARI interop).

--- a/viskores/rendering/CMakeLists.txt
+++ b/viskores/rendering/CMakeLists.txt
@@ -90,10 +90,6 @@ set(sources
   View2D.cxx
   View3D.cxx
   WorldAnnotator.cxx
-
-  raytracing/Logger.cxx
-  raytracing/MeshConnectivityContainers.cxx
-  raytracing/TriangleExtractor.cxx
   )
 
 # This list of sources has code that uses devices and so might need to be
@@ -114,29 +110,6 @@ set(device_sources
   MapperWireframer.cxx
   ScalarRenderer.cxx
   TextRendererBatcher.cxx
-
-  raytracing/BoundingVolumeHierarchy.cxx
-  raytracing/Camera.cxx
-  raytracing/ChannelBuffer.cxx
-  raytracing/ConnectivityTracer.cxx
-  raytracing/CylinderExtractor.cxx
-  raytracing/CylinderIntersector.cxx
-  raytracing/GlyphExtractor.cxx
-  raytracing/GlyphExtractorVector.cxx
-  raytracing/GlyphIntersector.cxx
-  raytracing/GlyphIntersectorVector.cxx
-  raytracing/MeshConnectivityBuilder.cxx
-  raytracing/QuadExtractor.cxx
-  raytracing/QuadIntersector.cxx
-  raytracing/RayOperations.cxx
-  raytracing/RayTracer.cxx
-  raytracing/RunTriangulator.cxx
-  raytracing/ScalarRenderer.cxx
-  raytracing/ShapeIntersector.cxx
-  raytracing/SphereExtractor.cxx
-  raytracing/SphereIntersector.cxx
-  raytracing/TriangleIntersector.cxx
-  raytracing/VolumeRendererStructured.cxx
   )
 
 # the None backend supports not building the opengl version
@@ -156,7 +129,6 @@ endif()
 
 #-----------------------------------------------------------------------------
 add_subdirectory(internal)
-add_subdirectory(raytracing)
 
 #-----------------------------------------------------------------------------
 # Pretty much obsolete, but might be expected to be exported.

--- a/viskores/rendering/ConnectivityProxy.cxx
+++ b/viskores/rendering/ConnectivityProxy.cxx
@@ -243,7 +243,9 @@ public:
     rayCamera.CreateRays(rays, this->Dataset.GetCoordinateSystem(this->CoordinateName).GetBounds());
     rays.Buffers.at(0).InitConst(0.f);
     raytracing::RayOperations::MapCanvasToRays(
-      rays, camera.CreateRaytracingCamera(canvas->GetWidth(), canvas->GetHeight()), *canvas);
+      rays,
+      camera.CreateRaytracingCamera(canvas->GetWidth(), canvas->GetHeight()),
+      canvas->GetDepthBuffer());
 
     if (this->Mode == RenderMode::Volume)
     {

--- a/viskores/rendering/MapperCylinder.cxx
+++ b/viskores/rendering/MapperCylinder.cxx
@@ -198,8 +198,9 @@ void MapperCylinder::RenderCellsImpl(const viskores::cont::UnknownCellSet& cells
 
   this->Internals->RayCamera.CreateRays(this->Internals->Rays, shapeBounds);
   this->Internals->Rays.Buffers.at(0).InitConst(0.f);
-  raytracing::RayOperations::MapCanvasToRays(
-    this->Internals->Rays, camera.CreateRaytracingCamera(width, height), *this->Internals->Canvas);
+  raytracing::RayOperations::MapCanvasToRays(this->Internals->Rays,
+                                             camera.CreateRaytracingCamera(width, height),
+                                             this->Internals->Canvas->GetDepthBuffer());
 
   this->Internals->Tracer.SetField(scalarField, scalarRange);
   this->Internals->Tracer.GetCamera() = this->Internals->RayCamera;

--- a/viskores/rendering/MapperGlyphScalar.cxx
+++ b/viskores/rendering/MapperGlyphScalar.cxx
@@ -483,7 +483,7 @@ void MapperGlyphScalar::RenderCellsImpl(
     RayCamera.CreateRays(Rays, shapeBounds);
     Rays.Buffers.at(0).InitConst(0.f);
     raytracing::RayOperations::MapCanvasToRays(
-      Rays, camera.CreateRaytracingCamera(width, height), *this->Canvas);
+      Rays, camera.CreateRaytracingCamera(width, height), this->Canvas->GetDepthBuffer());
 
     tracer.SetField(processedField, scalarRange);
     tracer.GetCamera() = RayCamera;

--- a/viskores/rendering/MapperGlyphVector.cxx
+++ b/viskores/rendering/MapperGlyphVector.cxx
@@ -153,7 +153,7 @@ void MapperGlyphVector::RenderCellsImpl(
   RayCamera.CreateRays(Rays, shapeBounds);
   Rays.Buffers.at(0).InitConst(0.f);
   raytracing::RayOperations::MapCanvasToRays(
-    Rays, camera.CreateRaytracingCamera(width, height), *this->Canvas);
+    Rays, camera.CreateRaytracingCamera(width, height), this->Canvas->GetDepthBuffer());
 
   auto magnitudeField = glyphExtractor.GetMagnitudeField();
   auto magnitudeFieldRange = magnitudeField.GetRange().ReadPortal().Get(0);

--- a/viskores/rendering/MapperPoint.cxx
+++ b/viskores/rendering/MapperPoint.cxx
@@ -229,8 +229,9 @@ void MapperPoint::RenderCellsImpl(const viskores::cont::UnknownCellSet& cellset,
 
   this->Internals->RayCamera.CreateRays(this->Internals->Rays, shapeBounds);
   this->Internals->Rays.Buffers.at(0).InitConst(0.f);
-  raytracing::RayOperations::MapCanvasToRays(
-    this->Internals->Rays, camera.CreateRaytracingCamera(width, height), *this->Internals->Canvas);
+  raytracing::RayOperations::MapCanvasToRays(this->Internals->Rays,
+                                             camera.CreateRaytracingCamera(width, height),
+                                             this->Internals->Canvas->GetDepthBuffer());
 
   this->Internals->Tracer.SetField(scalarField, scalarRange);
   this->Internals->Tracer.GetCamera() = this->Internals->RayCamera;

--- a/viskores/rendering/MapperQuad.cxx
+++ b/viskores/rendering/MapperQuad.cxx
@@ -117,8 +117,9 @@ void MapperQuad::RenderCellsImpl(const viskores::cont::UnknownCellSet& cellset,
 
   this->Internals->RayCamera.CreateRays(this->Internals->Rays, shapeBounds);
   this->Internals->Rays.Buffers.at(0).InitConst(0.f);
-  raytracing::RayOperations::MapCanvasToRays(
-    this->Internals->Rays, camera.CreateRaytracingCamera(width, height), *this->Internals->Canvas);
+  raytracing::RayOperations::MapCanvasToRays(this->Internals->Rays,
+                                             camera.CreateRaytracingCamera(width, height),
+                                             this->Internals->Canvas->GetDepthBuffer());
 
   this->Internals->Tracer.GetCamera() = this->Internals->RayCamera;
   this->Internals->Tracer.SetField(scalarField, scalarRange);

--- a/viskores/rendering/MapperRayTracer.cxx
+++ b/viskores/rendering/MapperRayTracer.cxx
@@ -127,8 +127,9 @@ void MapperRayTracer::RenderCellsImpl(const viskores::cont::UnknownCellSet& cell
   this->Internals->RayCamera.CreateRays(this->Internals->Rays, shapeBounds);
   this->Internals->Tracer.GetCamera() = this->Internals->RayCamera;
   this->Internals->Rays.Buffers.at(0).InitConst(0.f);
-  raytracing::RayOperations::MapCanvasToRays(
-    this->Internals->Rays, camera.CreateRaytracingCamera(width, height), *this->Internals->Canvas);
+  raytracing::RayOperations::MapCanvasToRays(this->Internals->Rays,
+                                             camera.CreateRaytracingCamera(width, height),
+                                             this->Internals->Canvas->GetDepthBuffer());
 
   this->Internals->Tracer.SetField(scalarField, scalarRange);
 

--- a/viskores/rendering/MapperVolume.cxx
+++ b/viskores/rendering/MapperVolume.cxx
@@ -114,8 +114,9 @@ void MapperVolume::RenderCellsImpl(const viskores::cont::UnknownCellSet& cellset
     viskores::rendering::raytracing::Ray<viskores::Float32> rays;
     rayCamera.CreateRays(rays, coords.GetBounds());
     rays.Buffers.at(0).InitConst(0.f);
-    raytracing::RayOperations::MapCanvasToRays(
-      rays, camera.CreateRaytracingCamera(width, height), *this->Internals->Canvas);
+    raytracing::RayOperations::MapCanvasToRays(rays,
+                                               camera.CreateRaytracingCamera(width, height),
+                                               this->Internals->Canvas->GetDepthBuffer());
 
 
     if (this->Internals->SampleDistance != DEFAULT_SAMPLE_DISTANCE)

--- a/viskores/rendering/Wireframer.h
+++ b/viskores/rendering/Wireframer.h
@@ -27,7 +27,6 @@
 #include <viskores/cont/ArrayHandle.h>
 #include <viskores/cont/AtomicArray.h>
 #include <viskores/rendering/MatrixHelpers.h>
-#include <viskores/rendering/Triangulator.h>
 #include <viskores/worklet/DispatcherMapField.h>
 #include <viskores/worklet/WorkletMapField.h>
 

--- a/viskores/rendering/anari-device/scene/surface/geometry/Quad.cpp
+++ b/viskores/rendering/anari-device/scene/surface/geometry/Quad.cpp
@@ -141,7 +141,7 @@ void Quad::render(viskores::rendering::Canvas& canvas,
   tracer.GetCamera() = rayCamera;
   rays.Buffers.at(0).InitConst(0.f);
   viskores::rendering::raytracing::RayOperations::MapCanvasToRays(
-    rays, camera.CreateRaytracingCamera(width, height), *canvasRT);
+    rays, camera.CreateRaytracingCamera(width, height), canvasRT->GetDepthBuffer());
 
   tracer.SetField(field, scalarRange);
   tracer.SetColorMap(colorMap);

--- a/viskores/rendering/anari-device/scene/surface/geometry/Sphere.cpp
+++ b/viskores/rendering/anari-device/scene/surface/geometry/Sphere.cpp
@@ -14,6 +14,7 @@
 #include <viskores/cont/ArrayHandleIndex.h>
 #include <viskores/cont/ArrayRangeCompute.h>
 #include <viskores/filter/MapFieldPermutation.h>
+#include <viskores/rendering/CanvasRayTracer.h>
 #include <viskores/rendering/raytracing/Camera.h>
 #include <viskores/rendering/raytracing/Ray.h>
 #include <viskores/rendering/raytracing/RayOperations.h>
@@ -165,7 +166,7 @@ void Sphere::render(viskores::rendering::Canvas& canvas,
   rayCamera.CreateRays(rays, shapeBounds);
   rays.Buffers.at(0).InitConst(0.f);
   viskores::rendering::raytracing::RayOperations::MapCanvasToRays(
-    rays, camera.CreateRaytracingCamera(width, height), *canvasRT);
+    rays, camera.CreateRaytracingCamera(width, height), canvasRT->GetDepthBuffer());
 
   tracer.SetField(field, scalarRange);
   tracer.GetCamera() = rayCamera;

--- a/viskores/rendering/anari-device/scene/surface/geometry/Triangle.cpp
+++ b/viskores/rendering/anari-device/scene/surface/geometry/Triangle.cpp
@@ -161,7 +161,7 @@ void Triangle::render(viskores::rendering::Canvas& canvas,
   tracer.GetCamera() = rayCamera;
   rays.Buffers.at(0).InitConst(0.f);
   viskores::rendering::raytracing::RayOperations::MapCanvasToRays(
-    rays, camera.CreateRaytracingCamera(width, height), *canvasRT);
+    rays, camera.CreateRaytracingCamera(width, height), canvasRT->GetDepthBuffer());
 
   tracer.SetField(field, scalarRange);
 

--- a/viskores/rendering/anari-device/scene/volume/TransferFunction1D.cpp
+++ b/viskores/rendering/anari-device/scene/volume/TransferFunction1D.cpp
@@ -313,7 +313,7 @@ void TransferFunction1D::render(viskores::rendering::Canvas& canvas,
   rayCamera.CreateRays(rays, coords.GetBounds());
   rays.Buffers.at(0).InitConst(0.f);
   viskores::rendering::raytracing::RayOperations::MapCanvasToRays(
-    rays, camera.CreateRaytracingCamera(width, height), *canvasRT);
+    rays, camera.CreateRaytracingCamera(width, height), canvasRT->GetDepthBuffer());
 
   tracer.SetSampleDistance(this->m_sampleDistance);
 

--- a/viskores/rendering/raytracing/BoundingVolumeHierarchy.cxx
+++ b/viskores/rendering/raytracing/BoundingVolumeHierarchy.cxx
@@ -723,10 +723,10 @@ void LinearBVH::SetData(AABBs& aabbs)
 }
 
 // explicitly export
-//template VISKORES_RENDERING_EXPORT void LinearBVH::ConstructOnDevice<
+//template VISKORES_RENDERING_RAYTRACING_EXPORT void LinearBVH::ConstructOnDevice<
 //  viskores::cont::DeviceAdapterTagSerial>(viskores::cont::DeviceAdapterTagSerial);
 //#ifdef VISKORES_ENABLE_TBB
-//template VISKORES_RENDERING_EXPORT void LinearBVH::ConstructOnDevice<viskores::cont::DeviceAdapterTagTBB>(
+//template VISKORES_RENDERING_RAYTRACING_EXPORT void LinearBVH::ConstructOnDevice<viskores::cont::DeviceAdapterTagTBB>(
 //  viskores::cont::DeviceAdapterTagTBB);
 //#endif
 //#ifdef VISKORES_ENABLE_OPENMP
@@ -734,7 +734,7 @@ void LinearBVH::SetData(AABBs& aabbs)
 //  viskores::cont::DeviceAdapterTagOpenMP);
 //#endif
 //#ifdef VISKORES_ENABLE_CUDA
-//template VISKORES_RENDERING_EXPORT void LinearBVH::ConstructOnDevice<viskores::cont::DeviceAdapterTagCuda>(
+//template VISKORES_RENDERING_RAYTRACING_EXPORT void LinearBVH::ConstructOnDevice<viskores::cont::DeviceAdapterTagCuda>(
 //  viskores::cont::DeviceAdapterTagCuda);
 //#endif
 //

--- a/viskores/rendering/raytracing/BoundingVolumeHierarchy.h
+++ b/viskores/rendering/raytracing/BoundingVolumeHierarchy.h
@@ -20,7 +20,7 @@
 
 #include <viskores/cont/ArrayHandle.h>
 #include <viskores/cont/DataSet.h>
-#include <viskores/rendering/viskores_rendering_export.h>
+#include <viskores/rendering/raytracing/viskores_rendering_raytracing_export.h>
 
 namespace viskores
 {
@@ -42,7 +42,7 @@ struct AABBs
 //
 // This is the data structure that is passed to the ray tracer.
 //
-class VISKORES_RENDERING_EXPORT LinearBVH
+class VISKORES_RENDERING_RAYTRACING_EXPORT LinearBVH
 {
 public:
   using InnerNodesHandle = viskores::cont::ArrayHandle<viskores::Vec4f_32>;

--- a/viskores/rendering/raytracing/CMakeLists.txt
+++ b/viskores/rendering/raytracing/CMakeLists.txt
@@ -58,7 +58,43 @@ set(headers
   Worklets.h
   )
 
+set(sources
+  Logger.cxx
+  MeshConnectivityContainers.cxx
+  TriangleExtractor.cxx
+  )
+
+set(device_sources
+  BoundingVolumeHierarchy.cxx
+  Camera.cxx
+  ChannelBuffer.cxx
+  ConnectivityTracer.cxx
+  CylinderExtractor.cxx
+  CylinderIntersector.cxx
+  GlyphExtractor.cxx
+  GlyphExtractorVector.cxx
+  GlyphIntersector.cxx
+  GlyphIntersectorVector.cxx
+  MeshConnectivityBuilder.cxx
+  QuadExtractor.cxx
+  QuadIntersector.cxx
+  RayOperations.cxx
+  RayTracer.cxx
+  RunTriangulator.cxx
+  ScalarRenderer.cxx
+  ShapeIntersector.cxx
+  SphereExtractor.cxx
+  SphereIntersector.cxx
+  TriangleIntersector.cxx
+  VolumeRendererStructured.cxx
+  )
+
 set_source_files_properties(CellTables.h
                             PROPERTIES Viskores_CANT_BE_HEADER_TESTED TRUE)
 
-viskores_declare_headers(${headers})
+viskores_library(
+  NAME viskores_rendering_raytracing
+  SOURCES ${sources}
+  HEADERS ${headers}
+  DEVICE_SOURCES ${device_sources}
+  )

--- a/viskores/rendering/raytracing/Camera.cxx
+++ b/viskores/rendering/raytracing/Camera.cxx
@@ -16,12 +16,14 @@
 //  PURPOSE.  See the above copyright notice for more information.
 //============================================================================
 
+#include <viskores/Transform3D.h>
 #include <viskores/VectorAnalysis.h>
 
 #include <viskores/cont/Algorithm.h>
 #include <viskores/cont/ErrorBadValue.h>
 #include <viskores/cont/Timer.h>
 
+#include <viskores/rendering/MatrixHelpers.h>
 #include <viskores/rendering/raytracing/Camera.h>
 #include <viskores/rendering/raytracing/Logger.h>
 #include <viskores/rendering/raytracing/RayOperations.h>

--- a/viskores/rendering/raytracing/Camera.h
+++ b/viskores/rendering/raytracing/Camera.h
@@ -29,7 +29,7 @@ namespace rendering
 namespace raytracing
 {
 
-struct Camera3DStruct
+struct VISKORES_RENDERING_RAYTRACING_EXPORT Camera3DStruct
 {
 public:
   VISKORES_CONT
@@ -61,7 +61,7 @@ public:
   viskores::Float32 Zoom;
 };
 
-struct VISKORES_RENDERING_EXPORT Camera2DStruct
+struct VISKORES_RENDERING_RAYTRACING_EXPORT Camera2DStruct
 {
 public:
   VISKORES_CONT
@@ -94,7 +94,7 @@ public:
   viskores::Float32 Zoom;
 };
 
-class VISKORES_RENDERING_EXPORT Camera
+class VISKORES_RENDERING_RAYTRACING_EXPORT Camera
 {
 private:
   viskores::Int32 Height = 500;

--- a/viskores/rendering/raytracing/ChannelBuffer.cxx
+++ b/viskores/rendering/raytracing/ChannelBuffer.cxx
@@ -24,7 +24,7 @@
 #include <viskores/cont/Invoker.h>
 #include <viskores/cont/TryExecute.h>
 
-#include <viskores/rendering/viskores_rendering_export.h>
+#include <viskores/rendering/raytracing/viskores_rendering_raytracing_export.h>
 
 #include <viskores/rendering/raytracing/ChannelBuffer.h>
 #include <viskores/rendering/raytracing/ChannelBufferOperations.h>

--- a/viskores/rendering/raytracing/ChannelBuffer.h
+++ b/viskores/rendering/raytracing/ChannelBuffer.h
@@ -20,7 +20,7 @@
 
 #include <viskores/cont/ArrayHandle.h>
 
-#include <viskores/rendering/viskores_rendering_export.h>
+#include <viskores/rendering/raytracing/viskores_rendering_raytracing_export.h>
 
 #include <viskores/rendering/raytracing/RayTracingTypeDefs.h>
 
@@ -50,7 +50,7 @@ namespace raytracing
 ///
 
 template <typename Precision>
-class VISKORES_RENDERING_EXPORT ChannelBuffer
+class VISKORES_RENDERING_RAYTRACING_EXPORT ChannelBuffer
 {
 protected:
   viskores::Int32 NumChannels;

--- a/viskores/rendering/raytracing/ConnectivityTracer.cxx
+++ b/viskores/rendering/raytracing/ConnectivityTracer.cxx
@@ -1515,31 +1515,35 @@ std::vector<PartialComposite<FloatType>> ConnectivityTracer::PartialTrace(Ray<Fl
   return partials;
 }
 
-template class detail::RayTracking<viskores::Float32>;
-template class detail::RayTracking<viskores::Float64>;
+template class VISKORES_RENDERING_RAYTRACING_EXPORT detail::RayTracking<viskores::Float32>;
+template class VISKORES_RENDERING_RAYTRACING_EXPORT detail::RayTracking<viskores::Float64>;
 
-template struct PartialComposite<viskores::Float32>;
-template struct PartialComposite<viskores::Float64>;
+template struct VISKORES_RENDERING_RAYTRACING_EXPORT PartialComposite<viskores::Float32>;
+template struct VISKORES_RENDERING_RAYTRACING_EXPORT PartialComposite<viskores::Float64>;
 
-template void ConnectivityTracer::FullTrace<viskores::Float32>(Ray<viskores::Float32>& rays);
-
-template std::vector<PartialComposite<viskores::Float32>>
-ConnectivityTracer::PartialTrace<viskores::Float32>(Ray<viskores::Float32>& rays);
-
-template void ConnectivityTracer::IntegrateMeshSegment<viskores::Float32>(
+template VISKORES_RENDERING_RAYTRACING_EXPORT void ConnectivityTracer::FullTrace<viskores::Float32>(
   Ray<viskores::Float32>& rays);
 
-template void ConnectivityTracer::FindMeshEntry<viskores::Float32>(Ray<viskores::Float32>& rays);
+template VISKORES_RENDERING_RAYTRACING_EXPORT std::vector<PartialComposite<viskores::Float32>>
+ConnectivityTracer::PartialTrace<viskores::Float32>(Ray<viskores::Float32>& rays);
 
-template void ConnectivityTracer::FullTrace<viskores::Float64>(Ray<viskores::Float64>& rays);
+template VISKORES_RENDERING_RAYTRACING_EXPORT void
+ConnectivityTracer::IntegrateMeshSegment<viskores::Float32>(Ray<viskores::Float32>& rays);
 
-template std::vector<PartialComposite<viskores::Float64>>
-ConnectivityTracer::PartialTrace<viskores::Float64>(Ray<viskores::Float64>& rays);
+template VISKORES_RENDERING_RAYTRACING_EXPORT void
+ConnectivityTracer::FindMeshEntry<viskores::Float32>(Ray<viskores::Float32>& rays);
 
-template void ConnectivityTracer::IntegrateMeshSegment<viskores::Float64>(
+template VISKORES_RENDERING_RAYTRACING_EXPORT void ConnectivityTracer::FullTrace<viskores::Float64>(
   Ray<viskores::Float64>& rays);
 
-template void ConnectivityTracer::FindMeshEntry<viskores::Float64>(Ray<viskores::Float64>& rays);
+template VISKORES_RENDERING_RAYTRACING_EXPORT std::vector<PartialComposite<viskores::Float64>>
+ConnectivityTracer::PartialTrace<viskores::Float64>(Ray<viskores::Float64>& rays);
+
+template VISKORES_RENDERING_RAYTRACING_EXPORT void
+ConnectivityTracer::IntegrateMeshSegment<viskores::Float64>(Ray<viskores::Float64>& rays);
+
+template VISKORES_RENDERING_RAYTRACING_EXPORT void
+ConnectivityTracer::FindMeshEntry<viskores::Float64>(Ray<viskores::Float64>& rays);
 }
 }
 } // namespace viskores::rendering::raytracing

--- a/viskores/rendering/raytracing/ConnectivityTracer.h
+++ b/viskores/rendering/raytracing/ConnectivityTracer.h
@@ -18,7 +18,7 @@
 #ifndef viskores_rendering_raytracing_ConnectivityTracer_h
 #define viskores_rendering_raytracing_ConnectivityTracer_h
 
-#include <viskores/rendering/viskores_rendering_export.h>
+#include <viskores/rendering/raytracing/viskores_rendering_raytracing_export.h>
 
 #include <viskores/cont/ArrayHandle.h>
 #include <viskores/cont/CellLocatorGeneral.h>
@@ -76,7 +76,7 @@ public:
  *        absorption and emission of N energy groups for simulated
  *        radiograhy.
  */
-class VISKORES_RENDERING_EXPORT ConnectivityTracer
+class VISKORES_RENDERING_RAYTRACING_EXPORT ConnectivityTracer
 {
 public:
   ConnectivityTracer()
@@ -226,6 +226,43 @@ protected:
   viskores::Float32 UnitScalar;
 
 }; // class ConnectivityTracer<CellType,ConnectivityType>
+
+extern template class VISKORES_RENDERING_RAYTRACING_TEMPLATE_EXPORT
+  detail::RayTracking<viskores::Float32>;
+extern template class VISKORES_RENDERING_RAYTRACING_TEMPLATE_EXPORT
+  detail::RayTracking<viskores::Float64>;
+
+extern template struct VISKORES_RENDERING_RAYTRACING_TEMPLATE_EXPORT
+  PartialComposite<viskores::Float32>;
+extern template struct VISKORES_RENDERING_RAYTRACING_TEMPLATE_EXPORT
+  PartialComposite<viskores::Float64>;
+
+extern template VISKORES_RENDERING_RAYTRACING_TEMPLATE_EXPORT void
+ConnectivityTracer::FullTrace<viskores::Float32>(Ray<viskores::Float32>& rays);
+
+extern template VISKORES_RENDERING_RAYTRACING_TEMPLATE_EXPORT
+  std::vector<PartialComposite<viskores::Float32>>
+  ConnectivityTracer::PartialTrace<viskores::Float32>(Ray<viskores::Float32>& rays);
+
+extern template VISKORES_RENDERING_RAYTRACING_TEMPLATE_EXPORT void
+ConnectivityTracer::IntegrateMeshSegment<viskores::Float32>(Ray<viskores::Float32>& rays);
+
+extern template VISKORES_RENDERING_RAYTRACING_TEMPLATE_EXPORT void
+ConnectivityTracer::FindMeshEntry<viskores::Float32>(Ray<viskores::Float32>& rays);
+
+extern template VISKORES_RENDERING_RAYTRACING_TEMPLATE_EXPORT void
+ConnectivityTracer::FullTrace<viskores::Float64>(Ray<viskores::Float64>& rays);
+
+extern template VISKORES_RENDERING_RAYTRACING_TEMPLATE_EXPORT
+  std::vector<PartialComposite<viskores::Float64>>
+  ConnectivityTracer::PartialTrace<viskores::Float64>(Ray<viskores::Float64>& rays);
+
+extern template VISKORES_RENDERING_RAYTRACING_TEMPLATE_EXPORT void
+ConnectivityTracer::IntegrateMeshSegment<viskores::Float64>(Ray<viskores::Float64>& rays);
+
+extern template VISKORES_RENDERING_RAYTRACING_TEMPLATE_EXPORT void
+ConnectivityTracer::FindMeshEntry<viskores::Float64>(Ray<viskores::Float64>& rays);
+
 }
 }
 } // namespace viskores::rendering::raytracing

--- a/viskores/rendering/raytracing/CylinderExtractor.h
+++ b/viskores/rendering/raytracing/CylinderExtractor.h
@@ -20,6 +20,8 @@
 
 #include <viskores/cont/DataSet.h>
 
+#include <viskores/rendering/raytracing/viskores_rendering_raytracing_export.h>
+
 namespace viskores
 {
 namespace rendering
@@ -32,7 +34,7 @@ namespace raytracing
  *        the edges of a cell set.
  *
  */
-class CylinderExtractor
+class VISKORES_RENDERING_RAYTRACING_EXPORT CylinderExtractor
 {
 protected:
   viskores::cont::ArrayHandle<viskores::Id3> CylIds;

--- a/viskores/rendering/raytracing/CylinderIntersector.h
+++ b/viskores/rendering/raytracing/CylinderIntersector.h
@@ -30,7 +30,7 @@ namespace raytracing
 namespace detail
 {
 }
-class CylinderIntersector : public ShapeIntersector
+class VISKORES_RENDERING_RAYTRACING_EXPORT CylinderIntersector : public ShapeIntersector
 {
 protected:
   viskores::cont::ArrayHandle<viskores::Id3> CylIds;

--- a/viskores/rendering/raytracing/GlyphExtractor.h
+++ b/viskores/rendering/raytracing/GlyphExtractor.h
@@ -20,6 +20,8 @@
 
 #include <viskores/cont/DataSet.h>
 
+#include <viskores/rendering/raytracing/viskores_rendering_raytracing_export.h>
+
 namespace viskores
 {
 namespace rendering
@@ -27,7 +29,7 @@ namespace rendering
 namespace raytracing
 {
 
-class GlyphExtractor
+class VISKORES_RENDERING_RAYTRACING_EXPORT GlyphExtractor
 {
 public:
   GlyphExtractor();

--- a/viskores/rendering/raytracing/GlyphExtractorVector.h
+++ b/viskores/rendering/raytracing/GlyphExtractorVector.h
@@ -20,6 +20,8 @@
 
 #include <viskores/cont/DataSet.h>
 
+#include <viskores/rendering/raytracing/viskores_rendering_raytracing_export.h>
+
 namespace viskores
 {
 namespace rendering
@@ -27,7 +29,7 @@ namespace rendering
 namespace raytracing
 {
 
-class GlyphExtractorVector
+class VISKORES_RENDERING_RAYTRACING_EXPORT GlyphExtractorVector
 {
 public:
   GlyphExtractorVector();

--- a/viskores/rendering/raytracing/GlyphIntersector.h
+++ b/viskores/rendering/raytracing/GlyphIntersector.h
@@ -28,7 +28,7 @@ namespace rendering
 namespace raytracing
 {
 
-class GlyphIntersector : public ShapeIntersector
+class VISKORES_RENDERING_RAYTRACING_EXPORT GlyphIntersector : public ShapeIntersector
 {
 public:
   GlyphIntersector(viskores::rendering::GlyphType glyphType);

--- a/viskores/rendering/raytracing/GlyphIntersectorVector.h
+++ b/viskores/rendering/raytracing/GlyphIntersectorVector.h
@@ -28,7 +28,7 @@ namespace rendering
 namespace raytracing
 {
 
-class GlyphIntersectorVector : public ShapeIntersector
+class VISKORES_RENDERING_RAYTRACING_EXPORT GlyphIntersectorVector : public ShapeIntersector
 {
 public:
   GlyphIntersectorVector(viskores::rendering::GlyphType glyphType);

--- a/viskores/rendering/raytracing/Logger.h
+++ b/viskores/rendering/raytracing/Logger.h
@@ -22,7 +22,7 @@
 #include <stack>
 
 #include <viskores/Types.h>
-#include <viskores/rendering/viskores_rendering_export.h>
+#include <viskores/rendering/raytracing/viskores_rendering_raytracing_export.h>
 
 namespace viskores
 {
@@ -31,7 +31,7 @@ namespace rendering
 namespace raytracing
 {
 
-class VISKORES_RENDERING_EXPORT Logger
+class VISKORES_RENDERING_RAYTRACING_EXPORT Logger
 {
 public:
   ~Logger();

--- a/viskores/rendering/raytracing/PartialComposite.h
+++ b/viskores/rendering/raytracing/PartialComposite.h
@@ -20,6 +20,7 @@
 
 #include <viskores/cont/ArrayHandle.h>
 #include <viskores/rendering/raytracing/ChannelBuffer.h>
+#include <viskores/rendering/raytracing/viskores_rendering_raytracing_export.h>
 
 namespace viskores
 {
@@ -29,7 +30,7 @@ namespace raytracing
 {
 
 template <typename FloatType>
-struct PartialComposite
+struct VISKORES_RENDERING_RAYTRACING_NO_EXPORT PartialComposite
 {
   viskores::cont::ArrayHandle<viskores::Id> PixelIds; // pixel that owns composite
   viskores::cont::ArrayHandle<FloatType> Distances;   // distance of composite end

--- a/viskores/rendering/raytracing/QuadExtractor.h
+++ b/viskores/rendering/raytracing/QuadExtractor.h
@@ -21,6 +21,8 @@
 #include <viskores/cont/DataSet.h>
 #include <viskores/rendering/viskores_rendering_export.h>
 
+#include <viskores/rendering/raytracing/viskores_rendering_raytracing_export.h>
+
 namespace viskores
 {
 namespace rendering
@@ -28,7 +30,7 @@ namespace rendering
 namespace raytracing
 {
 
-class VISKORES_RENDERING_EXPORT QuadExtractor
+class VISKORES_RENDERING_RAYTRACING_EXPORT QuadExtractor
 {
 protected:
   viskores::cont::ArrayHandle<viskores::Vec<viskores::Id, 5>> QuadIds;

--- a/viskores/rendering/raytracing/QuadIntersector.h
+++ b/viskores/rendering/raytracing/QuadIntersector.h
@@ -31,7 +31,7 @@ namespace raytracing
 namespace detail
 {
 }
-class VISKORES_RENDERING_EXPORT QuadIntersector : public ShapeIntersector
+class VISKORES_RENDERING_RAYTRACING_EXPORT QuadIntersector : public ShapeIntersector
 {
 protected:
   viskores::cont::ArrayHandle<viskores::Vec<viskores::Id, 5>> QuadIds;

--- a/viskores/rendering/raytracing/RayOperations.cxx
+++ b/viskores/rendering/raytracing/RayOperations.cxx
@@ -23,19 +23,21 @@ namespace rendering
 namespace raytracing
 {
 
-void RayOperations::MapCanvasToRays(Ray<viskores::Float32>& rays,
-                                    const viskores::rendering::raytracing::Camera& camera,
-                                    const viskores::rendering::CanvasRayTracer& canvas)
+void RayOperations::MapCanvasToRays(
+  Ray<viskores::Float32>& rays,
+  const viskores::rendering::raytracing::Camera& camera,
+  const viskores::cont::ArrayHandle<viskores::Float32>& depthBuffer)
 {
-  viskores::Id width = canvas.GetWidth();
-  viskores::Id height = canvas.GetHeight();
+  viskores::Id width = camera.GetWidth();
+  viskores::Id height = camera.GetHeight();
+  VISKORES_ASSERT(width * height == depthBuffer.GetNumberOfValues());
   viskores::Matrix<viskores::Float32, 4, 4> projview = camera.GetViewProjectionMatrix();
   bool valid;
   viskores::Matrix<viskores::Float32, 4, 4> inverse = viskores::MatrixInverse(projview, valid);
   (void)valid; // this can be a false negative for really tiny spatial domains.
   viskores::worklet::DispatcherMapField<detail::RayMapCanvas>(
     detail::RayMapCanvas(inverse, width, height, camera.GetPosition()))
-    .Invoke(rays.PixelIdx, rays.MaxDistance, rays.Origin, canvas.GetDepthBuffer());
+    .Invoke(rays.PixelIdx, rays.MaxDistance, rays.Origin, depthBuffer);
 }
 }
 }

--- a/viskores/rendering/raytracing/RayOperations.h
+++ b/viskores/rendering/raytracing/RayOperations.h
@@ -19,12 +19,11 @@
 #define viskores_rendering_raytracing_Ray_Operations_h
 
 #include <viskores/Matrix.h>
-#include <viskores/rendering/CanvasRayTracer.h>
 #include <viskores/rendering/raytracing/Camera.h>
 #include <viskores/rendering/raytracing/ChannelBufferOperations.h>
 #include <viskores/rendering/raytracing/Ray.h>
 #include <viskores/rendering/raytracing/Worklets.h>
-#include <viskores/rendering/viskores_rendering_export.h>
+#include <viskores/rendering/raytracing/viskores_rendering_raytracing_export.h>
 
 namespace viskores
 {
@@ -141,10 +140,10 @@ public:
     dispatcher.Invoke(rays.HitIdx, rays.Status);
   }
 
-  VISKORES_RENDERING_EXPORT static void MapCanvasToRays(
+  VISKORES_RENDERING_RAYTRACING_EXPORT static void MapCanvasToRays(
     Ray<viskores::Float32>& rays,
     const viskores::rendering::raytracing::Camera& camera,
-    const viskores::rendering::CanvasRayTracer& canvas);
+    const viskores::cont::ArrayHandle<viskores::Float32>& depthBuffer);
 
   template <typename T>
   static viskores::Id RaysInMesh(Ray<T>& rays)

--- a/viskores/rendering/raytracing/RayTracer.h
+++ b/viskores/rendering/raytracing/RayTracer.h
@@ -32,7 +32,7 @@ namespace rendering
 namespace raytracing
 {
 
-class VISKORES_RENDERING_EXPORT RayTracer
+class VISKORES_RENDERING_RAYTRACING_EXPORT RayTracer
 {
 protected:
   std::vector<std::shared_ptr<ShapeIntersector>> Intersectors;

--- a/viskores/rendering/raytracing/RunTriangulator.cxx
+++ b/viskores/rendering/raytracing/RunTriangulator.cxx
@@ -19,7 +19,7 @@
 #include <viskores/rendering/raytracing/RunTriangulator.h>
 
 #include <viskores/cont/TryExecute.h>
-#include <viskores/rendering/Triangulator.h>
+#include <viskores/rendering/raytracing/Triangulator.h>
 
 namespace viskores
 {
@@ -33,7 +33,7 @@ void RunTriangulator(const viskores::cont::UnknownCellSet& cellSet,
                      viskores::Id& numberOfTriangles,
                      const viskores::cont::Field& ghostField)
 {
-  viskores::rendering::Triangulator triangulator;
+  viskores::rendering::raytracing::Triangulator triangulator;
   triangulator.Run(cellSet, indices, numberOfTriangles, ghostField);
 }
 

--- a/viskores/rendering/raytracing/RunTriangulator.h
+++ b/viskores/rendering/raytracing/RunTriangulator.h
@@ -18,7 +18,7 @@
 #ifndef viskores_rendering_raytracing_RunTriangulator_h
 #define viskores_rendering_raytracing_RunTriangulator_h
 
-#include <viskores/rendering/viskores_rendering_export.h>
+#include <viskores/rendering/raytracing/viskores_rendering_raytracing_export.h>
 
 #include <viskores/cont/ArrayHandle.h>
 #include <viskores/cont/Field.h>
@@ -37,7 +37,7 @@ namespace raytracing
 /// really is a stop-gap. Eventually, the Triangulator should be moved to
 /// filters, and filters should be compiled in a library (for the same reason).
 ///
-VISKORES_RENDERING_EXPORT
+VISKORES_RENDERING_RAYTRACING_EXPORT
 void RunTriangulator(const viskores::cont::UnknownCellSet& cellSet,
                      viskores::cont::ArrayHandle<viskores::Id4>& indices,
                      viskores::Id& numberOfTriangles,

--- a/viskores/rendering/raytracing/ScalarRenderer.h
+++ b/viskores/rendering/raytracing/ScalarRenderer.h
@@ -33,7 +33,7 @@ namespace rendering
 namespace raytracing
 {
 
-class VISKORES_RENDERING_EXPORT ScalarRenderer
+class VISKORES_RENDERING_RAYTRACING_EXPORT ScalarRenderer
 {
 private:
   viskores::cont::Invoker Invoke;

--- a/viskores/rendering/raytracing/ShapeIntersector.h
+++ b/viskores/rendering/raytracing/ShapeIntersector.h
@@ -29,7 +29,7 @@ namespace rendering
 namespace raytracing
 {
 
-class VISKORES_RENDERING_EXPORT ShapeIntersector
+class VISKORES_RENDERING_RAYTRACING_EXPORT ShapeIntersector
 {
 protected:
   LinearBVH BVH;

--- a/viskores/rendering/raytracing/SphereExtractor.h
+++ b/viskores/rendering/raytracing/SphereExtractor.h
@@ -19,7 +19,7 @@
 #define viskores_rendering_raytracing_Sphere_Extractor_h
 
 #include <viskores/cont/DataSet.h>
-#include <viskores/rendering/viskores_rendering_export.h>
+#include <viskores/rendering/raytracing/viskores_rendering_raytracing_export.h>
 
 namespace viskores
 {
@@ -28,7 +28,7 @@ namespace rendering
 namespace raytracing
 {
 
-class VISKORES_RENDERING_EXPORT SphereExtractor
+class VISKORES_RENDERING_RAYTRACING_EXPORT SphereExtractor
 {
 protected:
   viskores::cont::ArrayHandle<viskores::Id> PointIds;

--- a/viskores/rendering/raytracing/SphereIntersector.h
+++ b/viskores/rendering/raytracing/SphereIntersector.h
@@ -19,7 +19,7 @@
 #define viskores_rendering_raytracing_Sphere_Intersector_h
 
 #include <viskores/rendering/raytracing/ShapeIntersector.h>
-#include <viskores/rendering/viskores_rendering_export.h>
+#include <viskores/rendering/raytracing/viskores_rendering_raytracing_export.h>
 
 namespace viskores
 {
@@ -28,7 +28,7 @@ namespace rendering
 namespace raytracing
 {
 
-class VISKORES_RENDERING_EXPORT SphereIntersector : public ShapeIntersector
+class VISKORES_RENDERING_RAYTRACING_EXPORT SphereIntersector : public ShapeIntersector
 {
 protected:
   viskores::cont::ArrayHandle<viskores::Id> PointIds;

--- a/viskores/rendering/raytracing/TriangleExtractor.h
+++ b/viskores/rendering/raytracing/TriangleExtractor.h
@@ -20,7 +20,7 @@
 
 #include <viskores/cont/DataSet.h>
 #include <viskores/cont/Field.h>
-#include <viskores/rendering/viskores_rendering_export.h>
+#include <viskores/rendering/raytracing/viskores_rendering_raytracing_export.h>
 
 namespace viskores
 {
@@ -29,7 +29,7 @@ namespace rendering
 namespace raytracing
 {
 
-class VISKORES_RENDERING_EXPORT TriangleExtractor
+class VISKORES_RENDERING_RAYTRACING_EXPORT TriangleExtractor
 {
 protected:
   viskores::cont::ArrayHandle<viskores::Id4> Triangles; // (cellid, v0, v1, v2)

--- a/viskores/rendering/raytracing/TriangleIntersector.h
+++ b/viskores/rendering/raytracing/TriangleIntersector.h
@@ -21,7 +21,7 @@
 #include <viskores/cont/DataSet.h>
 #include <viskores/rendering/raytracing/Ray.h>
 #include <viskores/rendering/raytracing/ShapeIntersector.h>
-#include <viskores/rendering/viskores_rendering_export.h>
+#include <viskores/rendering/raytracing/viskores_rendering_raytracing_export.h>
 
 namespace viskores
 {
@@ -30,7 +30,7 @@ namespace rendering
 namespace raytracing
 {
 
-class VISKORES_RENDERING_EXPORT TriangleIntersector : public ShapeIntersector
+class VISKORES_RENDERING_RAYTRACING_EXPORT TriangleIntersector : public ShapeIntersector
 {
 protected:
   viskores::cont::ArrayHandle<viskores::Id4> Triangles;

--- a/viskores/rendering/raytracing/VolumeRendererStructured.h
+++ b/viskores/rendering/raytracing/VolumeRendererStructured.h
@@ -21,7 +21,7 @@
 #include <viskores/cont/DataSet.h>
 
 #include <viskores/rendering/raytracing/Ray.h>
-#include <viskores/rendering/viskores_rendering_export.h>
+#include <viskores/rendering/raytracing/viskores_rendering_raytracing_export.h>
 
 namespace viskores
 {
@@ -30,7 +30,7 @@ namespace rendering
 namespace raytracing
 {
 
-class VISKORES_RENDERING_EXPORT VolumeRendererStructured
+class VISKORES_RENDERING_RAYTRACING_EXPORT VolumeRendererStructured
 {
 public:
   VISKORES_CONT

--- a/viskores/rendering/raytracing/viskores.module
+++ b/viskores/rendering/raytracing/viskores.module
@@ -1,0 +1,9 @@
+NAME
+  viskores_rendering_raytracing
+GROUPS
+  Rendering
+DEPENDS
+  viskores_cont
+PRIVATE_DEPENDS
+  viskores_worklet
+NO_TESTING

--- a/viskores/rendering/viskores.module
+++ b/viskores/rendering/viskores.module
@@ -6,6 +6,7 @@ DEPENDS
   viskores_filter_image_processing
   viskores_filter_entity_extraction
   viskores_io
+  viskores_rendering_raytracing
 PRIVATE_DEPENDS
   viskores_worklet
 TEST_DEPENDS


### PR DESCRIPTION
The rendering library is becoming a rat's nest of dependencies. We can help resolve them by putting the raytracing code in its own library.