### PR TITLE
add cone to anari

### DIFF
--- a/viskores/interop/anari/testing/CMakeLists.txt
+++ b/viskores/interop/anari/testing/CMakeLists.txt
@@ -22,6 +22,7 @@ SOURCES
   UnitTestANARIMapperPoints.cxx
   UnitTestANARIMapperTriangles.cxx
   UnitTestANARIMapperVolume.cxx
+  UnitTestANARIGeometryCone.cxx
   UnitTestANARIGeometryCylinder.cxx
   UnitTestANARIGeometryQuad.cxx
   UnitTestANARIScene.cxx

--- a/viskores/interop/anari/testing/UnitTestANARIGeometryCone.cxx
+++ b/viskores/interop/anari/testing/UnitTestANARIGeometryCone.cxx
@@ -1,0 +1,183 @@
+//============================================================================
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//============================================================================
+
+// viskores
+#include <viskores/cont/testing/Testing.h>
+#include <viskores/io/EncodePNG.h>
+
+#include "ANARITestCommon.h"
+
+namespace
+{
+
+void RenderTests()
+{
+  // Initialize ANARI /////////////////////////////////////////////////////////
+
+  auto d = loadANARIDevice();
+
+  const char** extensions = nullptr;
+  anariGetProperty(d, d, "extension", ANARI_STRING_LIST, &extensions, sizeof(char**), ANARI_WAIT);
+  bool conesSupported = false;
+  for (int i = 0; extensions[i] != nullptr; ++i)
+  {
+    if (extensions[i] == std::string("KHR_GEOMETRY_CONE") ||
+        extensions[i] == std::string("ANARI_KHR_GEOMETRY_CONE"))
+    {
+      conesSupported = true;
+      break;
+    }
+  }
+  if (!conesSupported)
+    VISKORES_TEST_SKIP("ANARI KHR_GEOMETRY_CONE extension not supported by ANARI device.");
+
+  // Create indexed ANARI cone geometry //////////////////////////////////////
+
+  auto indexedVertices = anari_cpp::newArray1D(d, ANARI_FLOAT32_VEC3, 4);
+  auto* indexedPositions = anari_cpp::map<viskores::Vec3f_32>(d, indexedVertices);
+  indexedPositions[0] = viskores::Vec3f_32(-0.8f, -0.35f, -0.25f);
+  indexedPositions[1] = viskores::Vec3f_32(0.05f, -0.1f, 0.2f);
+  indexedPositions[2] = viskores::Vec3f_32(-0.65f, 0.45f, -0.15f);
+  indexedPositions[3] = viskores::Vec3f_32(0.35f, 0.25f, 0.25f);
+  anari_cpp::unmap(d, indexedVertices);
+
+  auto indices = anari_cpp::newArray1D(d, ANARI_UINT32_VEC2, 2);
+  auto* cones = anari_cpp::map<viskores::Vec2ui_32>(d, indices);
+  cones[0] = viskores::Vec2ui_32(0, 1);
+  cones[1] = viskores::Vec2ui_32(2, 3);
+  anari_cpp::unmap(d, indices);
+
+  auto indexedRadii = anari_cpp::newArray1D(d, ANARI_FLOAT32, 4);
+  auto* indexedVertexRadii = anari_cpp::map<viskores::Float32>(d, indexedRadii);
+  indexedVertexRadii[0] = 0.22f;
+  indexedVertexRadii[1] = 0.08f;
+  indexedVertexRadii[2] = 0.17f;
+  indexedVertexRadii[3] = 0.f;
+  anari_cpp::unmap(d, indexedRadii);
+
+  auto caps = anari_cpp::newArray1D(d, ANARI_UINT8, 4);
+  auto* vertexCaps = anari_cpp::map<viskores::UInt8>(d, caps);
+  vertexCaps[0] = 1;
+  vertexCaps[1] = 1;
+  vertexCaps[2] = 1;
+  vertexCaps[3] = 0;
+  anari_cpp::unmap(d, caps);
+
+  auto primitiveAttributes = anari_cpp::newArray1D(d, ANARI_FLOAT32, 2);
+  auto* primitiveAttribute0 = anari_cpp::map<viskores::Float32>(d, primitiveAttributes);
+  primitiveAttribute0[0] = 0.f;
+  primitiveAttribute0[1] = 1.f;
+  anari_cpp::unmap(d, primitiveAttributes);
+
+  auto indexedGeometry = anari_cpp::newObject<anari_cpp::Geometry>(d, "cone");
+  anari_cpp::setAndReleaseParameter(d, indexedGeometry, "vertex.position", indexedVertices);
+  anari_cpp::setAndReleaseParameter(d, indexedGeometry, "primitive.index", indices);
+  anari_cpp::setAndReleaseParameter(d, indexedGeometry, "vertex.radius", indexedRadii);
+  anari_cpp::setAndReleaseParameter(d, indexedGeometry, "vertex.cap", caps);
+  anari_cpp::setAndReleaseParameter(
+    d, indexedGeometry, "primitive.attribute0", primitiveAttributes);
+  anari_cpp::setParameter(d, indexedGeometry, "caps", "none");
+  anari_cpp::commitParameters(d, indexedGeometry);
+
+  // Create non-indexed ANARI cone geometry //////////////////////////////////
+
+  auto vertices = anari_cpp::newArray1D(d, ANARI_FLOAT32_VEC3, 4);
+  auto* positions = anari_cpp::map<viskores::Vec3f_32>(d, vertices);
+  positions[0] = viskores::Vec3f_32(0.18f, -0.62f, -0.25f);
+  positions[1] = viskores::Vec3f_32(0.9f, -0.28f, 0.25f);
+  positions[2] = viskores::Vec3f_32(0.12f, 0.55f, 0.18f);
+  positions[3] = viskores::Vec3f_32(0.92f, 0.6f, -0.18f);
+  anari_cpp::unmap(d, vertices);
+
+  auto radii = anari_cpp::newArray1D(d, ANARI_FLOAT32, 4);
+  auto* vertexRadii = anari_cpp::map<viskores::Float32>(d, radii);
+  vertexRadii[0] = 0.f;
+  vertexRadii[1] = 0.14f;
+  vertexRadii[2] = 0.1f;
+  vertexRadii[3] = 0.22f;
+  anari_cpp::unmap(d, radii);
+
+  auto vertexAttributes = anari_cpp::newArray1D(d, ANARI_FLOAT32, 4);
+  auto* vertexAttribute0 = anari_cpp::map<viskores::Float32>(d, vertexAttributes);
+  vertexAttribute0[0] = 0.f;
+  vertexAttribute0[1] = 1.f;
+  vertexAttribute0[2] = 0.25f;
+  vertexAttribute0[3] = 0.75f;
+  anari_cpp::unmap(d, vertexAttributes);
+
+  auto geometry = anari_cpp::newObject<anari_cpp::Geometry>(d, "cone");
+  anari_cpp::setAndReleaseParameter(d, geometry, "vertex.position", vertices);
+  anari_cpp::setAndReleaseParameter(d, geometry, "vertex.radius", radii);
+  anari_cpp::setAndReleaseParameter(d, geometry, "vertex.attribute0", vertexAttributes);
+  anari_cpp::setParameter(d, geometry, "caps", "both");
+  anari_cpp::commitParameters(d, geometry);
+
+  // Assemble ANARI scene /////////////////////////////////////////////////////
+
+  auto colorArray = anari_cpp::newArray1D(d, ANARI_FLOAT32_VEC4, 4);
+  auto* colors = anari_cpp::map<viskores::Vec4f_32>(d, colorArray);
+  colors[0] = viskores::Vec4f_32(0.95f, 0.15f, 0.1f, 1.f);
+  colors[1] = viskores::Vec4f_32(0.95f, 0.85f, 0.1f, 1.f);
+  colors[2] = viskores::Vec4f_32(0.1f, 0.55f, 0.95f, 1.f);
+  colors[3] = viskores::Vec4f_32(0.15f, 0.75f, 0.25f, 1.f);
+  anari_cpp::unmap(d, colorArray);
+
+  auto sampler = anari_cpp::newObject<anari_cpp::Sampler>(d, "image1D");
+  anari_cpp::setAndReleaseParameter(d, sampler, "image", colorArray);
+  anari_cpp::setParameter(d, sampler, "filter", "nearest");
+  anari_cpp::setParameter(d, sampler, "wrapMode", "clampToEdge");
+  anari_cpp::setParameter(d, sampler, "inAttribute", "attribute0");
+  anari_cpp::commitParameters(d, sampler);
+
+  auto material = anari_cpp::newObject<anari_cpp::Material>(d, "matte");
+  anari_cpp::setParameter(d, material, "color", sampler);
+  anari_cpp::commitParameters(d, material);
+  anari_cpp::release(d, sampler);
+
+  auto indexedSurface = anari_cpp::newObject<anari_cpp::Surface>(d);
+  anari_cpp::setParameter(d, indexedSurface, "geometry", indexedGeometry);
+  anari_cpp::setParameter(d, indexedSurface, "material", material);
+  anari_cpp::commitParameters(d, indexedSurface);
+  anari_cpp::release(d, indexedGeometry);
+
+  auto surface = anari_cpp::newObject<anari_cpp::Surface>(d);
+  anari_cpp::setParameter(d, surface, "geometry", geometry);
+  anari_cpp::setParameter(d, surface, "material", material);
+  anari_cpp::commitParameters(d, surface);
+  anari_cpp::release(d, geometry);
+  anari_cpp::release(d, material);
+
+  anari_cpp::Surface surfaces[] = { indexedSurface, surface };
+  auto world = anari_cpp::newObject<anari_cpp::World>(d);
+  anari_cpp::setParameterArray1D(d, world, "surface", surfaces, 2);
+  anari_cpp::commitParameters(d, world);
+  anari_cpp::release(d, indexedSurface);
+  anari_cpp::release(d, surface);
+
+  // Render a frame ///////////////////////////////////////////////////////////
+
+  renderTestANARIImage(d,
+                       world,
+                       viskores::Vec3f_32(2.f, -2.2f, 1.3f),
+                       viskores::Vec3f_32(-2.f, 2.2f, -1.3f),
+                       viskores::Vec3f_32(0.f, 0.f, 1.f),
+                       "interop/anari/cone.png",
+                       viskores::Vec2ui_32(512, 512));
+
+  // Cleanup //////////////////////////////////////////////////////////////////
+
+  anari_cpp::release(d, world);
+  anari_cpp::release(d, d);
+}
+
+} // namespace
+
+int UnitTestANARIGeometryCone(int argc, char* argv[])
+{
+  return viskores::cont::testing::Testing::Run(RenderTests, argc, argv);
+}

--- a/viskores/rendering/anari-device/CMakeLists.txt
+++ b/viskores/rendering/anari-device/CMakeLists.txt
@@ -43,6 +43,7 @@ set (sources
 set(device_sources
   array/ArrayConversion.cpp
   frame/Frame.cpp
+  scene/surface/geometry/Cone.cpp
   scene/surface/geometry/Cylinder.cpp
   scene/surface/geometry/Quad.cpp
   scene/surface/geometry/Sphere.cpp

--- a/viskores/rendering/anari-device/scene/surface/geometry/Cone.cpp
+++ b/viskores/rendering/anari-device/scene/surface/geometry/Cone.cpp
@@ -1,0 +1,520 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#include "Cone.h"
+// Viskores
+#include <viskores/CellShape.h>
+#include <viskores/VectorAnalysis.h>
+#include <viskores/cont/ArrayCopy.h>
+#include <viskores/cont/ArrayHandle.h>
+#include <viskores/cont/ArrayHandlePermutation.h>
+#include <viskores/cont/ArrayHandleRuntimeVec.h>
+#include <viskores/cont/CellSetSingleType.h>
+#include <viskores/rendering/CanvasRayTracer.h>
+#include <viskores/rendering/raytracing/RayOperations.h>
+#include <viskores/rendering/raytracing/RayTracer.h>
+#include <viskores/rendering/raytracing/TriangleExtractor.h>
+#include <viskores/rendering/raytracing/TriangleIntersector.h>
+// std
+#include <cmath>
+#include <vector>
+
+namespace viskores_device
+{
+namespace
+{
+
+constexpr viskores::IdComponent ConeSegments = 24;
+constexpr viskores::Float32 TwoPi = 6.2831853071795864769f;
+constexpr viskores::Float32 Epsilon = 1.e-6f;
+
+void AddTriangle(std::vector<viskores::Vec3f_32>& points,
+                 std::vector<viskores::Id>& connectivity,
+                 std::vector<viskores::Id>& primitiveIds,
+                 std::vector<viskores::Id>& vertexIds,
+                 viskores::Id primitiveId,
+                 const viskores::Vec3f_32& a,
+                 viskores::Id aVertexId,
+                 const viskores::Vec3f_32& b,
+                 viskores::Id bVertexId,
+                 const viskores::Vec3f_32& c,
+                 viskores::Id cVertexId)
+{
+  const viskores::Id firstPoint = static_cast<viskores::Id>(points.size());
+  points.push_back(a);
+  points.push_back(b);
+  points.push_back(c);
+  connectivity.push_back(firstPoint);
+  connectivity.push_back(firstPoint + 1);
+  connectivity.push_back(firstPoint + 2);
+  primitiveIds.push_back(primitiveId);
+  vertexIds.push_back(aVertexId);
+  vertexIds.push_back(bVertexId);
+  vertexIds.push_back(cVertexId);
+}
+
+struct AddExpandedField
+{
+  viskores::cont::DataSet* DataSet;
+  std::string FieldName;
+  viskores::cont::Field::Association Association;
+  viskores::cont::ArrayHandle<viskores::Id> SourceIds;
+
+  template <typename FieldArrayType>
+  void operator()(const FieldArrayType& fieldArray) const
+  {
+    viskores::cont::ArrayHandle<typename FieldArrayType::ValueType> expandedField;
+    viskores::cont::ArrayCopy(
+      viskores::cont::make_ArrayHandlePermutation(this->SourceIds, fieldArray), expandedField);
+    this->DataSet->AddField(this->FieldName, this->Association, expandedField);
+  }
+};
+
+const char* AttributeName(viskores::IdComponent attribute)
+{
+  switch (attribute)
+  {
+    case 0:
+      return "color";
+    case 1:
+      return "attribute0";
+    case 2:
+      return "attribute1";
+    case 3:
+      return "attribute2";
+    case 4:
+      return "attribute3";
+    default:
+      return "";
+  }
+}
+
+template <typename RadiusPortalType>
+viskores::Float32 GetRadius(const RadiusPortalType& radii,
+                            viskores::Id numberOfRadii,
+                            viskores::Id numberOfCones,
+                            viskores::Id vertexId,
+                            viskores::Id coneId,
+                            viskores::Id endpointId,
+                            viskores::Float32 globalRadius)
+{
+  if (vertexId >= 0 && vertexId < numberOfRadii)
+    return radii.Get(vertexId);
+  if (2 * coneId + endpointId < numberOfRadii)
+    return radii.Get(2 * coneId + endpointId);
+  if (numberOfRadii >= numberOfCones && coneId < numberOfRadii)
+    return radii.Get(coneId);
+
+  return globalRadius;
+}
+
+template <typename CapPortalType>
+viskores::UInt8 GetCapMask(const CapPortalType& caps,
+                           viskores::Id numberOfCaps,
+                           viskores::Id numberOfVertices,
+                           viskores::Id numberOfCones,
+                           viskores::Id firstVertexId,
+                           viskores::Id secondVertexId,
+                           viskores::Id coneId,
+                           viskores::UInt8 globalCapMask)
+{
+  if (numberOfCaps >= numberOfVertices)
+  {
+    viskores::UInt8 capMask = 0;
+    if (firstVertexId >= 0 && firstVertexId < numberOfCaps && caps.Get(firstVertexId) != 0)
+      capMask |= 1;
+    if (secondVertexId >= 0 && secondVertexId < numberOfCaps && caps.Get(secondVertexId) != 0)
+      capMask |= 2;
+    return capMask;
+  }
+  if (numberOfCaps >= numberOfCones * 2)
+  {
+    viskores::UInt8 capMask = 0;
+    if (caps.Get(2 * coneId) != 0)
+      capMask |= 1;
+    if (caps.Get(2 * coneId + 1) != 0)
+      capMask |= 2;
+    return capMask;
+  }
+  if (numberOfCaps >= numberOfCones && coneId < numberOfCaps)
+    return caps.Get(coneId) != 0 ? viskores::UInt8(3) : viskores::UInt8(0);
+
+  return globalCapMask;
+}
+
+} // anonymous namespace
+
+Cone::Cone(ViskoresDeviceGlobalState* s)
+  : Geometry(s)
+  , m_index(this)
+  , m_vertexRadius(this)
+  , m_vertexCaps(this)
+{
+  this->m_vertexAttributes.setAttributes(
+    this, { "position", "color", "attribute0", "attribute1", "attribute2", "attribute3" });
+  this->m_vertexAttributes.setAnariAssociation("vertex");
+  this->m_vertexAttributes.setViskoresAssociation(viskores::cont::Field::Association::Points);
+}
+
+void Cone::commitParameters()
+{
+  this->Geometry::commitParameters();
+
+  this->m_index = getParamObject<Array1D>("primitive.index");
+  this->m_vertexRadius = getParamObject<Array1D>("vertex.radius");
+  this->m_vertexCaps = getParamObject<Array1D>("vertex.cap");
+  this->m_globalRadius = getParam<float>("radius", 1.f);
+  this->m_globalCapMask = this->ParseCaps(this->getParamString("caps", "none"));
+  this->m_vertexAttributes.commitParameters();
+}
+
+void Cone::finalize()
+{
+  this->m_dataSet = viskores::cont::DataSet{};
+
+  helium::ChangeObserverPtr<Array1D>& positionArray = this->m_vertexAttributes.getParam("position");
+  if (!positionArray)
+  {
+    reportMessage(ANARI_SEVERITY_WARNING, "'cone' geometry missing 'vertex.position' parameter");
+    return;
+  }
+
+  viskores::cont::ArrayHandle<viskores::Vec3f_32> positions;
+  viskores::cont::ArrayCopyShallowIfPossible(positionArray->dataAsViskoresArray(), positions);
+
+  viskores::cont::ArrayHandle<viskores::Float32> radii;
+  if (this->m_vertexRadius)
+  {
+    viskores::cont::ArrayCopyShallowIfPossible(this->m_vertexRadius->dataAsViskoresArray(), radii);
+  }
+  else
+  {
+    radii.AllocateAndFill(positions.GetNumberOfValues(), this->m_globalRadius);
+  }
+
+  viskores::cont::ArrayHandle<viskores::UInt8> caps;
+  if (this->m_vertexCaps)
+    viskores::cont::ArrayCopyShallowIfPossible(this->m_vertexCaps->dataAsViskoresArray(), caps);
+
+  viskores::cont::ArrayHandleRuntimeVec<viskores::Id> indexArray(2);
+  viskores::cont::ArrayHandle<viskores::Id> indexComponents;
+  if (this->m_index)
+  {
+    viskores::cont::ArrayCopyShallowIfPossible(this->m_index->dataAsViskoresArray(), indexArray);
+    indexComponents = indexArray.GetComponentsArray();
+  }
+
+  const viskores::Id numberOfVertices = positions.GetNumberOfValues();
+  const viskores::Id numberOfCones =
+    this->m_index ? indexComponents.GetNumberOfValues() / 2 : numberOfVertices / 2;
+
+  auto positionPortal = positions.ReadPortal();
+  auto radiusPortal = radii.ReadPortal();
+  auto capPortal = caps.ReadPortal();
+  auto indexPortal = indexComponents.ReadPortal();
+
+  std::vector<viskores::Vec3f_32> meshPoints;
+  std::vector<viskores::Id> connectivity;
+  std::vector<viskores::Id> primitiveIds;
+  std::vector<viskores::Id> vertexIds;
+  meshPoints.reserve(static_cast<std::size_t>(numberOfCones * ConeSegments * 12));
+  connectivity.reserve(static_cast<std::size_t>(numberOfCones * ConeSegments * 12));
+  primitiveIds.reserve(static_cast<std::size_t>(numberOfCones * ConeSegments * 4));
+  vertexIds.reserve(static_cast<std::size_t>(numberOfCones * ConeSegments * 12));
+
+  for (viskores::Id coneId = 0; coneId < numberOfCones; ++coneId)
+  {
+    const viskores::Id firstVertexId = this->m_index ? indexPortal.Get(2 * coneId) : 2 * coneId;
+    const viskores::Id secondVertexId =
+      this->m_index ? indexPortal.Get(2 * coneId + 1) : 2 * coneId + 1;
+
+    if (firstVertexId < 0 || firstVertexId >= numberOfVertices || secondVertexId < 0 ||
+        secondVertexId >= numberOfVertices)
+    {
+      continue;
+    }
+
+    const viskores::Vec3f_32 firstPoint = positionPortal.Get(firstVertexId);
+    const viskores::Vec3f_32 secondPoint = positionPortal.Get(secondVertexId);
+    const viskores::Vec3f_32 axis = secondPoint - firstPoint;
+    const viskores::Float32 axisLength2 = viskores::dot(axis, axis);
+    if (axisLength2 <= Epsilon * Epsilon)
+      continue;
+
+    const viskores::Float32 firstRadius = viskores::Max(viskores::Float32(0),
+                                                        GetRadius(radiusPortal,
+                                                                  radii.GetNumberOfValues(),
+                                                                  numberOfCones,
+                                                                  firstVertexId,
+                                                                  coneId,
+                                                                  0,
+                                                                  this->m_globalRadius));
+    const viskores::Float32 secondRadius = viskores::Max(viskores::Float32(0),
+                                                         GetRadius(radiusPortal,
+                                                                   radii.GetNumberOfValues(),
+                                                                   numberOfCones,
+                                                                   secondVertexId,
+                                                                   coneId,
+                                                                   1,
+                                                                   this->m_globalRadius));
+    if (firstRadius <= Epsilon && secondRadius <= Epsilon)
+      continue;
+
+    const viskores::UInt8 capMask = GetCapMask(capPortal,
+                                               caps.GetNumberOfValues(),
+                                               numberOfVertices,
+                                               numberOfCones,
+                                               firstVertexId,
+                                               secondVertexId,
+                                               coneId,
+                                               this->m_globalCapMask);
+
+    const viskores::Vec3f_32 axisDirection = axis / viskores::Sqrt(axisLength2);
+    const viskores::Vec3f_32 helper = viskores::Abs(axisDirection[0]) < 0.9f
+      ? viskores::Vec3f_32(1.f, 0.f, 0.f)
+      : viskores::Vec3f_32(0.f, 1.f, 0.f);
+    viskores::Vec3f_32 tangent = viskores::Cross(axisDirection, helper);
+    viskores::Normalize(tangent);
+    const viskores::Vec3f_32 bitangent = viskores::Cross(axisDirection, tangent);
+
+    std::vector<viskores::Vec3f_32> firstRing(static_cast<std::size_t>(ConeSegments));
+    std::vector<viskores::Vec3f_32> secondRing(static_cast<std::size_t>(ConeSegments));
+    for (viskores::IdComponent segment = 0; segment < ConeSegments; ++segment)
+    {
+      const viskores::Float32 angle = TwoPi * static_cast<viskores::Float32>(segment) /
+        static_cast<viskores::Float32>(ConeSegments);
+      const viskores::Vec3f_32 radialDirection =
+        tangent * std::cos(angle) + bitangent * std::sin(angle);
+      firstRing[static_cast<std::size_t>(segment)] = firstPoint + radialDirection * firstRadius;
+      secondRing[static_cast<std::size_t>(segment)] = secondPoint + radialDirection * secondRadius;
+    }
+
+    for (viskores::IdComponent segment = 0; segment < ConeSegments; ++segment)
+    {
+      const viskores::IdComponent nextSegment = (segment + 1) % ConeSegments;
+      const auto segmentIndex = static_cast<std::size_t>(segment);
+      const auto nextIndex = static_cast<std::size_t>(nextSegment);
+
+      if (firstRadius > Epsilon && secondRadius > Epsilon)
+      {
+        AddTriangle(meshPoints,
+                    connectivity,
+                    primitiveIds,
+                    vertexIds,
+                    coneId,
+                    firstRing[segmentIndex],
+                    firstVertexId,
+                    secondRing[segmentIndex],
+                    secondVertexId,
+                    secondRing[nextIndex],
+                    secondVertexId);
+        AddTriangle(meshPoints,
+                    connectivity,
+                    primitiveIds,
+                    vertexIds,
+                    coneId,
+                    firstRing[segmentIndex],
+                    firstVertexId,
+                    secondRing[nextIndex],
+                    secondVertexId,
+                    firstRing[nextIndex],
+                    firstVertexId);
+      }
+      else if (firstRadius > Epsilon)
+      {
+        AddTriangle(meshPoints,
+                    connectivity,
+                    primitiveIds,
+                    vertexIds,
+                    coneId,
+                    firstRing[segmentIndex],
+                    firstVertexId,
+                    secondPoint,
+                    secondVertexId,
+                    firstRing[nextIndex],
+                    firstVertexId);
+      }
+      else
+      {
+        AddTriangle(meshPoints,
+                    connectivity,
+                    primitiveIds,
+                    vertexIds,
+                    coneId,
+                    firstPoint,
+                    firstVertexId,
+                    secondRing[nextIndex],
+                    secondVertexId,
+                    secondRing[segmentIndex],
+                    secondVertexId);
+      }
+
+      if ((capMask & 1) != 0 && firstRadius > Epsilon)
+      {
+        AddTriangle(meshPoints,
+                    connectivity,
+                    primitiveIds,
+                    vertexIds,
+                    coneId,
+                    firstPoint,
+                    firstVertexId,
+                    firstRing[nextIndex],
+                    firstVertexId,
+                    firstRing[segmentIndex],
+                    firstVertexId);
+      }
+      if ((capMask & 2) != 0 && secondRadius > Epsilon)
+      {
+        AddTriangle(meshPoints,
+                    connectivity,
+                    primitiveIds,
+                    vertexIds,
+                    coneId,
+                    secondPoint,
+                    secondVertexId,
+                    secondRing[segmentIndex],
+                    secondVertexId,
+                    secondRing[nextIndex],
+                    secondVertexId);
+      }
+    }
+  }
+
+  auto pointsArray = viskores::cont::make_ArrayHandle(meshPoints, viskores::CopyFlag::On);
+  auto connectivityArray = viskores::cont::make_ArrayHandle(connectivity, viskores::CopyFlag::On);
+  auto primitiveIdArray = viskores::cont::make_ArrayHandle(primitiveIds, viskores::CopyFlag::On);
+  auto vertexIdArray = viskores::cont::make_ArrayHandle(vertexIds, viskores::CopyFlag::On);
+
+  viskores::cont::CellSetSingleType<> cellSet;
+  cellSet.Fill(static_cast<viskores::Id>(meshPoints.size()),
+               viskores::CELL_SHAPE_TRIANGLE,
+               3,
+               connectivityArray);
+  this->m_dataSet.SetCellSet(cellSet);
+  this->m_dataSet.AddCoordinateSystem("coords", pointsArray);
+
+  for (viskores::IdComponent attribute = 0; attribute < 5; ++attribute)
+    this->AddExpandedPrimitiveField(AttributeName(attribute), primitiveIdArray, numberOfCones);
+  for (viskores::IdComponent attribute = 0; attribute < 5; ++attribute)
+    this->AddExpandedVertexField(AttributeName(attribute), vertexIdArray, numberOfVertices);
+}
+
+void Cone::render(viskores::rendering::Canvas& canvas,
+                  const viskores::rendering::Camera& camera,
+                  const viskores::cont::Field& field,
+                  const viskores::cont::ArrayHandle<viskores::Vec4f_32>& colorMap) const
+{
+  const viskores::cont::DataSet& data = this->getDataSet();
+  if (data.GetNumberOfPoints() == 0)
+    return;
+
+  viskores::rendering::raytracing::RayTracer tracer;
+  viskores::rendering::raytracing::TriangleExtractor triExtractor;
+
+  viskores::cont::CoordinateSystem coords = data.GetCoordinateSystem();
+
+  viskores::Bounds shapeBounds;
+  viskores::Range scalarRange = field.GetRange().ReadPortal().Get(0);
+
+  triExtractor.ExtractCells(data.GetCellSet());
+
+  if (triExtractor.GetNumberOfTriangles() > 0)
+  {
+    auto triIntersector = std::make_shared<viskores::rendering::raytracing::TriangleIntersector>();
+    triIntersector->SetData(coords, triExtractor.GetTriangles());
+    tracer.AddShapeIntersector(triIntersector);
+    shapeBounds.Include(triIntersector->GetShapeBounds());
+  }
+
+  viskores::Int32 width = (viskores::Int32)canvas.GetWidth();
+  viskores::Int32 height = (viskores::Int32)canvas.GetHeight();
+
+  viskores::rendering::raytracing::Camera rayCamera = camera.CreateRaytracingCamera(width, height);
+
+  viskores::rendering::raytracing::Ray<viskores::Float32> rays;
+  viskores::rendering::CanvasRayTracer* canvasRT =
+    dynamic_cast<viskores::rendering::CanvasRayTracer*>(&canvas);
+  VISKORES_ASSERT(canvasRT != nullptr);
+
+  rayCamera.CreateRays(rays, shapeBounds);
+  tracer.GetCamera() = rayCamera;
+  rays.Buffers.at(0).InitConst(0.f);
+  viskores::rendering::raytracing::RayOperations::MapCanvasToRays(
+    rays, camera.CreateRaytracingCamera(width, height), canvasRT->GetDepthBuffer());
+
+  tracer.SetField(field, scalarRange);
+  tracer.SetColorMap(colorMap);
+  tracer.SetShadingOn(true);
+  tracer.Render(rays);
+
+  canvasRT->WriteToCanvas(rays, rays.Buffers.at(0).Buffer, camera);
+}
+
+bool Cone::isValid() const
+{
+  return this->m_vertexAttributes.getParam("position");
+}
+
+void Cone::AddExpandedPrimitiveField(const std::string& fieldName,
+                                     const viskores::cont::ArrayHandle<viskores::Id>& primitiveIds,
+                                     viskores::Id numberOfCones)
+{
+  const auto& fieldArray = this->m_primitiveAttributes.getParam(fieldName);
+  if (!fieldArray)
+    return;
+
+  const viskores::cont::UnknownArrayHandle fieldData = fieldArray->dataAsViskoresArray();
+  if (fieldData.GetNumberOfValues() < numberOfCones)
+  {
+    reportMessage(ANARI_SEVERITY_WARNING, "'cone' primitive attribute array is too short");
+    return;
+  }
+
+  fieldData.CastAndCallForTypesWithFloatFallback<VISKORES_DEFAULT_TYPE_LIST,
+                                                 VISKORES_DEFAULT_STORAGE_LIST>(AddExpandedField{
+    &this->m_dataSet, fieldName, viskores::cont::Field::Association::Cells, primitiveIds });
+}
+
+void Cone::AddExpandedVertexField(const std::string& fieldName,
+                                  const viskores::cont::ArrayHandle<viskores::Id>& vertexIds,
+                                  viskores::Id numberOfVertices)
+{
+  const auto& fieldArray = this->m_vertexAttributes.getParam(fieldName);
+  if (!fieldArray)
+    return;
+
+  const viskores::cont::UnknownArrayHandle fieldData = fieldArray->dataAsViskoresArray();
+  if (fieldData.GetNumberOfValues() < numberOfVertices)
+  {
+    reportMessage(ANARI_SEVERITY_WARNING, "'cone' vertex attribute array is too short");
+    return;
+  }
+
+  fieldData.CastAndCallForTypesWithFloatFallback<VISKORES_DEFAULT_TYPE_LIST,
+                                                 VISKORES_DEFAULT_STORAGE_LIST>(AddExpandedField{
+    &this->m_dataSet, fieldName, viskores::cont::Field::Association::Points, vertexIds });
+}
+
+viskores::UInt8 Cone::ParseCaps(const std::string& caps)
+{
+  if (caps == "none")
+    return 0;
+  if (caps == "first")
+    return 1;
+  if (caps == "second")
+    return 2;
+  if (caps == "both")
+    return 3;
+
+  reportMessage(ANARI_SEVERITY_WARNING, "invalid 'caps' value on 'cone' geometry");
+  return 0;
+}
+
+} // namespace viskores_device

--- a/viskores/rendering/anari-device/scene/surface/geometry/Cone.h
+++ b/viskores/rendering/anari-device/scene/surface/geometry/Cone.h
@@ -1,0 +1,55 @@
+//=============================================================================
+//
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//
+//=============================================================================
+
+#pragma once
+
+#include "Geometry.h"
+
+#include <viskores/cont/ArrayHandle.h>
+
+#include <string>
+
+namespace viskores_device
+{
+
+struct Cone : Geometry
+{
+  Cone(ViskoresDeviceGlobalState* s);
+
+  void commitParameters() override;
+  void finalize() override;
+
+  bool isValid() const override;
+
+  virtual void render(
+    viskores::rendering::Canvas& canvas,
+    const viskores::rendering::Camera& camera,
+    const viskores::cont::Field& field,
+    const viskores::cont::ArrayHandle<viskores::Vec4f_32>& colorMap) const override;
+
+private:
+  viskores::UInt8 ParseCaps(const std::string& caps);
+  void AddExpandedPrimitiveField(const std::string& fieldName,
+                                 const viskores::cont::ArrayHandle<viskores::Id>& primitiveIds,
+                                 viskores::Id numberOfCones);
+  void AddExpandedVertexField(const std::string& fieldName,
+                              const viskores::cont::ArrayHandle<viskores::Id>& vertexIds,
+                              viskores::Id numberOfVertices);
+
+  helium::ChangeObserverPtr<Array1D> m_index;
+  helium::ChangeObserverPtr<Array1D> m_vertexRadius;
+  helium::ChangeObserverPtr<Array1D> m_vertexCaps;
+  FieldArrayParameters m_vertexAttributes;
+
+  float m_globalRadius{ 1.f };
+  viskores::UInt8 m_globalCapMask{ 0 };
+};
+
+} // namespace viskores_device

--- a/viskores/rendering/anari-device/scene/surface/geometry/Geometry.cpp
+++ b/viskores/rendering/anari-device/scene/surface/geometry/Geometry.cpp
@@ -10,6 +10,7 @@
 
 #include "Geometry.h"
 // subtypes
+#include "Cone.h"
 #include "Cylinder.h"
 #include "Quad.h"
 #include "Sphere.h"
@@ -38,6 +39,8 @@ Geometry* Geometry::createInstance(std::string_view subtype, ViskoresDeviceGloba
   // std::cout << "Creating geometry of type " << subtype << "\n";
   if (subtype == "triangle")
     return new Triangle(s);
+  else if (subtype == "cone")
+    return new Cone(s);
   else if (subtype == "cylinder")
     return new Cylinder(s);
   else if (subtype == "quad")

--- a/viskores/rendering/anari-device/viskores_device.json
+++ b/viskores/rendering/anari-device/viskores_device.json
@@ -7,6 +7,7 @@
       "anari_core_objects_base_1_0",
       "khr_camera_orthographic",
       "khr_camera_perspective",
+      "khr_geometry_cone",
       "khr_geometry_cylinder",
       "khr_geometry_quad",
       "khr_geometry_triangle",


### PR DESCRIPTION
Add ANARI cone geometry support to the Viskores device.

This adds a cone geometry implementation, advertises `KHR_GEOMETRY_CONE`, wires cone creation into the ANARI device, and adds a direct ANARI cone geometry render test covering indexed and non-indexed cones, varying endpoint radii, caps, and primitive/vertex attributes.