### PR TITLE
Add cylinder geometry to ANARI.

### DIFF
--- a/viskores/interop/anari/testing/CMakeLists.txt
+++ b/viskores/interop/anari/testing/CMakeLists.txt
@@ -22,6 +22,7 @@ SOURCES
   UnitTestANARIMapperPoints.cxx
   UnitTestANARIMapperTriangles.cxx
   UnitTestANARIMapperVolume.cxx
+  UnitTestANARIGeometryCylinder.cxx
   UnitTestANARIGeometryQuad.cxx
   UnitTestANARIScene.cxx
   )

--- a/viskores/interop/anari/testing/UnitTestANARIGeometryCylinder.cxx
+++ b/viskores/interop/anari/testing/UnitTestANARIGeometryCylinder.cxx
@@ -1,0 +1,139 @@
+//============================================================================
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//============================================================================
+
+// viskores
+#include <viskores/cont/testing/Testing.h>
+#include <viskores/io/EncodePNG.h>
+
+#include "ANARITestCommon.h"
+
+namespace
+{
+
+void RenderTests()
+{
+  // Initialize ANARI /////////////////////////////////////////////////////////
+
+  auto d = loadANARIDevice();
+
+  const char** extensions = nullptr;
+  anariGetProperty(d, d, "extension", ANARI_STRING_LIST, &extensions, sizeof(char**), ANARI_WAIT);
+  bool cylindersSupported = false;
+  for (int i = 0; extensions[i] != nullptr; ++i)
+  {
+    if (extensions[i] == std::string("KHR_GEOMETRY_CYLINDER") ||
+        extensions[i] == std::string("ANARI_KHR_GEOMETRY_CYLINDER"))
+    {
+      cylindersSupported = true;
+      break;
+    }
+  }
+  if (!cylindersSupported)
+  {
+    VISKORES_TEST_SKIP("ANARI KHR_GEOMETRY_CYLINDER extension not supported by ANARI device.");
+  }
+
+  // Create ANARI cylinder geometry //////////////////////////////////////////
+
+  auto vertices = anari_cpp::newArray1D(d, ANARI_FLOAT32_VEC3, 4);
+  auto* positions = anari_cpp::map<viskores::Vec3f_32>(d, vertices);
+  positions[0] = viskores::Vec3f_32(-0.8f, -0.25f, 0.f);
+  positions[1] = viskores::Vec3f_32(0.6f, -0.25f, 0.f);
+  positions[2] = viskores::Vec3f_32(-0.45f, 0.35f, -0.35f);
+  positions[3] = viskores::Vec3f_32(0.4f, 0.35f, 0.35f);
+  anari_cpp::unmap(d, vertices);
+
+  auto indices = anari_cpp::newArray1D(d, ANARI_UINT32_VEC2, 2);
+  auto* cylinders = anari_cpp::map<viskores::Vec2ui_32>(d, indices);
+  cylinders[0] = viskores::Vec2ui_32(0, 1);
+  cylinders[1] = viskores::Vec2ui_32(2, 3);
+  anari_cpp::unmap(d, indices);
+
+  auto radii = anari_cpp::newArray1D(d, ANARI_FLOAT32, 2);
+  auto* cylinderRadii = anari_cpp::map<viskores::Float32>(d, radii);
+  cylinderRadii[0] = 0.18f;
+  cylinderRadii[1] = 0.12f;
+  anari_cpp::unmap(d, radii);
+
+  auto caps = anari_cpp::newArray1D(d, ANARI_UINT8, 4);
+  auto* vertexCaps = anari_cpp::map<viskores::UInt8>(d, caps);
+  vertexCaps[0] = 1;
+  vertexCaps[1] = 1;
+  vertexCaps[2] = 1;
+  vertexCaps[3] = 0;
+  anari_cpp::unmap(d, caps);
+
+  auto attributes = anari_cpp::newArray1D(d, ANARI_FLOAT32, 2);
+  auto* primitiveAttributes = anari_cpp::map<viskores::Float32>(d, attributes);
+  primitiveAttributes[0] = 0.f;
+  primitiveAttributes[1] = 1.f;
+  anari_cpp::unmap(d, attributes);
+
+  auto geometry = anari_cpp::newObject<anari_cpp::Geometry>(d, "cylinder");
+  anari_cpp::setAndReleaseParameter(d, geometry, "vertex.position", vertices);
+  anari_cpp::setAndReleaseParameter(d, geometry, "primitive.index", indices);
+  anari_cpp::setAndReleaseParameter(d, geometry, "primitive.radius", radii);
+  anari_cpp::setAndReleaseParameter(d, geometry, "vertex.cap", caps);
+  anari_cpp::setAndReleaseParameter(d, geometry, "primitive.attribute0", attributes);
+  anari_cpp::setParameter(d, geometry, "caps", "none");
+  anari_cpp::commitParameters(d, geometry);
+
+  // Assemble ANARI scene /////////////////////////////////////////////////////
+
+  auto colorArray = anari_cpp::newArray1D(d, ANARI_FLOAT32_VEC4, 2);
+  auto* colors = anari_cpp::map<viskores::Vec4f_32>(d, colorArray);
+  colors[0] = viskores::Vec4f_32(0.95f, 0.15f, 0.1f, 1.f);
+  colors[1] = viskores::Vec4f_32(0.1f, 0.55f, 0.95f, 1.f);
+  anari_cpp::unmap(d, colorArray);
+
+  auto sampler = anari_cpp::newObject<anari_cpp::Sampler>(d, "image1D");
+  anari_cpp::setAndReleaseParameter(d, sampler, "image", colorArray);
+  anari_cpp::setParameter(d, sampler, "filter", "nearest");
+  anari_cpp::setParameter(d, sampler, "wrapMode", "clampToEdge");
+  anari_cpp::setParameter(d, sampler, "inAttribute", "attribute0");
+  anari_cpp::commitParameters(d, sampler);
+
+  auto material = anari_cpp::newObject<anari_cpp::Material>(d, "matte");
+  anari_cpp::setParameter(d, material, "color", sampler);
+  anari_cpp::commitParameters(d, material);
+  anari_cpp::release(d, sampler);
+
+  auto surface = anari_cpp::newObject<anari_cpp::Surface>(d);
+  anari_cpp::setParameter(d, surface, "geometry", geometry);
+  anari_cpp::setParameter(d, surface, "material", material);
+  anari_cpp::commitParameters(d, surface);
+  anari_cpp::release(d, geometry);
+  anari_cpp::release(d, material);
+
+  auto world = anari_cpp::newObject<anari_cpp::World>(d);
+  anari_cpp::setParameterArray1D(d, world, "surface", &surface, 1);
+  anari_cpp::commitParameters(d, world);
+  anari_cpp::release(d, surface);
+
+  // Render a frame ///////////////////////////////////////////////////////////
+
+  renderTestANARIImage(d,
+                       world,
+                       viskores::Vec3f_32(1.7f, -2.f, 1.2f),
+                       viskores::Vec3f_32(-0.58f, 0.69f, -0.43f),
+                       viskores::Vec3f_32(0.f, 0.f, 1.f),
+                       "interop/anari/cylinder.png",
+                       viskores::Vec2ui_32(512, 512));
+
+  // Cleanup //////////////////////////////////////////////////////////////////
+
+  anari_cpp::release(d, world);
+  anari_cpp::release(d, d);
+}
+
+} // namespace
+
+int UnitTestANARIGeometryCylinder(int argc, char* argv[])
+{
+  return viskores::cont::testing::Testing::Run(RenderTests, argc, argv);
+}

--- a/viskores/rendering/anari-device/CMakeLists.txt
+++ b/viskores/rendering/anari-device/CMakeLists.txt
@@ -43,6 +43,7 @@ set (sources
 set(device_sources
   array/ArrayConversion.cpp
   frame/Frame.cpp
+  scene/surface/geometry/Cylinder.cpp
   scene/surface/geometry/Quad.cpp
   scene/surface/geometry/Sphere.cpp
   scene/surface/geometry/Triangle.cpp

--- a/viskores/rendering/anari-device/scene/surface/geometry/Cylinder.cpp
+++ b/viskores/rendering/anari-device/scene/surface/geometry/Cylinder.cpp
@@ -1,0 +1,280 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#include "Cylinder.h"
+// Viskores
+#include <viskores/CellShape.h>
+#include <viskores/cont/Algorithm.h>
+#include <viskores/cont/ArrayCopy.h>
+#include <viskores/cont/ArrayHandleConstant.h>
+#include <viskores/cont/ArrayHandleRuntimeVec.h>
+#include <viskores/cont/CellSetSingleType.h>
+#include <viskores/cont/Invoker.h>
+#include <viskores/rendering/CanvasRayTracer.h>
+#include <viskores/rendering/raytracing/CylinderExtractor.h>
+#include <viskores/rendering/raytracing/CylinderIntersector.h>
+#include <viskores/rendering/raytracing/RayOperations.h>
+#include <viskores/rendering/raytracing/RayTracer.h>
+#include <viskores/worklet/WorkletMapField.h>
+// std
+#include <numeric>
+
+namespace viskores_device
+{
+namespace
+{
+
+class BuildCylinderCapMasks : public viskores::worklet::WorkletMapField
+{
+public:
+  viskores::UInt8 GlobalMask{ 0 };
+  viskores::Id NumberOfVertices{ 0 };
+  viskores::Id NumberOfCylinders{ 0 };
+  viskores::Id NumberOfCaps{ 0 };
+
+  VISKORES_CONT
+  BuildCylinderCapMasks(viskores::UInt8 globalMask,
+                        viskores::Id numberOfVertices,
+                        viskores::Id numberOfCylinders,
+                        viskores::Id numberOfCaps)
+    : GlobalMask(globalMask)
+    , NumberOfVertices(numberOfVertices)
+    , NumberOfCylinders(numberOfCylinders)
+    , NumberOfCaps(numberOfCaps)
+  {
+  }
+
+  using ControlSignature = void(FieldIn, FieldOut, WholeArrayIn);
+  using ExecutionSignature = void(_1, _2, _3, WorkIndex);
+
+  template <typename CapPortalType>
+  VISKORES_EXEC void operator()(const viskores::Id3& cylinderId,
+                                viskores::UInt8& capMask,
+                                const CapPortalType& caps,
+                                viskores::Id workIndex) const
+  {
+    if (this->NumberOfCaps >= this->NumberOfVertices)
+    {
+      capMask = 0;
+      if (caps.Get(cylinderId[1]) != 0)
+        capMask |= 1;
+      if (caps.Get(cylinderId[2]) != 0)
+        capMask |= 2;
+    }
+    else if (this->NumberOfCaps >= this->NumberOfCylinders * 2)
+    {
+      capMask = 0;
+      if (caps.Get(2 * workIndex) != 0)
+        capMask |= 1;
+      if (caps.Get(2 * workIndex + 1) != 0)
+        capMask |= 2;
+    }
+    else if (this->NumberOfCaps >= this->NumberOfCylinders)
+    {
+      capMask = caps.Get(workIndex) != 0 ? viskores::UInt8(3) : viskores::UInt8(0);
+    }
+    else
+    {
+      capMask = this->GlobalMask;
+    }
+  }
+};
+
+} // anonymous namespace
+
+Cylinder::Cylinder(ViskoresDeviceGlobalState* s)
+  : Geometry(s)
+  , m_index(this)
+  , m_radius(this)
+  , m_caps(this)
+{
+  this->m_vertexAttributes.setAttributes(
+    this, { "position", "color", "attribute0", "attribute1", "attribute2", "attribute3" });
+  this->m_vertexAttributes.setAnariAssociation("vertex");
+  this->m_vertexAttributes.setViskoresAssociation(viskores::cont::Field::Association::Points);
+}
+
+void Cylinder::commitParameters()
+{
+  this->Geometry::commitParameters();
+
+  this->m_index = getParamObject<Array1D>("primitive.index");
+  this->m_radius = getParamObject<Array1D>("primitive.radius");
+  this->m_caps = getParamObject<Array1D>("vertex.cap");
+  this->m_globalRadius = getParam<float>("radius", 0.01f);
+  this->m_globalCapMask = this->ParseCaps(this->getParamString("caps", "none"));
+  this->m_vertexAttributes.commitParameters();
+}
+
+void Cylinder::finalize()
+{
+  this->m_dataSet = viskores::cont::DataSet{};
+  this->m_cylinderIds = viskores::cont::ArrayHandle<viskores::Id3>{};
+  this->m_radii = viskores::cont::ArrayHandle<viskores::Float32>{};
+  this->m_capMasks = viskores::cont::ArrayHandle<viskores::UInt8>{};
+  this->m_cylinderIntersector.reset();
+
+  helium::ChangeObserverPtr<Array1D>& positionArray = this->m_vertexAttributes.getParam("position");
+  if (!positionArray)
+  {
+    reportMessage(ANARI_SEVERITY_WARNING,
+                  "'cylinder' geometry missing 'vertex.position' parameter");
+    return;
+  }
+
+  if (!this->m_index)
+  {
+    reportMessage(ANARI_SEVERITY_INFO, "generating 'cylinder' index array");
+
+    Array1DMemoryDescriptor md;
+    md.appMemory = nullptr;
+    md.deleter = nullptr;
+    md.deleterPtr = nullptr;
+    md.elementType = ANARI_UINT32_VEC2;
+    md.numItems = positionArray->totalSize() / 2;
+
+    this->m_index = new Array1D(this->deviceState(), md);
+    this->m_index->refDec(helium::RefType::PUBLIC); // no public references
+
+    auto* begin = (uint32_t*)this->m_index->map();
+    auto* end = begin + this->m_index->totalSize() * 2;
+    std::iota(begin, end, 0);
+  }
+
+  viskores::cont::ArrayHandleRuntimeVec<viskores::Id> connectionArray(2);
+  viskores::cont::ArrayCopyShallowIfPossible(this->m_index->dataAsViskoresArray(), connectionArray);
+
+  viskores::cont::CellSetSingleType<> cellSet;
+  cellSet.Fill(static_cast<viskores::Id>(positionArray->size()),
+               viskores::CELL_SHAPE_LINE,
+               2,
+               connectionArray.GetComponentsArray());
+  this->m_dataSet.SetCellSet(cellSet);
+
+  this->Geometry::finalize();
+  this->m_vertexAttributes.setFields(this->m_dataSet);
+
+  this->m_dataSet.AddCoordinateSystem("position");
+
+  viskores::rendering::raytracing::CylinderExtractor cylinderExtractor;
+  cylinderExtractor.ExtractCells(this->m_dataSet.GetCellSet(), this->m_globalRadius);
+
+  this->m_cylinderIds = cylinderExtractor.GetCylIds();
+  this->BuildRadii(cylinderExtractor.GetNumberOfCylinders());
+  this->BuildCapMasks();
+
+  if (this->m_cylinderIds.GetNumberOfValues() > 0)
+  {
+    this->m_cylinderIntersector =
+      std::make_shared<viskores::rendering::raytracing::CylinderIntersector>();
+    this->m_cylinderIntersector->SetData(
+      this->m_dataSet.GetCoordinateSystem(), this->m_cylinderIds, this->m_radii, this->m_capMasks);
+  }
+}
+
+void Cylinder::render(viskores::rendering::Canvas& canvas,
+                      const viskores::rendering::Camera& camera,
+                      const viskores::cont::Field& field,
+                      const viskores::cont::ArrayHandle<viskores::Vec4f_32>& colorMap) const
+{
+  viskores::rendering::raytracing::RayTracer tracer;
+
+  viskores::Bounds shapeBounds;
+  viskores::Range scalarRange = field.GetRange().ReadPortal().Get(0);
+
+  if (this->m_cylinderIntersector)
+  {
+    tracer.AddShapeIntersector(this->m_cylinderIntersector);
+    shapeBounds.Include(this->m_cylinderIntersector->GetShapeBounds());
+  }
+
+  viskores::Int32 width = (viskores::Int32)canvas.GetWidth();
+  viskores::Int32 height = (viskores::Int32)canvas.GetHeight();
+
+  viskores::rendering::raytracing::Camera rayCamera = camera.CreateRaytracingCamera(width, height);
+
+  viskores::rendering::raytracing::Ray<viskores::Float32> rays;
+  viskores::rendering::CanvasRayTracer* canvasRT =
+    dynamic_cast<viskores::rendering::CanvasRayTracer*>(&canvas);
+  VISKORES_ASSERT(canvasRT != nullptr);
+
+  rayCamera.CreateRays(rays, shapeBounds);
+  tracer.GetCamera() = rayCamera;
+  rays.Buffers.at(0).InitConst(0.f);
+  viskores::rendering::raytracing::RayOperations::MapCanvasToRays(
+    rays, camera.CreateRaytracingCamera(width, height), canvasRT->GetDepthBuffer());
+
+  tracer.SetField(field, scalarRange);
+  tracer.SetColorMap(colorMap);
+  tracer.SetShadingOn(true);
+  tracer.Render(rays);
+
+  canvasRT->WriteToCanvas(rays, rays.Buffers.at(0).Buffer, camera);
+}
+
+bool Cylinder::isValid() const
+{
+  return this->m_vertexAttributes.getParam("position");
+}
+
+viskores::UInt8 Cylinder::ParseCaps(const std::string& caps)
+{
+  if (caps == "none")
+    return 0;
+  if (caps == "first")
+    return 1;
+  if (caps == "second")
+    return 2;
+  if (caps == "both")
+    return 3;
+
+  reportMessage(ANARI_SEVERITY_WARNING, "invalid 'caps' value on 'cylinder' geometry");
+  return 0;
+}
+
+void Cylinder::BuildRadii(viskores::Id numberOfCylinders)
+{
+  if (this->m_radius && this->m_radius->size() >= static_cast<size_t>(numberOfCylinders))
+  {
+    viskores::cont::ArrayCopyShallowIfPossible(this->m_radius->dataAsViskoresArray(),
+                                               this->m_radii);
+  }
+  else
+  {
+    this->m_radii.AllocateAndFill(numberOfCylinders, this->m_globalRadius);
+  }
+}
+
+void Cylinder::BuildCapMasks()
+{
+  const viskores::Id numberOfCylinders = this->m_cylinderIds.GetNumberOfValues();
+
+  if (this->m_caps)
+  {
+    auto& positionArray = this->m_vertexAttributes.getParam("position");
+    viskores::cont::ArrayHandle<viskores::UInt8> caps;
+    viskores::cont::ArrayCopyShallowIfPossible(this->m_caps->dataAsViskoresArray(), caps);
+
+    viskores::cont::Invoker invoke;
+    invoke(BuildCylinderCapMasks(this->m_globalCapMask,
+                                 static_cast<viskores::Id>(positionArray->size()),
+                                 numberOfCylinders,
+                                 static_cast<viskores::Id>(this->m_caps->size())),
+           this->m_cylinderIds,
+           this->m_capMasks,
+           caps);
+  }
+  else
+  {
+    this->m_capMasks.AllocateAndFill(numberOfCylinders, this->m_globalCapMask);
+  }
+}
+
+} // namespace viskores_device

--- a/viskores/rendering/anari-device/scene/surface/geometry/Cylinder.h
+++ b/viskores/rendering/anari-device/scene/surface/geometry/Cylinder.h
@@ -1,0 +1,71 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#pragma once
+
+#include "Geometry.h"
+#include "array/Array1D.h"
+
+#include <viskores/cont/ArrayHandle.h>
+
+#include <memory>
+#include <string>
+
+namespace viskores
+{
+namespace rendering
+{
+namespace raytracing
+{
+class CylinderIntersector;
+}
+}
+}
+
+namespace viskores_device
+{
+
+struct Cylinder : public Geometry
+{
+  Cylinder(ViskoresDeviceGlobalState* s);
+
+  void commitParameters() override;
+  void finalize() override;
+
+  bool isValid() const override;
+
+  virtual void render(
+    viskores::rendering::Canvas& canvas,
+    const viskores::rendering::Camera& camera,
+    const viskores::cont::Field& field,
+    const viskores::cont::ArrayHandle<viskores::Vec4f_32>& colorMap) const override;
+
+private:
+  viskores::UInt8 ParseCaps(const std::string& caps);
+
+  void BuildRadii(viskores::Id numberOfCylinders);
+
+  void BuildCapMasks();
+
+  helium::ChangeObserverPtr<Array1D> m_index;
+  helium::ChangeObserverPtr<Array1D> m_radius;
+  helium::ChangeObserverPtr<Array1D> m_caps;
+  FieldArrayParameters m_vertexAttributes;
+
+  viskores::cont::ArrayHandle<viskores::Id3> m_cylinderIds;
+  viskores::cont::ArrayHandle<viskores::Float32> m_radii;
+  viskores::cont::ArrayHandle<viskores::UInt8> m_capMasks;
+  std::shared_ptr<viskores::rendering::raytracing::CylinderIntersector> m_cylinderIntersector;
+
+  float m_globalRadius{ 0.01f };
+  viskores::UInt8 m_globalCapMask{ 0 };
+};
+
+} // namespace viskores_device

--- a/viskores/rendering/anari-device/scene/surface/geometry/Geometry.cpp
+++ b/viskores/rendering/anari-device/scene/surface/geometry/Geometry.cpp
@@ -10,6 +10,7 @@
 
 #include "Geometry.h"
 // subtypes
+#include "Cylinder.h"
 #include "Quad.h"
 #include "Sphere.h"
 #include "Triangle.h"
@@ -37,6 +38,8 @@ Geometry* Geometry::createInstance(std::string_view subtype, ViskoresDeviceGloba
   // std::cout << "Creating geometry of type " << subtype << "\n";
   if (subtype == "triangle")
     return new Triangle(s);
+  else if (subtype == "cylinder")
+    return new Cylinder(s);
   else if (subtype == "quad")
     return new Quad(s);
   else if (subtype == "sphere")
@@ -60,9 +63,7 @@ void Geometry::FieldArrayParameters::setAttributes(Geometry* self,
 {
   this->m_geometry = self;
   for (auto&& attrib : attributes)
-  {
     this->m_attributes.emplace(attrib, self);
-  }
 }
 
 void Geometry::FieldArrayParameters::setAnariAssociation(const std::string& association)
@@ -90,9 +91,7 @@ void Geometry::FieldArrayParameters::setFields(viskores::cont::DataSet& dataSet)
   for (auto& iter : this->m_attributes)
   {
     if (iter.second)
-    {
       dataSet.AddField(iter.first, this->m_viskoresAssociation, iter.second->dataAsViskoresArray());
-    }
   }
 }
 

--- a/viskores/rendering/anari-device/viskores_device.json
+++ b/viskores/rendering/anari-device/viskores_device.json
@@ -7,6 +7,7 @@
       "anari_core_objects_base_1_0",
       "khr_camera_orthographic",
       "khr_camera_perspective",
+      "khr_geometry_cylinder",
       "khr_geometry_quad",
       "khr_geometry_triangle",
       "khr_material_matte",

--- a/viskores/rendering/raytracing/CylinderIntersector.cxx
+++ b/viskores/rendering/raytracing/CylinderIntersector.cxx
@@ -158,16 +158,27 @@ public:
   using IdArrayPortal = typename IdHandle::ReadPortalType;
   using FloatHandle = viskores::cont::ArrayHandle<viskores::Float32>;
   using FloatPortal = typename FloatHandle::ReadPortalType;
+  using UInt8Handle = viskores::cont::ArrayHandle<viskores::UInt8>;
+  using UInt8Portal = typename UInt8Handle::ReadPortalType;
   IdArrayPortal CylIds;
   FloatPortal Radii;
+  UInt8Portal CapMasks;
+  bool UseCapMasks;
 
-  CylinderLeafIntersector() {}
+  CylinderLeafIntersector()
+    : UseCapMasks(false)
+  {
+  }
 
   CylinderLeafIntersector(const IdHandle& cylIds,
                           const FloatHandle& radii,
+                          const UInt8Handle& capMasks,
+                          bool useCapMasks,
                           viskores::cont::Token& token)
     : CylIds(cylIds.PrepareForInput(Device(), token))
     , Radii(radii.PrepareForInput(Device(), token))
+    , CapMasks(capMasks.PrepareForInput(Device(), token))
+    , UseCapMasks(useCapMasks)
   {
   }
 
@@ -263,6 +274,106 @@ public:
     return vec3(1, t * nlen, 0);
   }
 
+  template <typename Precision>
+  VISKORES_EXEC void CheckHit(const Precision& t,
+                              const Precision& minDistance,
+                              Precision& closestDistance,
+                              Precision& hitType,
+                              const Precision& candidateType) const
+  {
+    if (t < closestDistance && t > minDistance)
+    {
+      closestDistance = t;
+      hitType = candidateType;
+    }
+  }
+
+  template <typename vec3, typename Precision>
+  VISKORES_EXEC bool cappedCylinder(const vec3& rayStart,
+                                    const vec3& rayDirection,
+                                    const vec3& first,
+                                    const vec3& second,
+                                    const Precision& radius,
+                                    const viskores::UInt8 capMask,
+                                    const Precision& minDistance,
+                                    Precision& closestDistance,
+                                    Precision& hitType) const
+  {
+    constexpr Precision epsilon = Precision(1e-6f);
+
+    const vec3 axis = second - first;
+    const vec3 relOrigin = rayStart - first;
+    const Precision axisLength2 = viskores::dot(axis, axis);
+    if (axisLength2 <= epsilon)
+    {
+      return false;
+    }
+
+    const Precision rayAxis = viskores::dot(rayDirection, axis);
+    const Precision originAxis = viskores::dot(relOrigin, axis);
+    const Precision rayLength2 = viskores::dot(rayDirection, rayDirection);
+    const Precision originLength2 = viskores::dot(relOrigin, relOrigin);
+    const Precision originRay = viskores::dot(relOrigin, rayDirection);
+    const Precision radius2 = radius * radius;
+
+    bool hit = false;
+    const Precision originalClosest = closestDistance;
+
+    const Precision a = axisLength2 * rayLength2 - rayAxis * rayAxis;
+    const Precision b = axisLength2 * originRay - originAxis * rayAxis;
+    const Precision c =
+      axisLength2 * originLength2 - originAxis * originAxis - radius2 * axisLength2;
+
+    if (viskores::Abs(a) > epsilon)
+    {
+      const Precision discriminant = b * b - a * c;
+      if (discriminant >= Precision(0))
+      {
+        const Precision sqrtDiscriminant = viskores::Sqrt(discriminant);
+        const Precision invA = Precision(1) / a;
+        const Precision t0 = (-b - sqrtDiscriminant) * invA;
+        const Precision z0 = originAxis + t0 * rayAxis;
+        if (z0 >= Precision(0) && z0 <= axisLength2)
+        {
+          this->CheckHit(t0, minDistance, closestDistance, hitType, Precision(0));
+        }
+
+        const Precision t1 = (-b + sqrtDiscriminant) * invA;
+        const Precision z1 = originAxis + t1 * rayAxis;
+        if (z1 >= Precision(0) && z1 <= axisLength2)
+        {
+          this->CheckHit(t1, minDistance, closestDistance, hitType, Precision(0));
+        }
+      }
+    }
+
+    if (viskores::Abs(rayAxis) > epsilon)
+    {
+      if ((capMask & viskores::UInt8(1)) != 0)
+      {
+        const Precision t = -originAxis / rayAxis;
+        const vec3 offset = relOrigin + rayDirection * t;
+        if (viskores::dot(offset, offset) <= radius2)
+        {
+          this->CheckHit(t, minDistance, closestDistance, hitType, Precision(1));
+        }
+      }
+
+      if ((capMask & viskores::UInt8(2)) != 0)
+      {
+        const Precision t = (axisLength2 - originAxis) / rayAxis;
+        const vec3 offset = rayStart + rayDirection * t - second;
+        if (viskores::dot(offset, offset) <= radius2)
+        {
+          this->CheckHit(t, minDistance, closestDistance, hitType, Precision(2));
+        }
+      }
+    }
+
+    hit = closestDistance < originalClosest;
+    return hit;
+  }
+
   template <typename PointPortalType, typename LeafPortalType, typename Precision>
   VISKORES_EXEC inline void IntersectLeaf(
     const viskores::Int32& currentNode,
@@ -271,7 +382,7 @@ public:
     const PointPortalType& points,
     viskores::Id& hitIndex,
     Precision& closestDistance, // closest distance in this set of primitives
-    Precision& viskoresNotUsed(minU),
+    Precision& minU,
     Precision& viskoresNotUsed(minV),
     LeafPortalType leafs,
     const Precision& minDistance) const // report intesections past this distance
@@ -288,15 +399,39 @@ public:
         bottom = viskores::Vec<Precision, 3>(points.Get(pointIndex[1]));
         top = viskores::Vec<Precision, 3>(points.Get(pointIndex[2]));
 
-        viskores::Vec3f_32 ret;
-        ret = cylinder(origin, dir, bottom, top, radius);
-        if (ret[0] > 0)
+        if (this->UseCapMasks)
         {
-          if (ret[1] < closestDistance && ret[1] > minDistance)
+          const viskores::UInt8 capMask = (cylIndex < this->CapMasks.GetNumberOfValues())
+            ? this->CapMasks.Get(cylIndex)
+            : viskores::UInt8(0);
+          Precision hitType = Precision(0);
+          if (this->cappedCylinder(origin,
+                                   dir,
+                                   bottom,
+                                   top,
+                                   Precision(radius),
+                                   capMask,
+                                   minDistance,
+                                   closestDistance,
+                                   hitType))
           {
-            //matid = viskores::Vec<, 3>(points.Get(cur_offset + 2))[0];
-            closestDistance = ret[1];
             hitIndex = cylIndex;
+            minU = hitType;
+          }
+        }
+        else
+        {
+          viskores::Vec3f_32 ret;
+          ret = cylinder(origin, dir, bottom, top, radius);
+          if (ret[0] > 0)
+          {
+            if (ret[1] < closestDistance && ret[1] > minDistance)
+            {
+              //matid = viskores::Vec<, 3>(points.Get(cur_offset + 2))[0];
+              closestDistance = ret[1];
+              hitIndex = cylIndex;
+              minU = Precision(0);
+            }
           }
         }
       }
@@ -309,13 +444,18 @@ class CylinderLeafWrapper : public viskores::cont::ExecutionObjectBase
 protected:
   using IdHandle = viskores::cont::ArrayHandle<viskores::Id3>;
   using FloatHandle = viskores::cont::ArrayHandle<viskores::Float32>;
+  using UInt8Handle = viskores::cont::ArrayHandle<viskores::UInt8>;
   IdHandle CylIds;
   FloatHandle Radii;
+  UInt8Handle CapMasks;
+  bool UseCapMasks;
 
 public:
-  CylinderLeafWrapper(IdHandle& cylIds, FloatHandle radii)
+  CylinderLeafWrapper(IdHandle& cylIds, FloatHandle radii, UInt8Handle capMasks, bool useCapMasks)
     : CylIds(cylIds)
     , Radii(radii)
+    , CapMasks(capMasks)
+    , UseCapMasks(useCapMasks)
   {
   }
 
@@ -324,7 +464,8 @@ public:
     Device,
     viskores::cont::Token& token) const
   {
-    return CylinderLeafIntersector<Device>(this->CylIds, this->Radii, token);
+    return CylinderLeafIntersector<Device>(
+      this->CylIds, this->Radii, this->CapMasks, this->UseCapMasks, token);
   }
 };
 
@@ -333,11 +474,18 @@ class CalculateNormals : public viskores::worklet::WorkletMapField
 public:
   VISKORES_CONT
   CalculateNormals() {}
-  typedef void
-    ControlSignature(FieldIn, FieldIn, FieldOut, FieldOut, FieldOut, WholeArrayIn, WholeArrayIn);
-  typedef void ExecutionSignature(_1, _2, _3, _4, _5, _6, _7);
+  typedef void ControlSignature(FieldIn,
+                                FieldIn,
+                                FieldIn,
+                                FieldOut,
+                                FieldOut,
+                                FieldOut,
+                                WholeArrayIn,
+                                WholeArrayIn);
+  typedef void ExecutionSignature(_1, _2, _3, _4, _5, _6, _7, _8);
   template <typename Precision, typename PointPortalType, typename IndicesPortalType>
   VISKORES_EXEC inline void operator()(const viskores::Id& hitIndex,
+                                       const Precision& hitType,
                                        const viskores::Vec<Precision, 3>& intersection,
                                        Precision& normalX,
                                        Precision& normalY,
@@ -358,7 +506,23 @@ public:
     ap = intersection - a;
     ab = b - a;
 
-    Precision mag2 = viskores::Magnitude(ab);
+    if (hitType == Precision(1) || hitType == Precision(2))
+    {
+      viskores::Vec<Precision, 3> normal = ab;
+      viskores::Normalize(normal);
+      if (hitType == Precision(1))
+      {
+        normal = -normal;
+      }
+
+      normalX = normal[0];
+      normalY = normal[1];
+      normalZ = normal[2];
+      return;
+    }
+
+    // Project onto the cylinder axis. The denominator is the squared axis length.
+    Precision mag2 = viskores::dot(ab, ab);
     Precision len = viskores::dot(ab, ap);
     Precision t = len / mag2;
 
@@ -428,6 +592,7 @@ public:
 
 CylinderIntersector::CylinderIntersector()
   : ShapeIntersector()
+  , UseCapMasks(false)
 {
 }
 
@@ -437,8 +602,19 @@ void CylinderIntersector::SetData(const viskores::cont::CoordinateSystem& coords
                                   viskores::cont::ArrayHandle<viskores::Id3> cylIds,
                                   viskores::cont::ArrayHandle<viskores::Float32> radii)
 {
+  this->UseCapMasks = false;
+  this->SetData(coords, cylIds, radii, viskores::cont::ArrayHandle<viskores::UInt8>{});
+}
+
+void CylinderIntersector::SetData(const viskores::cont::CoordinateSystem& coords,
+                                  viskores::cont::ArrayHandle<viskores::Id3> cylIds,
+                                  viskores::cont::ArrayHandle<viskores::Float32> radii,
+                                  viskores::cont::ArrayHandle<viskores::UInt8> capMasks)
+{
   this->Radii = radii;
   this->CylIds = cylIds;
+  this->CapMasks = capMasks;
+  this->UseCapMasks = capMasks.GetNumberOfValues() > 0;
   this->CoordsHandle = coords;
   AABBs AABB;
 
@@ -471,7 +647,8 @@ void CylinderIntersector::IntersectRaysImp(Ray<Precision>& rays,
                                            bool viskoresNotUsed(returnCellIndex))
 {
 
-  detail::CylinderLeafWrapper leafIntersector(this->CylIds, Radii);
+  detail::CylinderLeafWrapper leafIntersector(
+    this->CylIds, this->Radii, this->CapMasks, this->UseCapMasks);
 
   BVHTraverser traverser;
   traverser.IntersectRays(rays, this->BVH, leafIntersector, this->CoordsHandle);
@@ -495,6 +672,7 @@ void CylinderIntersector::IntersectionDataImp(Ray<Precision>& rays,
 
   viskores::worklet::DispatcherMapField<detail::CalculateNormals>(detail::CalculateNormals())
     .Invoke(rays.HitIdx,
+            rays.U,
             rays.Intersection,
             rays.NormalX,
             rays.NormalY,

--- a/viskores/rendering/raytracing/CylinderIntersector.h
+++ b/viskores/rendering/raytracing/CylinderIntersector.h
@@ -35,6 +35,8 @@ class VISKORES_RENDERING_RAYTRACING_EXPORT CylinderIntersector : public ShapeInt
 protected:
   viskores::cont::ArrayHandle<viskores::Id3> CylIds;
   viskores::cont::ArrayHandle<viskores::Float32> Radii;
+  viskores::cont::ArrayHandle<viskores::UInt8> CapMasks;
+  bool UseCapMasks;
 
 public:
   CylinderIntersector();
@@ -44,6 +46,11 @@ public:
   void SetData(const viskores::cont::CoordinateSystem& coords,
                viskores::cont::ArrayHandle<viskores::Id3> cylIds,
                viskores::cont::ArrayHandle<viskores::Float32> radii);
+
+  void SetData(const viskores::cont::CoordinateSystem& coords,
+               viskores::cont::ArrayHandle<viskores::Id3> cylIds,
+               viskores::cont::ArrayHandle<viskores::Float32> radii,
+               viskores::cont::ArrayHandle<viskores::UInt8> capMasks);
 
   void IntersectRays(Ray<viskores::Float32>& rays, bool returnCellIndex = false) override;
 


### PR DESCRIPTION
Add ANARI cylinder geometry support to the Viskores ANARI device.

This adds a new device-side cylinder geometry implementation with indexed and implicit endpoint pairs, global and per-primitive radii, primitive/vertex attributes, and cap handling through global caps and vertex.cap. It registers khr_geometry_cylinder, wires the geometry into the device factory/build, and extends the raytracing cylinder intersector with optional per-cylinder cap masks while preserving the existing uncapped path.