### PR TITLE
fix(anari): return device extensions from getDeviceExtensions

### DIFF
--- a/docs/changelog/anari-getdeciveextensions-fix.md
+++ b/docs/changelog/anari-getdeciveextensions-fix.md
@@ -1,0 +1,30 @@
+## Fix ANARI ViskoresLibrary getDeviceExtensions to return device extensions
+The ANARI device returned a nullptr for `getDeviceExtensions` which meant 
+that any client (e.g. Paraview, but also ANARI-SDK examples) checking 
+features via `anariGetDeviceExtensions` failed.
+
+Example from calling `anariInfo` from ANARI-SDK:
+
+Before:
+```bash
+➜  bin ./anariInfo -l viskores | grep -A 10 Extensions
+[DEBUG] destroying Viskores device (0x10445ea20)
+```
+
+After fix:
+```bash
+➜  bin ./anariInfo -l viskores | grep -A 10 Extensions
+[DEBUG] destroying Viskores device (0x10557ea20)
+   Extensions:
+      ANARI_KHR_CAMERA_ORTHOGRAPHIC
+      ANARI_KHR_CAMERA_PERSPECTIVE
+      ANARI_KHR_GEOMETRY_CYLINDER
+      ANARI_KHR_GEOMETRY_QUAD
+      ANARI_KHR_GEOMETRY_SPHERE
+      ANARI_KHR_GEOMETRY_TRIANGLE
+      ANARI_KHR_MATERIAL_MATTE
+      ANARI_KHR_SAMPLER_IMAGE1D
+      ANARI_KHR_VOLUME_TRANSFER_FUNCTION1D
+   Subtypes:
+
+```

--- a/viskores/rendering/anari-device/ViskoresLibrary.cpp
+++ b/viskores/rendering/anari-device/ViskoresLibrary.cpp
@@ -11,6 +11,7 @@
 #include "ViskoresDevice.h"
 #include "anari/backend/LibraryImpl.h"
 #include "anari_library_viskores_export.h"
+#include "anari_library_viskores_queries.h"
 
 #include <viskores/cont/Initialize.h>
 
@@ -45,7 +46,7 @@ ANARIDevice ViskoresLibrary::newDevice(const char* /*subtype*/)
 
 const char** ViskoresLibrary::getDeviceExtensions(const char* /*deviceType*/)
 {
-  return nullptr;
+  return query_extensions();
 }
 
 } // namespace viskores_device


### PR DESCRIPTION
The ANARI device returned a nullptr for `getDeviceExtensions` which meant that any client (e.g. Paraview, but also ANARI-SDK examples) checking features via `anariGetDeviceExtensions` failed.

Example from calling `anariInfo` from ANARI-SDK:

Before:
```bash
➜  bin ./anariInfo -l viskores | grep -A 10 Extensions
[DEBUG] destroying Viskores device (0x10445ea20)
```

After fix:
```bash
➜  bin ./anariInfo -l viskores | grep -A 10 Extensions
[DEBUG] destroying Viskores device (0x10557ea20)
   Extensions:
      ANARI_KHR_CAMERA_ORTHOGRAPHIC
      ANARI_KHR_CAMERA_PERSPECTIVE
      ANARI_KHR_GEOMETRY_CYLINDER
      ANARI_KHR_GEOMETRY_QUAD
      ANARI_KHR_GEOMETRY_SPHERE
      ANARI_KHR_GEOMETRY_TRIANGLE
      ANARI_KHR_MATERIAL_MATTE
      ANARI_KHR_SAMPLER_IMAGE1D
      ANARI_KHR_VOLUME_TRANSFER_FUNCTION1D
   Subtypes:

```

This was previously not caught because the unit tests called 
```cpp
anariGetProperty(d, d, "extension", ANARI_STRING_LIST, &extensions, sizeof(char**), ANARI_WAIT);
```
instead of 
```cpp
ANARI_INTERFACE const char ** anariGetDeviceExtensions(ANARILibrary library, const char* deviceSubtype);
```

So it might make sense to also change the unit tests to use the `anariGetDeviceExtensions`.

If you agree I can add that as well before merge.

Best
Marcel