### PR TITLE
Fix CMake generator statement

### DIFF
--- a/CMake/ViskoresCompilerFlags.cmake
+++ b/CMake/ViskoresCompilerFlags.cmake
@@ -85,7 +85,7 @@ endif()
 if(VISKORES_COMPILER_IS_MSVC)
   target_compile_options(viskores_compiler_flags INTERFACE $<$<COMPILE_LANGUAGE:CXX>:/Zc:preprocessor>)
   if(TARGET viskores_cuda)
-    target_compile_options(viskores_compiler_flags INTERFACE $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler="/Zc:preprocessor")
+    target_compile_options(viskores_compiler_flags INTERFACE $<$<COMPILE_LANGUAGE:CUDA>:-Xcompiler="/Zc:preprocessor">)
   endif()
 endif()
 


### PR DESCRIPTION
There was an error in the CMake generator statement for adding the flag for a compliant preprocessor to the MSVC Cuda build. The closing `>` was missing. This error was introduced in commit
dbb0f58006a936ef51c0cf61064044281c090412 (GitHub PR #277).

Fixes #343