### PR TITLE
Add Buffer::PinHost for permanent host-pointer pinning

### DIFF
--- a/docs/changelog/buffer-pin-host.md
+++ b/docs/changelog/buffer-pin-host.md
@@ -1,0 +1,15 @@
+## Add Buffer::PinHost for stable host-pointer access
+
+`viskores::cont::internal::Buffer` now provides a `PinHost(Token&)` method
+that locks the host allocation in place for the remainder of the `Buffer`
+object's lifetime. The host pointer is guaranteed not to move after PinHost
+is called; any subsequent attempt to grow the buffer raises
+`viskores::cont::ErrorBadAllocation` rather than silently relocating the
+allocation. The operation is intentionally irreversible — callers that need
+only bounded-lifetime pointer stability should hold a
+`viskores::cont::Token` instead.
+
+This is intended for handing a buffer's host pointer to external libraries
+that manage memory independently. For example, the Python bindings use it
+to wrap a Viskores-allocated `ArrayHandleBasic` in a zero-copy NumPy view
+whose lifetime is decoupled from the originating `ArrayHandle`.

--- a/viskores/cont/internal/Buffer.cxx
+++ b/viskores/cont/internal/Buffer.cxx
@@ -1088,6 +1088,16 @@ viskores::cont::internal::TransferredBuffer Buffer::TakeHostBufferOwnership() co
   }
 }
 
+void Buffer::PinHost(viskores::cont::Token& token) const
+{
+  LockType lock = this->Internals->GetLock();
+  detail::BufferHelper::AllocateOnHost(
+    this->Internals, lock, token, detail::BufferHelper::AccessMode::READ);
+  auto& buffer = this->Internals->GetHostBuffer(lock);
+  buffer.Pinned = true;
+  buffer.Info.PreventReallocation();
+}
+
 viskores::cont::internal::TransferredBuffer Buffer::TakeDeviceBufferOwnership(
   viskores::cont::DeviceAdapterId device) const
 {

--- a/viskores/cont/internal/Buffer.h
+++ b/viskores/cont/internal/Buffer.h
@@ -318,6 +318,44 @@ public:
   VISKORES_CONT viskores::cont::internal::TransferredBuffer TakeDeviceBufferOwnership(
     viskores::cont::DeviceAdapterId device) const;
 
+  /// @brief Pin the host buffer so its pointer remains stable.
+  ///
+  /// Marks the buffer on the host as pinned. This ensures that the memory allocation will
+  /// never be moved for the remainder of the life of the `Buffer` object. This can be used
+  /// to ensure that C pointers to the buffer's array and array portals work for extended
+  /// periods of time. For example, to transfer a Viskores `ArrayHandleBasic` to an
+  /// external libraries array management object, such as wrapping it in a Python NumPy
+  /// array, one can pin the buffer and keep a reference around.
+  ///
+  /// Note that pinning the buffer has consequences that cannot be undone. The biggest
+  /// consequence is that reallocating the buffer is disabled because a reallocation is
+  /// likely to move the buffer to a new area of memory. Attempting to allocate the buffer
+  /// to a new size will cause a `viskores::cont::ErrorBadAllocation` to be thrown.
+  ///
+  /// If the `Buffer` is requested to provide data on a device, that may "invalidate" the
+  /// host array. Pinned memory will still exist, but the data may be out of date and writes
+  /// may get overridden the next time the `Buffer` updates the control memory.
+  ///
+  /// The `Buffer` object will ensure the pinned memory is available during its entire
+  /// lifetime, but if all instances of `Buffer` leave scope, the memory will be freed during
+  /// cleanup. Thus, it is important to keep a reference to the `Buffer` (or the
+  /// `viskores::cont::ArrayHandle` containing it) until the pinned memory is no longer
+  /// used.
+  ///
+  /// Pinning memory and holding a `Buffer` reference is similar holding a read or write
+  /// `viskores::cont::Token` object. However, unlike pinned memory, a `Token` can
+  /// block other code from using the `Buffer` in various memory spaces and can lead
+  /// to deadlocking, even on a single thread. Thus, `viskores::cont::Token` should only
+  /// be used in well-scoped situations whereas pinned memory is appropriate for
+  /// extended use.
+  ///
+  /// Note that the memory is pinned only with respect to the user accessible memory
+  /// space. This method does _not_, for example, pin a memory page to a particular
+  /// physical memory bank and is not appropriate for things like DMA transfers. Such
+  /// pinning would have to take place in the device adapter layer.
+  ///
+  VISKORES_CONT void PinHost(viskores::cont::Token& token) const;
+
   /// \brief Fill up the buffer with particular values.
   ///
   /// Given a short `source` C array (defined on the host), sets all values in the buffer

--- a/viskores/cont/internal/DeviceAdapterMemoryManager.cxx
+++ b/viskores/cont/internal/DeviceAdapterMemoryManager.cxx
@@ -301,6 +301,11 @@ void BufferInfo::Reallocate(viskores::BufferSizeType newSize)
   this->Internals->Size = newSize;
 }
 
+void BufferInfo::PreventReallocation()
+{
+  this->Internals->Reallocate = viskores::cont::internal::InvalidRealloc;
+}
+
 TransferredBuffer BufferInfo::TransferOwnership()
 {
   TransferredBuffer tbufffer = { this->Internals->Memory,

--- a/viskores/cont/internal/DeviceAdapterMemoryManager.h
+++ b/viskores/cont/internal/DeviceAdapterMemoryManager.h
@@ -117,6 +117,12 @@ public:
   ///
   VISKORES_CONT TransferredBuffer TransferOwnership();
 
+  /// Replace the buffer's reallocater with one that throws `ErrorBadAllocation` on any
+  /// attempted resize. Used to lock the underlying pointer in place when the memory has
+  /// been pinned for external access.
+  ///
+  VISKORES_CONT void PreventReallocation();
+
 private:
   detail::BufferInfoInternals* Internals;
   viskores::cont::DeviceAdapterId Device;

--- a/viskores/cont/testing/UnitTestArrayHandle.cxx
+++ b/viskores/cont/testing/UnitTestArrayHandle.cxx
@@ -17,6 +17,7 @@
 //============================================================================
 #include <viskores/TypeTraits.h>
 #include <viskores/cont/ArrayHandle.h>
+#include <viskores/cont/ErrorBadAllocation.h>
 
 #include <viskores/worklet/DispatcherMapField.h>
 #include <viskores/worklet/WorkletMapField.h>
@@ -563,6 +564,99 @@ struct VerifyFill
   }
 };
 
+struct VerifyPinnedMemory
+{
+  template <typename T>
+  VISKORES_CONT void operator()(T) const
+  {
+    viskores::cont::Invoker invoke;
+
+    std::cout << "Creating pinned Viskores-allocated array." << std::endl;
+    viskores::cont::ArrayHandleBasic<T> arrayHandle;
+    arrayHandle.Allocate(ARRAY_SIZE);
+    {
+      auto portal = arrayHandle.WritePortal();
+      for (viskores::Id index = 0; index < ARRAY_SIZE; ++index)
+      {
+        portal.Set(index, TestValue(index, T()));
+      }
+    }
+
+    T* hostPointer = nullptr;
+    {
+      viskores::cont::Token token;
+      hostPointer = arrayHandle.GetWritePointer(token);
+      arrayHandle.GetBuffers()[0].PinHost(token);
+    }
+    VISKORES_TEST_ASSERT(hostPointer != nullptr, "Pinned host pointer is null.");
+
+    // Pointer writes should be visible through the portal and vice versa.
+    for (viskores::Id index = 0; index < ARRAY_SIZE; ++index)
+    {
+      hostPointer[index] = static_cast<T>(TestValue(index, T()) + T(7));
+    }
+    {
+      auto portal = arrayHandle.ReadPortal();
+      for (viskores::Id index = 0; index < ARRAY_SIZE; ++index)
+      {
+        VISKORES_TEST_ASSERT(
+          test_equal(portal.Get(index), static_cast<T>(TestValue(index, T()) + T(7))),
+          "Pointer write not visible through portal.");
+      }
+    }
+    {
+      auto portal = arrayHandle.WritePortal();
+      for (viskores::Id index = 0; index < ARRAY_SIZE; ++index)
+      {
+        portal.Set(index, static_cast<T>(TestValue(index, T()) + T(11)));
+      }
+    }
+    for (viskores::Id index = 0; index < ARRAY_SIZE; ++index)
+    {
+      VISKORES_TEST_ASSERT(
+        test_equal(hostPointer[index], static_cast<T>(TestValue(index, T()) + T(11))),
+        "Portal write not visible through C pointer.");
+    }
+
+    // Same-size reallocation should be a no-op, not throw.
+    arrayHandle.Allocate(ARRAY_SIZE, viskores::CopyFlag::On);
+    VISKORES_TEST_ASSERT(arrayHandle.GetNumberOfValues() == ARRAY_SIZE,
+                         "Same-size reallocation changed the array size.");
+
+    std::cout << "Check out worklet output." << std::endl;
+    invoke(AssignTestValue{}, viskores::cont::ArrayHandleIndex(ARRAY_SIZE), arrayHandle);
+    arrayHandle.SyncControlArray();
+    {
+      auto portal = arrayHandle.ReadPortal();
+      for (viskores::Id index = 0; index < ARRAY_SIZE; ++index)
+      {
+        VISKORES_TEST_ASSERT(test_equal(portal.Get(index), TestValue(index, T())),
+                             "Worklet output not visible through portal.");
+        VISKORES_TEST_ASSERT(test_equal(hostPointer[index], TestValue(index, T())),
+                             "Worklet output not visible through pinned C pointer.");
+      }
+    }
+
+    std::cout << "Check invalid reallocation." << std::endl;
+    {
+      // Allocate with CopyFlag::On defers the resize until the next buffer
+      // access, so force the reallocation attempt with ReadPortal.
+      bool gotException = false;
+      try
+      {
+        arrayHandle.Allocate(ARRAY_SIZE * 2, viskores::CopyFlag::On);
+        arrayHandle.ReadPortal();
+      }
+      catch (viskores::cont::ErrorBadAllocation&)
+      {
+        gotException = true;
+      }
+      VISKORES_TEST_ASSERT(gotException,
+                           "Growing a pinned host buffer should throw ErrorBadAllocation.");
+    }
+  }
+};
+
 VISKORES_CONT void Run()
 {
   viskores::testing::Testing::TryTypes(VerifyEmptyArrays{});
@@ -574,6 +668,7 @@ VISKORES_CONT void Run()
   viskores::testing::Testing::TryTypes(VerifyVISKORESTransferredOwnership{});
   viskores::testing::Testing::TryTypes(VerifyEqualityOperators{});
   viskores::testing::Testing::TryTypes(VerifyFill{});
+  viskores::testing::Testing::TryTypes(VerifyPinnedMemory{});
 }
 
 } // anonymous namespace


### PR DESCRIPTION
## Summary

Adds a single new public method on `Buffer`:

```cpp
void Buffer::PinHost(viskores::cont::Token& token) const;
```

It allocates the buffer on the host if not already there (attached to the caller's `Token`), marks it pinned, and swaps the host `BufferInfo`'s reallocater to `InvalidRealloc`. After the call the host pointer is guaranteed not to move for the remainder of the buffer's lifetime; any later attempt to grow the buffer throws `ErrorBadAllocation` cleanly instead of silently relocating.

The operation is intentionally **irreversible** (per @kmorel's review feedback). Callers that only need bounded-lifetime pointer stability should hold a `Token` instead — this API is for cases where the pointer leaves Viskores entirely (e.g. is handed to numpy via a capsule).

A small additive helper, `BufferInfo::PreventReallocation()`, is added so the reallocater swap can be expressed without exposing the underlying internals.

## Motivation

Needed by the Python bindings work (#308) to implement zero-copy `asnumpy()` for Viskores-allocated buffers. The numpy array, wrapped in an `nb::capsule` that holds a reference to the originating `ArrayHandle`, needs a stable host pointer for its lifetime — including across any Viskores-side operations on the same `ArrayHandle`. Setting the pin flag alone is not sufficient because `HostReallocate` can move the pointer in place; the reallocater swap closes that gap.

## Scope

Pure addition, ~167 lines across 6 files:

- `viskores/cont/internal/Buffer.h` (+38): `PinHost` declaration + extended docstring describing the irreversibility, device-staleness behavior, and Token comparison.
- `viskores/cont/internal/Buffer.cxx` (+10): `PinHost` definition.
- `viskores/cont/internal/DeviceAdapterMemoryManager.h` (+6): `BufferInfo::PreventReallocation()` declaration.
- `viskores/cont/internal/DeviceAdapterMemoryManager.cxx` (+5): `BufferInfo::PreventReallocation()` definition.
- `viskores/cont/testing/UnitTestArrayHandle.cxx` (+95): `VerifyPinnedMemory` exercising the 7-step plan @kmorel outlined — pin under a scoped Token, check pointer↔portal cross-visibility, same-size reallocate (no-op), worklet output → `SyncControlArray` → verify both views, then verify that growing the buffer throws `ErrorBadAllocation`. Runs over every type via `Testing::TryTypes`.
- `docs/changelog/buffer-pin-host.md` (+15): topic changelog entry.

No existing fields, methods, or call sites are modified. `BufferState::Pinned` remains `bool`. `TakeHostBufferOwnership` / `TakeDeviceBufferOwnership` / `Reset` are untouched.

## Open questions

- Device pinning: this PR is host-only, matching the immediate need. A parallel `PinDevice(Token&, DeviceAdapterId)` would mirror this implementation against the device-side sync paths if there's appetite for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)