### PR TITLE
Replace ContourTreeUniformDistributed InternalStruct with local ExecutionState

### DIFF
--- a/docs/changelog/contour-tree-execution-state.md
+++ b/docs/changelog/contour-tree-execution-state.md
@@ -1,0 +1,11 @@
+## Contour Tree Filter No Longer Stores Execution Scratch as Filter State
+
+The `ContourTreeUniformDistributed` filter previously held its intermediate
+results (local meshes, contour trees, boundary trees, interior forests, and the
+iteration count) as filter member state. Because filters can be copied, copies
+could share or clobber this mutable scratch when executed independently.
+
+These intermediate results are now collected in a local `ExecutionState` object
+that lives only for the duration of a single execution and is passed by
+reference through the filter's helper functions. Copies of the filter no longer
+share execution scratch.

--- a/viskores/filter/scalar_topology/ContourTreeUniformDistributed.cxx
+++ b/viskores/filter/scalar_topology/ContourTreeUniformDistributed.cxx
@@ -101,8 +101,22 @@ namespace filter
 namespace scalar_topology
 {
 
-struct ContourTreeUniformDistributed::InternalStruct
+struct ContourTreeUniformDistributed::ExecutionState
 {
+  /// Construct the execution state with all per-block result vectors sized to the
+  /// global number of data blocks being processed.
+  explicit ExecutionState(viskores::Id numberOfPartitions)
+    : LocalMeshes(static_cast<std::size_t>(numberOfPartitions))
+    , LocalContourTrees(static_cast<std::size_t>(numberOfPartitions))
+    , LocalBoundaryTrees(static_cast<std::size_t>(numberOfPartitions))
+    , LocalInteriorForests(static_cast<std::size_t>(numberOfPartitions))
+  {
+  }
+
+  /// The execution state is always passed by reference, never copied.
+  ExecutionState(const ExecutionState&) = delete;
+  ExecutionState& operator=(const ExecutionState&) = delete;
+
   /// Intermediate results (one per local data block)...
   /// ... local mesh information needed at end of fan out
   std::vector<viskores::worklet::contourtree_augmented::DataSetMesh> LocalMeshes;
@@ -117,7 +131,7 @@ struct ContourTreeUniformDistributed::InternalStruct
   //
   //std::vector<viskores::worklet::contourtree_distributed::HierarchicalContourTree> HierarchicalContourTrees;
   /// Number of iterations used to compute the contour tree
-  viskores::Id NumIterations;
+  viskores::Id NumIterations = 0;
 };
 
 //-----------------------------------------------------------------------------
@@ -201,7 +215,6 @@ ContourTreeUniformDistributed::ContourTreeUniformDistributed(
   viskores::cont::LogLevel treeLogLevel)
   : TimingsLogLevel(timingsLogLevel)
   , TreeLogLevel(treeLogLevel)
-  , Internals(new InternalStruct)
 {
   this->SetOutputFieldName("resultData");
 }
@@ -214,7 +227,8 @@ template <typename T, typename StorageType>
 void ContourTreeUniformDistributed::ComputeLocalTree(
   const viskores::Id blockIndex,
   const viskores::cont::DataSet& input,
-  const viskores::cont::ArrayHandle<T, StorageType>& fieldArray)
+  const viskores::cont::ArrayHandle<T, StorageType>& fieldArray,
+  ExecutionState& state)
 {
   // Get mesh size
   viskores::Id3 meshSize;
@@ -228,24 +242,24 @@ void ContourTreeUniformDistributed::ComputeLocalTree(
   {
     viskores::worklet::contourtree_augmented::DataSetMeshTriangulation2DFreudenthal mesh(
       viskores::Id2{ meshSize[0], meshSize[1] });
-    this->Internals->LocalMeshes[static_cast<std::size_t>(blockIndex)] = mesh;
+    state.LocalMeshes[static_cast<std::size_t>(blockIndex)] = mesh;
     auto meshBoundaryExecObject = mesh.GetMeshBoundaryExecutionObject();
-    this->ComputeLocalTreeImpl(blockIndex, input, fieldArray, mesh, meshBoundaryExecObject);
+    this->ComputeLocalTreeImpl(blockIndex, input, fieldArray, mesh, meshBoundaryExecObject, state);
   }
   else if (this->UseMarchingCubes) // 3D marching cubes mesh
   {
     viskores::worklet::contourtree_augmented::DataSetMeshTriangulation3DMarchingCubes mesh(
       meshSize);
-    this->Internals->LocalMeshes[static_cast<std::size_t>(blockIndex)] = mesh;
+    state.LocalMeshes[static_cast<std::size_t>(blockIndex)] = mesh;
     auto meshBoundaryExecObject = mesh.GetMeshBoundaryExecutionObject();
-    this->ComputeLocalTreeImpl(blockIndex, input, fieldArray, mesh, meshBoundaryExecObject);
+    this->ComputeLocalTreeImpl(blockIndex, input, fieldArray, mesh, meshBoundaryExecObject, state);
   }
   else // Regular 3D mesh
   {
     viskores::worklet::contourtree_augmented::DataSetMeshTriangulation3DFreudenthal mesh(meshSize);
-    this->Internals->LocalMeshes[static_cast<std::size_t>(blockIndex)] = mesh;
+    state.LocalMeshes[static_cast<std::size_t>(blockIndex)] = mesh;
     auto meshBoundaryExecObject = mesh.GetMeshBoundaryExecutionObject();
-    this->ComputeLocalTreeImpl(blockIndex, input, fieldArray, mesh, meshBoundaryExecObject);
+    this->ComputeLocalTreeImpl(blockIndex, input, fieldArray, mesh, meshBoundaryExecObject, state);
   }
 } // ContourTreeUniformDistributed::ComputeLocalTree
 
@@ -256,7 +270,8 @@ void ContourTreeUniformDistributed::ComputeLocalTreeImpl(
   const viskores::cont::DataSet& ds, // input,
   const viskores::cont::ArrayHandle<T, StorageType>& field,
   MeshType& mesh,
-  MeshBoundaryExecType& meshBoundaryExecObject)
+  MeshBoundaryExecType& meshBoundaryExecObject,
+  ExecutionState& state)
 {
   viskores::cont::Timer timer;
   timer.Start();
@@ -269,9 +284,9 @@ void ContourTreeUniformDistributed::ComputeLocalTreeImpl(
     viskores::cont::LogLevel::Off; // turn of the loggin, we do this afterwards
   worklet.Run(field,
               mesh,
-              this->Internals->LocalContourTrees[static_cast<std::size_t>(blockIndex)],
-              this->Internals->LocalMeshes[static_cast<std::size_t>(blockIndex)].SortOrder,
-              this->Internals->NumIterations,
+              state.LocalContourTrees[static_cast<std::size_t>(blockIndex)],
+              state.LocalMeshes[static_cast<std::size_t>(blockIndex)].SortOrder,
+              state.NumIterations,
               compRegularStruct,
               meshBoundaryExecObject);
   // Log the contour tree timiing stats
@@ -306,12 +321,12 @@ void ContourTreeUniformDistributed::ComputeLocalTreeImpl(
   // Initialize the BoundaryTreeMaker
   auto boundaryTreeMaker =
     viskores::worklet::contourtree_distributed::BoundaryTreeMaker<MeshType, MeshBoundaryExecType>(
-      &mesh,                                                                    // The input mesh
-      meshBoundaryExecObject,                                                   // The mesh boundary
-      this->Internals->LocalContourTrees[static_cast<std::size_t>(blockIndex)], // The contour tree
-      &this->Internals->LocalBoundaryTrees[static_cast<std::size_t>(
+      &mesh,                                                         // The input mesh
+      meshBoundaryExecObject,                                        // The mesh boundary
+      state.LocalContourTrees[static_cast<std::size_t>(blockIndex)], // The contour tree
+      &state.LocalBoundaryTrees[static_cast<std::size_t>(
         blockIndex)], // The boundary tree (a.k.a BRACT) to be computed
-      &this->Internals->LocalInteriorForests[static_cast<std::size_t>(
+      &state.LocalInteriorForests[static_cast<std::size_t>(
         blockIndex)] // The interior forest (a.k.a. Residue) to be computed
     );
   // Execute the BRACT construction, including the compute of the InteriorForest
@@ -339,7 +354,7 @@ void ContourTreeUniformDistributed::ComputeLocalTreeImpl(
         std::string("_Block_") + std::to_string(static_cast<int>(blockIndex)) + "_Initial_BRACT.gv";
       std::ofstream bractFile(bractFileName);
       std::string bractString =
-        this->Internals->LocalBoundaryTrees[static_cast<std::size_t>(blockIndex)].PrintGlobalDot(
+        state.LocalBoundaryTrees[static_cast<std::size_t>(blockIndex)].PrintGlobalDot(
           "Before Fan In",
           mesh,
           field,
@@ -368,12 +383,11 @@ void ContourTreeUniformDistributed::ComputeLocalTreeImpl(
           MeshType,
           viskores::worklet::contourtree_augmented::IdArrayType>(
           label, // graph title
-          static_cast<MeshType&>(this->Internals->LocalMeshes[static_cast<std::size_t>(
+          static_cast<MeshType&>(state.LocalMeshes[static_cast<std::size_t>(
             blockIndex)]),           // the underlying mesh for the contour tree
           &localToGlobalIdRelabeler, // relabler needed to compute global ids
           field,                     // data values
-          this->Internals
-            ->LocalContourTrees[static_cast<std::size_t>(blockIndex)], // local contour tree
+          state.LocalContourTrees[static_cast<std::size_t>(blockIndex)], // local contour tree
           dotSettings // mask with flags for what elements to show
         );
       regularStructureFile << regularStructureString << std::endl;
@@ -401,11 +415,10 @@ void ContourTreeUniformDistributed::ComputeLocalTreeImpl(
           MeshType,
           viskores::worklet::contourtree_augmented::IdArrayType>(
           ctPrintLabel,
-          static_cast<MeshType&>(
-            this->Internals->LocalMeshes[static_cast<std::size_t>(blockIndex)]),
+          static_cast<MeshType&>(state.LocalMeshes[static_cast<std::size_t>(blockIndex)]),
           &localToGlobalIdRelabeler,
           field,
-          this->Internals->LocalContourTrees[static_cast<std::size_t>(blockIndex)],
+          state.LocalContourTrees[static_cast<std::size_t>(blockIndex)],
           ctPrintSettings);
       superStructureFile << superStructureString << std::endl;
     }
@@ -421,10 +434,9 @@ void ContourTreeUniformDistributed::ComputeLocalTreeImpl(
         viskores::worklet::contourtree_distributed::BoundaryTreeDotGraphPrint(
           std::string("Block ") + std::to_string(static_cast<size_t>(blockIndex)) +
             std::string(" Initial Step 3 Boundary Tree"),
-          static_cast<MeshType&>(
-            this->Internals->LocalMeshes[static_cast<std::size_t>(blockIndex)]),
+          static_cast<MeshType&>(state.LocalMeshes[static_cast<std::size_t>(blockIndex)]),
           meshBoundaryExecObject,
-          this->Internals->LocalBoundaryTrees[static_cast<std::size_t>(blockIndex)],
+          state.LocalBoundaryTrees[static_cast<std::size_t>(blockIndex)],
           &localToGlobalIdRelabeler,
           field);
       boundaryTreeFile << boundaryTreeString << std::endl;
@@ -440,11 +452,10 @@ void ContourTreeUniformDistributed::ComputeLocalTreeImpl(
       std::string interiorForestString =
         worklet::contourtree_distributed::InteriorForestDotGraphPrint(
           std::string("Block ") + std::to_string(rank) + " Initial Step 4 Interior Forest",
-          this->Internals->LocalInteriorForests[static_cast<std::size_t>(blockIndex)],
-          this->Internals->LocalContourTrees[static_cast<std::size_t>(blockIndex)],
-          this->Internals->LocalBoundaryTrees[static_cast<std::size_t>(blockIndex)],
-          static_cast<MeshType&>(
-            this->Internals->LocalMeshes[static_cast<std::size_t>(blockIndex)]),
+          state.LocalInteriorForests[static_cast<std::size_t>(blockIndex)],
+          state.LocalContourTrees[static_cast<std::size_t>(blockIndex)],
+          state.LocalBoundaryTrees[static_cast<std::size_t>(blockIndex)],
+          static_cast<MeshType&>(state.LocalMeshes[static_cast<std::size_t>(blockIndex)]),
           meshBoundaryExecObject,
           &localToGlobalIdRelabeler,
           field);
@@ -517,16 +528,6 @@ VISKORES_CONT void ContourTreeUniformDistributed::PreExecute(
                                                  "match number of specified blocks indices.");
     }
   }
-
-  // Allocate vectors
-  this->Internals->LocalMeshes.resize(
-    static_cast<std::size_t>(input.GetGlobalNumberOfPartitions()));
-  this->Internals->LocalContourTrees.resize(
-    static_cast<std::size_t>(input.GetGlobalNumberOfPartitions()));
-  this->Internals->LocalBoundaryTrees.resize(
-    static_cast<std::size_t>(input.GetGlobalNumberOfPartitions()));
-  this->Internals->LocalInteriorForests.resize(
-    static_cast<std::size_t>(input.GetGlobalNumberOfPartitions()));
 }
 
 viskores::cont::PartitionedDataSet ContourTreeUniformDistributed::DoExecutePartitions(
@@ -537,6 +538,10 @@ viskores::cont::PartitionedDataSet ContourTreeUniformDistributed::DoExecuteParti
   timer.Start();
 
   this->PreExecute(input);
+
+  // Intermediate results used during this execution only. Kept local (rather than
+  // as filter state) so that copies of the filter do not share mutable scratch.
+  ExecutionState state(input.GetGlobalNumberOfPartitions());
 
   // Compute the local contour tree, boundary tree, and interior forest for each local data block
   for (viskores::Id blockNo = 0; blockNo < input.GetNumberOfPartitions(); ++blockNo)
@@ -549,35 +554,36 @@ viskores::cont::PartitionedDataSet ContourTreeUniformDistributed::DoExecuteParti
       throw viskores::cont::ErrorFilterExecution("Point field expected.");
     }
 
-    this->CastAndCallScalarField(
-      field, [&](const auto concrete) { this->ComputeLocalTree(blockNo, dataset, concrete); });
+    this->CastAndCallScalarField(field,
+                                 [&](const auto concrete)
+                                 { this->ComputeLocalTree(blockNo, dataset, concrete, state); });
   }
 
   // Log sizes of the local contour trees, boundary trees, and interior forests
-  for (size_t bi = 0; bi < this->Internals->LocalContourTrees.size(); bi++)
+  for (size_t bi = 0; bi < state.LocalContourTrees.size(); bi++)
   {
     VISKORES_LOG_S(this->TreeLogLevel,
                    std::endl
                      << "    ---------------- Contour Tree Array Sizes ---------------------"
                      << std::endl
                      << "    Block Index : " << bi << std::endl
-                     << this->Internals->LocalContourTrees[bi].PrintArraySizes());
+                     << state.LocalContourTrees[bi].PrintArraySizes());
     VISKORES_LOG_S(this->TreeLogLevel,
                    std::endl
                      << "    ---------------- Boundary Tree Array Sizes ---------------------"
                      << std::endl
                      << "    Block Index : " << bi << std::endl
-                     << this->Internals->LocalBoundaryTrees[bi].PrintArraySizes());
+                     << state.LocalBoundaryTrees[bi].PrintArraySizes());
     VISKORES_LOG_S(this->TreeLogLevel,
                    std::endl
                      << "    ---------------- Interior Forest Array Sizes ---------------------"
                      << std::endl
                      << "    Block Index : " << bi << std::endl
-                     << this->Internals->LocalInteriorForests[bi].PrintArraySizes());
+                     << state.LocalInteriorForests[bi].PrintArraySizes());
     // VISKORES_LOG_S(this->TreeLogLevel,
     //           std::endl
     //           << "    ---------------- Hyperstructure Statistics ---------------------"  << std::endl
-    //           << this->Internals->LocalContourTrees[bi].PrintHyperStructureStatistics(false) << std::endl);
+    //           << state.LocalContourTrees[bi].PrintHyperStructureStatistics(false) << std::endl);
   }
 
   // Log timing statistics
@@ -588,7 +594,7 @@ viskores::cont::PartitionedDataSet ContourTreeUniformDistributed::DoExecuteParti
                    << ": " << timer.GetElapsedTime() << " seconds");
 
   viskores::cont::PartitionedDataSet result;
-  this->PostExecute(input, result);
+  this->PostExecute(input, result, state);
 
   return result;
 }
@@ -596,7 +602,8 @@ viskores::cont::PartitionedDataSet ContourTreeUniformDistributed::DoExecuteParti
 //-----------------------------------------------------------------------------
 VISKORES_CONT void ContourTreeUniformDistributed::PostExecute(
   const viskores::cont::PartitionedDataSet& input,
-  viskores::cont::PartitionedDataSet& result)
+  viskores::cont::PartitionedDataSet& result,
+  ExecutionState& state)
 {
   viskores::cont::Timer timer;
   timer.Start();
@@ -607,7 +614,7 @@ VISKORES_CONT void ContourTreeUniformDistributed::PostExecute(
   auto PostExecuteCaller = [&](const auto& concrete)
   {
     using T = typename std::decay_t<decltype(concrete)>::ValueType;
-    this->DoPostExecute<T>(input, result);
+    this->DoPostExecute<T>(input, result, state);
   };
   this->CastAndCallScalarField(field, PostExecuteCaller);
 
@@ -915,7 +922,8 @@ inline VISKORES_CONT void ContourTreeUniformDistributed::ComputeVolumeMetric(
 template <typename FieldType>
 VISKORES_CONT void ContourTreeUniformDistributed::DoPostExecute(
   const viskores::cont::PartitionedDataSet& input,
-  viskores::cont::PartitionedDataSet& result)
+  viskores::cont::PartitionedDataSet& result,
+  ExecutionState& state)
 {
   viskores::cont::Timer timer;
   timer.Start();
@@ -1014,11 +1022,11 @@ VISKORES_CONT void ContourTreeUniformDistributed::DoPostExecute(
     newBlock->FixedBlockSize = pointDimensions;
 
     // Save local tree information for fan out; TODO/FIXME: Try to avoid copy
-    newBlock->ContourTrees.push_back(this->Internals->LocalContourTrees[bi]);
-    newBlock->InteriorForests.push_back(this->Internals->LocalInteriorForests[bi]);
+    newBlock->ContourTrees.push_back(state.LocalContourTrees[bi]);
+    newBlock->InteriorForests.push_back(state.LocalInteriorForests[bi]);
 
     // ... Compute arrays needed for constructing contour tree mesh
-    const auto sortOrder = this->Internals->LocalMeshes[bi].SortOrder;
+    const auto sortOrder = state.LocalMeshes[bi].SortOrder;
     // ... Compute the global mesh index for the partially augmented contour tree. I.e., here we
     // don't need the global mesh index for all nodes, but only for the augmented nodes from the
     // tree. We, hence, permute the sortOrder by contourTree.augmentednodes and then compute the
@@ -1026,7 +1034,7 @@ VISKORES_CONT void ContourTreeUniformDistributed::DoPostExecute(
     viskores::worklet::contourtree_augmented::IdArrayType localGlobalMeshIndex;
     viskores::cont::ArrayHandlePermutation<viskores::worklet::contourtree_augmented::IdArrayType,
                                            viskores::worklet::contourtree_augmented::IdArrayType>
-      permutedSortOrder(this->Internals->LocalBoundaryTrees[bi].VertexIndex, sortOrder);
+      permutedSortOrder(state.LocalBoundaryTrees[bi].VertexIndex, sortOrder);
     auto transformedIndex = viskores::cont::make_ArrayHandleTransform(
       permutedSortOrder,
       viskores::worklet::contourtree_augmented::mesh_dem::IdRelabeler(
@@ -1040,8 +1048,8 @@ VISKORES_CONT void ContourTreeUniformDistributed::DoPostExecute(
     viskores::cont::ArrayCopy(currField.GetData(), fieldData);
 
     // ... compute and store the actual mesh
-    newBlock->ContourTreeMeshes.emplace_back(this->Internals->LocalBoundaryTrees[bi].VertexIndex,
-                                             this->Internals->LocalBoundaryTrees[bi].Superarcs,
+    newBlock->ContourTreeMeshes.emplace_back(state.LocalBoundaryTrees[bi].VertexIndex,
+                                             state.LocalBoundaryTrees[bi].Superarcs,
                                              sortOrder,
                                              fieldData,
                                              localGlobalMeshIndex);
@@ -1218,10 +1226,9 @@ VISKORES_CONT void ContourTreeUniformDistributed::DoPostExecute(
       iterationTimer.Start();
       viskores::worklet::contourtree_distributed::
         TreeGrafter<viskores::worklet::contourtree_augmented::DataSetMesh, FieldType>
-          grafter(
-            &(this->Internals->LocalMeshes[static_cast<std::size_t>(blockData->LocalBlockNo)]),
-            blockData->ContourTrees[0],
-            &(blockData->InteriorForests[0]));
+          grafter(&(state.LocalMeshes[static_cast<std::size_t>(blockData->LocalBlockNo)]),
+                  blockData->ContourTrees[0],
+                  &(blockData->InteriorForests[0]));
       viskores::cont::DataSet currBlock = input.GetPartition(blockData->LocalBlockNo);
       auto currField =
         currBlock.GetField(this->GetActiveFieldName(), this->GetActiveFieldAssociation());

--- a/viskores/filter/scalar_topology/ContourTreeUniformDistributed.h
+++ b/viskores/filter/scalar_topology/ContourTreeUniformDistributed.h
@@ -150,11 +150,22 @@ public:
 
   VISKORES_CONT bool GetSaveDotFiles() { return this->SaveDotFiles; }
 
+private:
+  /// Intermediate results computed while executing the filter. These are only valid
+  /// during a single invocation of DoExecutePartitions and are passed by reference
+  /// through the helper functions rather than stored as filter state, so that copies
+  /// of the filter do not share mutable execution scratch.
+  struct ExecutionState;
+
+  VISKORES_CONT viskores::cont::DataSet DoExecute(const viskores::cont::DataSet& input) override;
+  VISKORES_CONT viskores::cont::PartitionedDataSet DoExecutePartitions(
+    const viskores::cont::PartitionedDataSet& input) override;
+
   template <typename T, typename StorageType>
-  VISKORES_CONT void ComputeLocalTree(
-    const viskores::Id blockIndex,
-    const viskores::cont::DataSet& input,
-    const viskores::cont::ArrayHandle<T, StorageType>& fieldArray);
+  VISKORES_CONT void ComputeLocalTree(const viskores::Id blockIndex,
+                                      const viskores::cont::DataSet& input,
+                                      const viskores::cont::ArrayHandle<T, StorageType>& fieldArray,
+                                      ExecutionState& state);
 
   /// Implement per block contour tree computation after the MeshType has been discovered
   template <typename T, typename StorageType, typename MeshType, typename MeshBoundaryExecType>
@@ -162,12 +173,8 @@ public:
                                           const viskores::cont::DataSet& input,
                                           const viskores::cont::ArrayHandle<T, StorageType>& field,
                                           MeshType& mesh,
-                                          MeshBoundaryExecType& meshBoundaryExecObject);
-
-private:
-  VISKORES_CONT viskores::cont::DataSet DoExecute(const viskores::cont::DataSet& input) override;
-  VISKORES_CONT viskores::cont::PartitionedDataSet DoExecutePartitions(
-    const viskores::cont::PartitionedDataSet& input) override;
+                                          MeshBoundaryExecType& meshBoundaryExecObject,
+                                          ExecutionState& state);
 
   ///@{
   /// when operating on viskores::cont::MultiBlock we want to
@@ -176,7 +183,8 @@ private:
   VISKORES_CONT void PreExecute(const viskores::cont::PartitionedDataSet& input);
 
   VISKORES_CONT void PostExecute(const viskores::cont::PartitionedDataSet& input,
-                                 viskores::cont::PartitionedDataSet& output);
+                                 viskores::cont::PartitionedDataSet& output,
+                                 ExecutionState& state);
 
 
   template <typename FieldType>
@@ -198,7 +206,8 @@ private:
   /// computed on the block to compute the final contour tree.
   template <typename T>
   VISKORES_CONT void DoPostExecute(const viskores::cont::PartitionedDataSet& input,
-                                   viskores::cont::PartitionedDataSet& output);
+                                   viskores::cont::PartitionedDataSet& output,
+                                   ExecutionState& state);
   ///@}
 
   /// Use only boundary critical points in the parallel merge to reduce communication.
@@ -228,9 +237,6 @@ private:
   viskores::Id3 BlocksPerDimension = { -1, -1, -1 };
   // ... Index of the local blocks in x,y,z, i.e., in i,j,k mesh coordinates
   viskores::cont::ArrayHandle<viskores::Id3> LocalBlockIndices;
-
-  struct InternalStruct;
-  std::shared_ptr<InternalStruct> Internals;
 };
 } // namespace scalar_topology
 } // namespace filter


### PR DESCRIPTION
Follow-up requested in https://github.com/Viskores/viskores/pull/316#discussion_r3326677244. Parent #316 is merged and this branch is rebased onto `main`, so the diff is just the `ExecutionState` refactor.

## Motivation

PR #316 introduced `std::shared_ptr<InternalStruct> Internals` to hold the `ContourTreeUniformDistributed` filter's intermediate results. Because filters can be copied, copies share this mutable execution scratch and can race or clobber each other when executed independently. @kmorel asked that the fix land in a separate PR with smaller scope — this is that PR.

## Change

- Rename `InternalStruct` → `ExecutionState` and **remove it from filter member state**.
- `ExecutionState` gains an `explicit` constructor that sizes the per-block result vectors to the number of partitions, so it is always correctly sized.
- Construct `ExecutionState` locally in `DoExecutePartitions` and pass it by reference through `ComputeLocalTree`, `ComputeLocalTreeImpl`, `PostExecute`, and `DoPostExecute`.
- `PreExecute` reverts to validation-only (no longer touches the result vectors), which also trims redundant `GetGlobalNumberOfPartitions()` calls.
- Move `ComputeLocalTree`/`ComputeLocalTreeImpl` to `private` (filter-internal; no external callers).
- The user-set configuration members (`BlocksPerDimension`, `LocalBlockIndices`) remain filter state — they are not execution scratch.

Copies of the filter no longer share execution scratch.

## CI

Builds and tests pass on macOS, Windows, and 17/18 GitLab configs (all CUDA / HIP+Kokkos / Clang / GCC / sanitizer / AlmaLinux). The single `ubuntu2004_gcc9` failure is an infrastructure error (container networking / out-of-memory during runner setup) that never reached compilation, and `ubuntu2004_gcc9_cuda118` with the same compiler passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)