### PR TITLE
Fix Reduce optimization in Kokkos adapter

### DIFF
--- a/docs/changelog/kokkos-reduce-bug.md
+++ b/docs/changelog/kokkos-reduce-bug.md
@@ -1,0 +1,10 @@
+## Fixed bug in Kokkos Reduce function
+
+The `Reduce()` function in the Kokkos device adapter had a potential bug where
+it would attempt to access an array on the host. Normally, it is fine to request
+an array handle on the host with, for example, the `ReadPortal()` method.
+However, in some rare cases with custom array handles, the portal specifically
+accesses functions or data on the device. This was the case for the
+`CountBitSet` method in the Kokkos device adapter, and that could ead to
+problems such as a segmentation fault. The `Reduce()` is now more careful to
+access its input array only on the device.

--- a/viskores/cont/kokkos/internal/DeviceAdapterAlgorithmKokkos.h
+++ b/viskores/cont/kokkos/internal/DeviceAdapterAlgorithmKokkos.h
@@ -427,7 +427,13 @@ public:
     }
     if (input.GetNumberOfValues() == 1)
     {
-      return binaryOperator(initialValue, input.ReadPortal().Get(0));
+      // We have run into a situation (particularly with CountSetBits) where
+      // simply calling `input.ReadPortal().Get(0)` can seg fault because the
+      // array handle has a speecial portal that only works on the device. Get
+      // around this by copying to a known basic array.
+      viskores::cont::ArrayHandle<T> oneValue;
+      DeviceAdapterAlgorithm::Copy(input, oneValue);
+      return binaryOperator(initialValue, oneValue.ReadPortal().Get(0));
     }
 
 #if defined(VISKORES_KOKKOS_CUDA)

--- a/viskores/cont/testing/TestingDeviceAdapter.h
+++ b/viskores/cont/testing/TestingDeviceAdapter.h
@@ -2813,6 +2813,19 @@ private:
       verifyPopCount(bits);
     };
 
+    {
+      std::cout << "Testing CountSetBits with a single word" << std::endl;
+
+      BitField bits;
+      {
+        bits.Allocate(32);
+        auto fillPortal = bits.WritePortal();
+        fillPortal.SetWord(0, WordType{ 0xaa770011u });
+      }
+
+      verifyPopCount(bits);
+    }
+
     testRepeatedMask(0x00000000);
     testRepeatedMask(0xeeeeeeee);
     testRepeatedMask(0xffffffff);


### PR DESCRIPTION
Ran into a problem with optimization of calling CountBitSet with only one value in the array. It was caused by getting a value on the host when the portal was specialized to only work on the device.