### PR TITLE
WIP: Check FPE in UnitTestParameterCoordinates

### DIFF
--- a/viskores/exec/testing/UnitTestParametricCoordinates.cxx
+++ b/viskores/exec/testing/UnitTestParametricCoordinates.cxx
@@ -218,6 +218,7 @@ struct TestPCoordsFunctor
 void TestAllPCoords()
 {
   viskores::UInt32 seed = static_cast<viskores::UInt32>(std::time(nullptr));
+  seed = 1782519515;
   std::cout << "Seed: " << seed << std::endl;
   g_RandomGenerator.seed(seed);
 

--- a/viskores/exec/testing/UnitTestParametricCoordinates.cxx
+++ b/viskores/exec/testing/UnitTestParametricCoordinates.cxx
@@ -134,7 +134,9 @@ void TestPCoordsSample(const PointWCoordsType& pointWCoords, CellShapeTag shape)
       pcoords = pcoords + weight * pointPcoords;
       totalWeight += weight;
     }
+    std::cout << "Total weight: " << totalWeight << std::endl;
     pcoords = (1 / totalWeight) * pcoords;
+    std::cout << "Test pcoords: " << pcoords << std::endl;
 
     // If you convert to world coordinates and back, you should get the
     // same value.
@@ -153,7 +155,15 @@ void TestPCoordsSample(const PointWCoordsType& pointWCoords, CellShapeTag shape)
 template <typename PointWCoordsType, typename CellShellTag>
 static void TestPCoords(const PointWCoordsType& pointWCoords, CellShellTag shape)
 {
+  std::cout << "... Coordinates: [ ";
+  for (viskores::IdComponent comp = 0; comp < pointWCoords.GetNumberOfComponents(); ++comp)
+  {
+    std::cout << pointWCoords[comp] << " ";
+  }
+  std::cout << "]\n";
+  std::cout << "Special" << std::endl;
   TestPCoordsSpecial(pointWCoords, shape);
+  std::cout << "Sample" << std::endl;
   TestPCoordsSample(pointWCoords, shape);
 }
 


### PR DESCRIPTION
In a CI build, I had the UnitTestParametricCoordinates test fail on ubuntu2204_cuda122_kokkos41 (release+benchmarks+kokkos+ampere+64bit_floats+shared+ccache) with a floating point exception (FPE).

https://open.cdash.org/index.php?compare1=61&filtercount=1&field1=revision&project=Viskores&showfilters=0&limit=100&value1=aa59c1f34e2f5b35528dc44084400cb055cc2f37&showfeed=0

https://open.cdash.org/tests/2630118371

This appears to be an intermittent issue. It might be a host/device thing. But this test also uses a random number generator to create data. This change fixes the seed to that used in the failed test to see if that causes it to repeat.