### PR TITLE
Properly check for ANARI cone extension

### DIFF
--- a/viskores/interop/anari/testing/UnitTestANARIMapperGlyphs.cxx
+++ b/viskores/interop/anari/testing/UnitTestANARIMapperGlyphs.cxx
@@ -45,7 +45,7 @@ void RenderTests()
   bool conesSupported = false;
   for (int i = 0; extensions[i] != nullptr; ++i)
   {
-    if (extensions[i] == std::string("KHR_GEOMETRY_CONE"))
+    if (extensions[i] == std::string("ANARI_KHR_GEOMETRY_CONE"))
     {
       conesSupported = true;
       break;


### PR DESCRIPTION
UnitTestANARIMapperGlyphs will skip the test if the KHR_GEOMETRY_CONE extension is missing (as it is in the Viskores device). However, it was always skipping (even for helide, which supports the extension) because it was checking the wrong string. The string to compare is fixed.