### PR TITLE
Fix make_ArrayHandleSOAStride

### DIFF
--- a/docs/changelog/make-array-handle-soa-stride.md
+++ b/docs/changelog/make-array-handle-soa-stride.md
@@ -1,0 +1,8 @@
+## Fixed make_ArrayHandleSOAStride
+
+The `make_ArrayHandleSOAStride` helper function had the wrong calling
+specification and therefore could never be compiled correctly. The function is
+fixed and now tested.
+
+There has also been some documentation added to make this function easier to
+use.

--- a/docs/users-guide/examples/CMakeLists.txt
+++ b/docs/users-guide/examples/CMakeLists.txt
@@ -28,6 +28,7 @@ set(examples
   GuideExampleArrayHandlePermutation.cxx
   GuideExampleArrayHandleRandom.cxx
   GuideExampleArrayHandleRuntimeVec.cxx
+  GuideExampleArrayHandleSOAStride.cxx
   GuideExampleArrayHandleSwizzle.cxx
   GuideExampleArrayHandleView.cxx
   GuideExampleArrayHandleZip.cxx

--- a/docs/users-guide/examples/GuideExampleArrayHandleCompositeVector.cxx
+++ b/docs/users-guide/examples/GuideExampleArrayHandleCompositeVector.cxx
@@ -56,25 +56,11 @@ void ArrayHandleCompositeVectorBasic()
 
   // Create an array with [3, 1, 4, 1, 5]
   using ArrayType2 = viskores::cont::ArrayHandle<viskores::Id>;
-  ArrayType2 array2;
-  array2.Allocate(5);
-  ArrayType2::WritePortalType arrayPortal2 = array2.WritePortal();
-  arrayPortal2.Set(0, 3);
-  arrayPortal2.Set(1, 1);
-  arrayPortal2.Set(2, 4);
-  arrayPortal2.Set(3, 1);
-  arrayPortal2.Set(4, 5);
+  ArrayType2 array2 = viskores::cont::make_ArrayHandle<viskores::Id>({ 3, 1, 4, 1, 5 });
 
   // Create an array with [2, 7, 1, 8, 2]
   using ArrayType3 = viskores::cont::ArrayHandle<viskores::Id>;
-  ArrayType3 array3;
-  array3.Allocate(5);
-  ArrayType2::WritePortalType arrayPortal3 = array3.WritePortal();
-  arrayPortal3.Set(0, 2);
-  arrayPortal3.Set(1, 7);
-  arrayPortal3.Set(2, 1);
-  arrayPortal3.Set(3, 8);
-  arrayPortal3.Set(4, 2);
+  ArrayType3 array3 = viskores::cont::make_ArrayHandle<viskores::Id>({ 2, 7, 1, 8, 2 });
 
   // Create an array with [0, 0, 0, 0]
   using ArrayType4 = viskores::cont::ArrayHandleConstant<viskores::Id>;

--- a/docs/users-guide/examples/GuideExampleArrayHandleSOAStride.cxx
+++ b/docs/users-guide/examples/GuideExampleArrayHandleSOAStride.cxx
@@ -1,0 +1,69 @@
+//============================================================================
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//============================================================================
+
+#include <viskores/cont/ArrayExtractComponent.h>
+#include <viskores/cont/ArrayHandleSOAStride.h>
+#include <viskores/cont/UnknownArrayHandle.h>
+
+#include <viskores/cont/testing/Testing.h>
+
+namespace
+{
+
+viskores::cont::ArrayHandle<viskores::Vec3f> GetColors()
+{
+  return viskores::cont::make_ArrayHandle<viskores::Vec3f>(
+    { { 0.f, 0.5f, 1.f }, { 1.f, 0.5f, 0.f } });
+}
+
+viskores::cont::ArrayHandle<viskores::FloatDefault> GetOpacity()
+{
+  return viskores::cont::make_ArrayHandle<viskores::FloatDefault>({ 0.5f, 1.0f });
+}
+
+void CheckArray(const viskores::cont::UnknownArrayHandle& array)
+{
+  array.PrintSummary(std::cout);
+
+  VISKORES_TEST_ASSERT(
+    test_equal_ArrayHandles(array,
+                            viskores::cont::make_ArrayHandle<viskores::Vec4f_64>(
+                              { { 0.0, 0.5, 1.0, 0.5 }, { 1.0, 0.5, 0.0, 1.0 } })));
+}
+
+void MakeArrayHandleSOAStride()
+{
+  ////
+  //// BEGIN-EXAMPLE MakeArrayHandleSOAStride
+  ////
+  viskores::cont::ArrayHandle<viskores::Vec3f> colors = GetColors();
+  viskores::cont::ArrayHandle<viskores::FloatDefault> opacities = GetOpacity();
+
+  viskores::cont::ArrayHandleSOAStride<viskores::Vec4f> rgba =
+    viskores::cont::make_ArrayHandleSOAStride(
+      viskores::cont::ArrayExtractComponent(colors, 0),
+      viskores::cont::ArrayExtractComponent(colors, 1),
+      viskores::cont::ArrayExtractComponent(colors, 2),
+      viskores::cont::ArrayExtractComponent(opacities, 0));
+  ////
+  //// END-EXAMPLE MakeArrayHandleSOAStride
+  ////
+  CheckArray(rgba);
+}
+
+void Test()
+{
+  MakeArrayHandleSOAStride();
+}
+
+} // anonymous namespace
+
+int GuideExampleArrayHandleSOAStride(int argc, char* argv[])
+{
+  return viskores::cont::testing::Testing::Run(Test, argc, argv);
+}

--- a/docs/users-guide/memory-layout.rst
+++ b/docs/users-guide/memory-layout.rst
@@ -174,7 +174,19 @@ Recombined Vec Arrays of Strided Components
 .. doxygenclass:: viskores::cont::ArrayHandleSOAStride
    :members:
 
-|Viskores| also contains a similar special array names :class:`viskores::cont::ArrayHandleRecombineVec`.
+You can also use the :func:`viskores::cont::make_ArrayHandleSOAStride` convenience function to build a :class:`viskores::cont::ArrayHandleSOAStride`.
+
+.. doxygenfunction:: viskores::cont::make_ArrayHandleSOAStride
+
+:class:`viskores::cont::ArrayHandleSOAStride` is a mechanism to treat arrays with different storage tags as the same type of array.
+This is done by extracting all the components of the source array and constructing a :class:`viskores::cont::ArrayHandleSOAStride` with those extracted arrays.
+:class:`viskores::cont::ArrayHandleSOAStride` can also be used to combine components from different arrays as demonstrated in the following example.
+
+.. load-example:: MakeArrayHandleSOAStride
+   :file: GuideExampleArrayHandleSOAStride.cxx
+   :caption: Building a :class:`viskores::cont::ArrayHandleSOAStride`.
+
+|Viskores| also contains a similar special array named :class:`viskores::cont::ArrayHandleRecombineVec`.
 This array is similar to :class:`viskores::cont::ArrayHandleSOAStride` except that
 the number of components can be specified at runtime.
 This is useful when you know little or nothing about the value type and storage type but comes with limitations in its use.

--- a/viskores/cont/ArrayHandleSOAStride.h
+++ b/viskores/cont/ArrayHandleSOAStride.h
@@ -463,70 +463,37 @@ public:
   }
 };
 
-/// @brief Create a `viskores::cont::ArrayHandleSOAStride` with an initializer list of array handles.
-///
-/// @code{.cpp}
-/// viskores::cont::ArrayHandle<T> components1;
-/// viskores::cont::ArrayHandle<T> components2;
-/// viskores::cont::ArrayHandle<T> components3;
-/// // Fill arrays...
-///
-/// auto vecarray = viskores::cont::make_ArrayHandleSOAStride<viskores::Vec<T, 3>>(
-///   { components1, components2, components3 });
-/// @endcode
-template <typename ValueType>
-VISKORES_CONT ArrayHandleSOAStride<ValueType> make_ArrayHandleSOAStride(
-  std::initializer_list<
-    viskores::cont::ArrayHandle<typename viskores::VecTraits<ValueType>::ComponentType,
-                                viskores::cont::StorageTagBasic>>&& componentArrays)
+namespace internal
 {
-  return ArrayHandleSOAStride<ValueType>(std::move(componentArrays));
-}
+
+template <typename ComponentType, std::size_t NumComponents>
+struct AHSOAStrideValueType
+{
+  VISKORES_STATIC_ASSERT(NumComponents > 1);
+  using Type = viskores::Vec<ComponentType, static_cast<viskores::IdComponent>(NumComponents)>;
+};
+
+template <typename ComponentType>
+struct AHSOAStrideValueType<ComponentType, 1>
+{
+  using Type = ComponentType;
+};
+
+} // namespace internal
 
 /// @brief Create a `viskores::cont::ArrayHandleSOAStride` with a number of array handles.
 ///
 /// This only works if all the templated arguments are of type
-/// `viskores::cont::ArrayHandle<ComponentType>`.
-///
-/// @code{.cpp}
-/// viskores::cont::ArrayHandle<T> components1;
-/// viskores::cont::ArrayHandle<T> components2;
-/// viskores::cont::ArrayHandle<T> components3;
-/// // Fill arrays...
-///
-/// auto vecarray =
-///   viskores::cont::make_ArrayHandleSOAStride(components1, components2, components3);
-/// @endcode
+/// `viskores::cont::ArrayHandleStride<ComponentType>`.
 template <typename ComponentType, typename... RemainingArrays>
 VISKORES_CONT ArrayHandleSOAStride<
-  viskores::Vec<ComponentType, internal::VecSizeFromRemaining<RemainingArrays...>::value>>
+  typename internal::AHSOAStrideValueType<ComponentType, sizeof...(RemainingArrays) + 1>::Type>
 make_ArrayHandleSOAStride(
-  const viskores::cont::ArrayHandle<ComponentType, viskores::cont::StorageTagBasic>&
+  const viskores::cont::ArrayHandle<ComponentType, viskores::cont::StorageTagStride>&
     componentArray0,
   const RemainingArrays&... componentArrays)
 {
   return { componentArray0, componentArrays... };
-}
-
-/// @brief Create a `viskores::cont::ArrayHandleSOAStride` with a `std::vector` of component arrays.
-///
-/// The data is copied from the `std::vector`s to the array handle.
-///
-/// @code{.cpp}
-/// std::vector<T> components1;
-/// std::vector<T> components2;
-/// std::vector<T> components3;
-/// // Fill arrays...
-///
-/// auto vecarray = viskores::cont::make_ArrayHandleSOAStride<viskores::Vec<T, 3>>(
-///   { components1, components2, components3 });
-/// @endcode
-template <typename ValueType>
-VISKORES_CONT ArrayHandleSOAStride<ValueType> make_ArrayHandleSOAStride(
-  std::initializer_list<std::vector<typename viskores::VecTraits<ValueType>::ComponentType>>&&
-    componentVectors)
-{
-  return ArrayHandleSOAStride<ValueType>(std::move(componentVectors));
 }
 
 namespace internal

--- a/viskores/cont/testing/UnitTestArrayHandleSOAStride.cxx
+++ b/viskores/cont/testing/UnitTestArrayHandleSOAStride.cxx
@@ -58,6 +58,15 @@ struct TestSOASAsInput
     constexpr viskores::IdComponent NUM_COMPONENTS = VTraits::NUM_COMPONENTS;
 
     viskores::cont::ArrayHandleSOAStride<ValueType> soaStrideArray;
+    if constexpr (NUM_COMPONENTS == 1)
+    {
+      viskores::cont::ArrayHandle<ComponentType> dataArray;
+      dataArray.Allocate(ARRAY_SIZE);
+      SetPortal(dataArray.WritePortal());
+      soaStrideArray = viskores::cont::make_ArrayHandleSOAStride(
+        viskores::cont::ArrayExtractComponent(dataArray, 0));
+    }
+    else
     {
       viskores::cont::ArrayHandle<ComponentType> dataArray;
       auto groupVec = viskores::cont::make_ArrayHandleGroupVec<NUM_COMPONENTS>(dataArray);
@@ -118,6 +127,12 @@ struct TestSOASAsOutput
 
     viskores::cont::ArrayHandleSOAStride<ValueType> soaStrideArray;
     viskores::cont::ArrayHandle<ComponentType> dataArray;
+    if constexpr (NUM_COMPONENTS == 1)
+    {
+      soaStrideArray = viskores::cont::make_ArrayHandleSOAStride(
+        viskores::cont::ArrayExtractComponent(dataArray, 0));
+    }
+    else
     {
       auto groupVec = viskores::cont::make_ArrayHandleGroupVec<NUM_COMPONENTS>(dataArray);
       for (viskores::IdComponent componentIndex = 0; componentIndex < NUM_COMPONENTS;


### PR DESCRIPTION
The `make_ArrayHandleSOAStride` helper function had the wrong calling specification and therefore could never be compiled correctly. The function is fixed and now tested.