### PR TITLE
Add Python bindings for Field, CoordinateSystem, DataSet, and DataSetBuilderUniform

### DIFF
--- a/docs/changelog/python-bindings-dataset.md
+++ b/docs/changelog/python-bindings-dataset.md
@@ -11,11 +11,7 @@ build and inspect datasets from Python:
   `UnknownArrayHandle`; `.asnumpy()` is a convenience shortcut.
 
 * `viskores.cont.CoordinateSystem(name, data)` — constructs a coordinate
-  system from a name and a `UnknownArrayHandle`. Three-component float32 or
-  float64 arrays produced by `array_from_numpy` are copied to
-  `ArrayHandle<Vec3f_32>` / `ArrayHandle<Vec3f_64>` storage so that filters
-  can dispatch on them via `CoordinateSystem::GetData()`. See the design
-  question in `cont_bindings.cxx` for discussion of alternatives.
+  system from a name and a `UnknownArrayHandle`.
 
 * `viskores.cont.DataSet` — exposes `AddField`, `AddPointField`,
   `AddCellField`, `HasField`, `GetField`, `AddCoordinateSystem`,

--- a/docs/changelog/python-bindings-dataset.md
+++ b/docs/changelog/python-bindings-dataset.md
@@ -3,6 +3,10 @@
 The Viskores Python bindings now expose the core DataSet types needed to
 build and inspect datasets from Python:
 
+* `viskores.Range` and `viskores.Bounds` — mirror `viskores::Range` and
+  `viskores::Bounds` with read/write `Min`/`Max` and `X`/`Y`/`Z` members plus
+  `IsNonEmpty()`, `Length()`, and `Center()` accessors.
+
 * `viskores.cont.FieldAssociation` — enum with values `Any`, `WholeDataSet`,
   `Points`, `Cells`, `Partitions`, and `Global`.
 
@@ -11,13 +15,17 @@ build and inspect datasets from Python:
   `UnknownArrayHandle`; `.asnumpy()` is a convenience shortcut.
 
 * `viskores.cont.CoordinateSystem(name, data)` — constructs a coordinate
-  system from a name and a `UnknownArrayHandle`.
+  system from a name and a `UnknownArrayHandle`. `.GetBounds()` returns the
+  axis-aligned bounds as a `viskores.Bounds`.
 
 * `viskores.cont.DataSet` — exposes `AddField`, `AddPointField`,
   `AddCellField`, `HasField`, `GetField`, `AddCoordinateSystem`,
   `GetCoordinateSystem`, and the `GetNumberOf{Fields,Points,Cells,
-  CoordinateSystems}` accessors.
+  CoordinateSystems}` accessors. Indexed accessors validate the index and
+  raise an exception when it is out of range.
 
-* `viskores.cont.DataSetBuilderUniform.create(dimensions)` — creates a
+* `viskores.cont.DataSetBuilderUniform.Create(dimensions)` — creates a
   uniform rectilinear dataset. Pass a list of 1, 2, or 3 integer dimensions
-  (number of points per axis); origin is `[0,0,0]` and spacing is `[1,1,1]`.
+  (number of points per axis, each >= 1); origin is `[0,0,0]` and spacing is
+  `[1,1,1]`. As in the C++ API, a dimension of 1 collapses that axis,
+  lowering the dataset's dimensionality.

--- a/docs/changelog/python-bindings-dataset.md
+++ b/docs/changelog/python-bindings-dataset.md
@@ -1,0 +1,27 @@
+## Add Python bindings for DataSet, Field, CoordinateSystem, and DataSetBuilderUniform
+
+The Viskores Python bindings now expose the core DataSet types needed to
+build and inspect datasets from Python:
+
+* `viskores.cont.FieldAssociation` — enum with values `Any`, `WholeDataSet`,
+  `Points`, `Cells`, `Partitions`, and `Global`.
+
+* `viskores.cont.Field(name, association, data)` — wraps a
+  `UnknownArrayHandle` with a name and association. `.GetData()` returns the
+  `UnknownArrayHandle`; `.asnumpy()` is a convenience shortcut.
+
+* `viskores.cont.CoordinateSystem(name, data)` — constructs a coordinate
+  system from a name and a `UnknownArrayHandle`. Three-component float32 or
+  float64 arrays produced by `array_from_numpy` are copied to
+  `ArrayHandle<Vec3f_32>` / `ArrayHandle<Vec3f_64>` storage so that filters
+  can dispatch on them via `CoordinateSystem::GetData()`. See the design
+  question in `cont_bindings.cxx` for discussion of alternatives.
+
+* `viskores.cont.DataSet` — exposes `AddField`, `AddPointField`,
+  `AddCellField`, `HasField`, `GetField`, `AddCoordinateSystem`,
+  `GetCoordinateSystem`, and the `GetNumberOf{Fields,Points,Cells,
+  CoordinateSystems}` accessors.
+
+* `viskores.cont.DataSetBuilderUniform.create(dimensions)` — creates a
+  uniform rectilinear dataset. Pass a list of 1, 2, or 3 integer dimensions
+  (number of points per axis); origin is `[0,0,0]` and spacing is `[1,1,1]`.

--- a/python_bindings/src/cont_bindings.cxx
+++ b/python_bindings/src/cont_bindings.cxx
@@ -172,8 +172,7 @@ void BindCont(nb::module_& m)
          nb::arg("association") = viskores::cont::Field::Association::Any,
          nb::rv_policy::reference_internal,
          "Retrieve a field by name. Throws if not found.\n"
-         "The returned Field shares storage with the DataSet; the DataSet\n"
-         "must remain alive while the Field is in use.")
+         "The returned Field shares storage with the DataSet and keeps it alive.")
     .def("GetField",
          [](viskores::cont::DataSet& self, viskores::Id index) -> viskores::cont::Field&
          {
@@ -187,7 +186,7 @@ void BindCont(nb::module_& m)
          nb::arg("index"),
          nb::rv_policy::reference_internal,
          "Retrieve a field by index (0 to GetNumberOfFields()-1). Throws if out of range.\n"
-         "The returned Field shares storage with the DataSet.")
+         "The returned Field shares storage with the DataSet and keeps it alive.")
     .def("AddCoordinateSystem",
          [](viskores::cont::DataSet& self, const viskores::cont::CoordinateSystem& cs)
          { self.AddCoordinateSystem(cs); },
@@ -218,10 +217,10 @@ void BindCont(nb::module_& m)
         }
         for (auto d : dims)
         {
-          if (d < 2)
+          if (d < 1)
           {
             throw viskores::cont::ErrorBadValue(
-              "DataSetBuilderUniform.Create() requires each dimension to be >= 2, got " +
+              "DataSetBuilderUniform.Create() requires each dimension to be >= 1, got " +
               std::to_string(d));
           }
         }
@@ -239,8 +238,9 @@ void BindCont(nb::module_& m)
       },
       nb::arg("dimensions"),
       "Create a uniform rectilinear DataSet. Pass a list of 1, 2, or 3 integer\n"
-      "dimensions (number of points per axis), each >= 2. Origin is [0,0,0] and\n"
-      "spacing is [1,1,1] by default.");
+      "dimensions (number of points per axis), each >= 1. As in the C++ API, a\n"
+      "dimension of 1 collapses that axis, lowering the dataset's dimensionality.\n"
+      "Origin is [0,0,0] and spacing is [1,1,1] by default.");
 }
 
 } // namespace viskores::python::bindings

--- a/python_bindings/src/cont_bindings.cxx
+++ b/python_bindings/src/cont_bindings.cxx
@@ -14,6 +14,7 @@
 #include <viskores/cont/CoordinateSystem.h>
 #include <viskores/cont/DataSet.h>
 #include <viskores/cont/DataSetBuilderUniform.h>
+#include <viskores/cont/ErrorBadValue.h>
 #include <viskores/cont/Field.h>
 #include <viskores/cont/UnknownArrayHandle.h>
 
@@ -88,8 +89,7 @@ void BindCont(nb::module_& m)
     .value("Points", viskores::cont::Field::Association::Points)
     .value("Cells", viskores::cont::Field::Association::Cells)
     .value("Partitions", viskores::cont::Field::Association::Partitions)
-    .value("Global", viskores::cont::Field::Association::Global)
-    .export_values();
+    .value("Global", viskores::cont::Field::Association::Global);
 
   nb::class_<viskores::cont::Field>(m, "Field")
     .def(nb::init<std::string, viskores::cont::Field::Association,
@@ -115,23 +115,13 @@ void BindCont(nb::module_& m)
 
   nb::class_<viskores::cont::CoordinateSystem, viskores::cont::Field>(m, "CoordinateSystem")
     .def(nb::init<>())
-    .def("__init__",
-         [](viskores::cont::CoordinateSystem* self,
-            const std::string& name,
-            const viskores::cont::UnknownArrayHandle& data) {
-           new (self) viskores::cont::CoordinateSystem(name, data);
-         },
+    .def(nb::init<std::string, const viskores::cont::UnknownArrayHandle&>(),
          nb::arg("name"),
          nb::arg("data"),
          "Construct a CoordinateSystem from a name and an UnknownArrayHandle.")
     .def("GetBounds",
-         [](const viskores::cont::CoordinateSystem& self)
-         {
-           viskores::Bounds b = self.GetBounds();
-           return std::vector<double>{ b.X.Min, b.X.Max, b.Y.Min,
-                                       b.Y.Max, b.Z.Min, b.Z.Max };
-         },
-         "Return axis-aligned bounds as [xmin,xmax,ymin,ymax,zmin,zmax].");
+         &viskores::cont::CoordinateSystem::GetBounds,
+         "Return the axis-aligned bounds of the coordinate data.");
 
   nb::class_<viskores::cont::DataSet>(m, "DataSet")
     .def(nb::init<>())
@@ -169,10 +159,7 @@ void BindCont(nb::module_& m)
          nb::arg("data"),
          "Add a cell-associated field from an UnknownArrayHandle.")
     .def("HasField",
-         [](const viskores::cont::DataSet& self,
-            const std::string& name,
-            viskores::cont::Field::Association assoc)
-         { return self.HasField(name, assoc); },
+         &viskores::cont::DataSet::HasField,
          nb::arg("name"),
          nb::arg("association") = viskores::cont::Field::Association::Any,
          "Return True if a field with the given name (and optional association) exists.")
@@ -189,10 +176,17 @@ void BindCont(nb::module_& m)
          "must remain alive while the Field is in use.")
     .def("GetField",
          [](viskores::cont::DataSet& self, viskores::Id index) -> viskores::cont::Field&
-         { return self.GetField(index); },
+         {
+           if ((index < 0) || (index >= self.GetNumberOfFields()))
+           {
+             throw viskores::cont::ErrorBadValue("Field index out of range: " +
+                                                 std::to_string(index));
+           }
+           return self.GetField(index);
+         },
          nb::arg("index"),
          nb::rv_policy::reference_internal,
-         "Retrieve a field by index (0 to GetNumberOfFields()-1).\n"
+         "Retrieve a field by index (0 to GetNumberOfFields()-1). Throws if out of range.\n"
          "The returned Field shares storage with the DataSet.")
     .def("AddCoordinateSystem",
          [](viskores::cont::DataSet& self, const viskores::cont::CoordinateSystem& cs)
@@ -201,15 +195,36 @@ void BindCont(nb::module_& m)
          "Add a CoordinateSystem to the DataSet.")
     .def("GetCoordinateSystem",
          [](const viskores::cont::DataSet& self, viskores::Id index)
-         { return self.GetCoordinateSystem(index); },
+         {
+           if ((index < 0) || (index >= self.GetNumberOfCoordinateSystems()))
+           {
+             throw viskores::cont::ErrorBadValue("Coordinate system index out of range: " +
+                                                 std::to_string(index));
+           }
+           return self.GetCoordinateSystem(index);
+         },
          nb::arg("index") = 0,
-         "Return the CoordinateSystem at the given index (default 0).");
+         "Return the CoordinateSystem at the given index (default 0). Throws if out of range.");
 
   nb::class_<viskores::cont::DataSetBuilderUniform>(m, "DataSetBuilderUniform")
     .def_static(
-      "create",
+      "Create",
       [](std::vector<viskores::Id> dims) -> viskores::cont::DataSet
       {
+        if ((dims.size() < 1) || (dims.size() > 3))
+        {
+          throw viskores::cont::ErrorBadValue(
+            "DataSetBuilderUniform.Create() requires a list of 1, 2, or 3 dimensions.");
+        }
+        for (auto d : dims)
+        {
+          if (d < 2)
+          {
+            throw viskores::cont::ErrorBadValue(
+              "DataSetBuilderUniform.Create() requires each dimension to be >= 2, got " +
+              std::to_string(d));
+          }
+        }
         if (dims.size() == 1)
         {
           return viskores::cont::DataSetBuilderUniform::Create(dims[0]);
@@ -219,18 +234,13 @@ void BindCont(nb::module_& m)
           return viskores::cont::DataSetBuilderUniform::Create(
             viskores::Id2(dims[0], dims[1]));
         }
-        if (dims.size() == 3)
-        {
-          return viskores::cont::DataSetBuilderUniform::Create(
-            viskores::Id3(dims[0], dims[1], dims[2]));
-        }
-        throw viskores::cont::ErrorBadValue(
-          "DataSetBuilderUniform.create() requires a list of 1, 2, or 3 dimensions.");
+        return viskores::cont::DataSetBuilderUniform::Create(
+          viskores::Id3(dims[0], dims[1], dims[2]));
       },
       nb::arg("dimensions"),
       "Create a uniform rectilinear DataSet. Pass a list of 1, 2, or 3 integer\n"
-      "dimensions (number of points per axis). Origin is [0,0,0] and spacing\n"
-      "is [1,1,1] by default.");
+      "dimensions (number of points per axis), each >= 2. Origin is [0,0,0] and\n"
+      "spacing is [1,1,1] by default.");
 }
 
 } // namespace viskores::python::bindings

--- a/python_bindings/src/cont_bindings.cxx
+++ b/python_bindings/src/cont_bindings.cxx
@@ -11,9 +11,18 @@
 #include <viskores/interop/python/ArrayHandleToNumPy.h>
 #include <viskores/interop/python/NumPyToArrayHandle.h>
 
+#include <viskores/cont/ArrayHandleRuntimeVec.h>
+#include <viskores/cont/CoordinateSystem.h>
+#include <viskores/cont/DataSet.h>
+#include <viskores/cont/DataSetBuilderUniform.h>
+#include <viskores/cont/Field.h>
 #include <viskores/cont/UnknownArrayHandle.h>
 
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/vector.h>
+
 #include <string>
+#include <vector>
 
 namespace vip = viskores::interop::python;
 
@@ -27,6 +36,91 @@ std::string UnknownArrayHandleRepr(const viskores::cont::UnknownArrayHandle& sel
   return "viskores.cont.UnknownArrayHandle(values=" +
     std::to_string(self.GetNumberOfValues()) +
     ", components=" + std::to_string(self.GetNumberOfComponentsFlat()) + ")";
+}
+
+// -------------------------------------------------------------------
+// DESIGN QUESTION FOR REVIEW: RuntimeVec vs ArrayHandleBasic<Vec<T,N>>
+// for Python-supplied coordinate arrays.
+//
+// PR #308 established (at Ken's explicit request) that ArrayFromNumPyVectorArray
+// produces ArrayHandleRuntimeVec<ComponentType> for 2D NumPy inputs. This is
+// clean for UnknownArrayHandle interop: one owner class handles all component
+// counts without needing a switch on N.
+//
+// However, CoordinateSystem::GetData() returns:
+//   UncertainArrayHandle<TypeListFieldVec3, VISKORES_DEFAULT_STORAGE_LIST>
+// where VISKORES_DEFAULT_STORAGE_LIST == StorageListCommon, which does NOT include
+// StorageTagRuntimeVec. This means a Python-supplied coordinate array stored as
+// ArrayHandleRuntimeVec will silently fail to dispatch in any filter that calls
+// CastAndCall on coordinate data via CoordinateSystem::GetData().
+//
+// This binding works around that by copying RuntimeVec<Float32/Float64>(3) to
+// ArrayHandle<Vec3f_32/Vec3f_64> before passing to the CoordinateSystem constructor.
+// Is this the right fix? Alternatives we see:
+//   (a) Change ArrayFromNumPyVectorArray to produce ArrayHandleBasic<Vec<T,N>>
+//       for N=2,3,4, reverting the PR #308 RuntimeVec decision for fixed-N arrays.
+//   (b) Keep this copy here and accept that Python-supplied coordinates always
+//       incur one host copy when building a CoordinateSystem.
+//   (c) Add StorageTagRuntimeVec to StorageListCommon (or provide a RuntimeVec-aware
+//       UncertainArrayHandle alias) so filters dispatch through it without copies.
+// -------------------------------------------------------------------
+template <typename ComponentType, viskores::IdComponent N>
+viskores::cont::ArrayHandle<viskores::Vec<ComponentType, N>>
+CopyRuntimeVecToFixedVec(const viskores::cont::ArrayHandleRuntimeVec<ComponentType>& rv)
+{
+  viskores::cont::ArrayHandle<viskores::Vec<ComponentType, N>> dest;
+  dest.Allocate(rv.GetNumberOfValues());
+  auto srcPortal = rv.ReadPortal();
+  auto destPortal = dest.WritePortal();
+  for (viskores::Id i = 0; i < rv.GetNumberOfValues(); ++i)
+  {
+    auto v = srcPortal.Get(i);
+    viskores::Vec<ComponentType, N> vec;
+    for (viskores::IdComponent c = 0; c < N; ++c)
+    {
+      vec[c] = v[c];
+    }
+    destPortal.Set(i, vec);
+  }
+  return dest;
+}
+
+// Convert a Python-supplied UnknownArrayHandle to storage compatible with
+// CoordinateSystem filter dispatch. See the design question comment above.
+viskores::cont::UnknownArrayHandle ToCoordinateCompatibleArray(
+  const viskores::cont::UnknownArrayHandle& input)
+{
+  const viskores::IdComponent nComp = input.GetNumberOfComponentsFlat();
+  if (nComp != 3)
+  {
+    return input;
+  }
+
+  {
+    using RV = viskores::cont::ArrayHandleRuntimeVec<viskores::Float32>;
+    if (input.CanConvert<RV>())
+    {
+      RV rv;
+      input.AsArrayHandle(rv);
+      if (rv.GetNumberOfComponents() == 3)
+      {
+        return CopyRuntimeVecToFixedVec<viskores::Float32, 3>(rv);
+      }
+    }
+  }
+  {
+    using RV = viskores::cont::ArrayHandleRuntimeVec<viskores::Float64>;
+    if (input.CanConvert<RV>())
+    {
+      RV rv;
+      input.AsArrayHandle(rv);
+      if (rv.GetNumberOfComponents() == 3)
+      {
+        return CopyRuntimeVecToFixedVec<viskores::Float64, 3>(rv);
+      }
+    }
+  }
+  return input;
 }
 
 } // namespace
@@ -72,6 +166,160 @@ void BindCont(nb::module_& m)
         nb::arg("array"),
         "Return a read-only NumPy view of a Viskores UnknownArrayHandle.\n"
         "Equivalent to array.asnumpy().");
+
+  // Field::Association enum
+  nb::enum_<viskores::cont::Field::Association>(m, "FieldAssociation")
+    .value("Any", viskores::cont::Field::Association::Any)
+    .value("WholeDataSet", viskores::cont::Field::Association::WholeDataSet)
+    .value("Points", viskores::cont::Field::Association::Points)
+    .value("Cells", viskores::cont::Field::Association::Cells)
+    .value("Partitions", viskores::cont::Field::Association::Partitions)
+    .value("Global", viskores::cont::Field::Association::Global)
+    .export_values();
+
+  nb::class_<viskores::cont::Field>(m, "Field")
+    .def(nb::init<std::string, viskores::cont::Field::Association,
+                  const viskores::cont::UnknownArrayHandle&>(),
+         nb::arg("name"),
+         nb::arg("association"),
+         nb::arg("data"),
+         "Construct a Field from a name, association, and UnknownArrayHandle.")
+    .def("GetName", &viskores::cont::Field::GetName, "Field name.")
+    .def("GetAssociation",
+         &viskores::cont::Field::GetAssociation,
+         "Field association (Points, Cells, etc.).")
+    .def("GetNumberOfValues",
+         &viskores::cont::Field::GetNumberOfValues,
+         "Number of tuples in the field array.")
+    .def("GetData",
+         [](const viskores::cont::Field& self) { return self.GetData(); },
+         "Return the field data as an UnknownArrayHandle.")
+    .def("asnumpy",
+         [](const viskores::cont::Field& self)
+         { return vip::ArrayHandleToNumPy(self.GetData()); },
+         "Return a read-only NumPy view of the field data.");
+
+  nb::class_<viskores::cont::CoordinateSystem, viskores::cont::Field>(m, "CoordinateSystem")
+    .def(nb::init<>())
+    .def("__init__",
+         [](viskores::cont::CoordinateSystem* self,
+            const std::string& name,
+            const viskores::cont::UnknownArrayHandle& data) {
+           new (self) viskores::cont::CoordinateSystem(name, ToCoordinateCompatibleArray(data));
+         },
+         nb::arg("name"),
+         nb::arg("data"),
+         "Construct a CoordinateSystem from a name and an UnknownArrayHandle.\n"
+         "Arrays produced by array_from_numpy with 3 float32 or float64\n"
+         "components are copied to ArrayHandle<Vec3f> storage so that filters\n"
+         "can dispatch on them via CoordinateSystem::GetData().")
+    .def("GetBounds",
+         [](const viskores::cont::CoordinateSystem& self)
+         {
+           viskores::Bounds b = self.GetBounds();
+           return std::vector<double>{ b.X.Min, b.X.Max, b.Y.Min,
+                                       b.Y.Max, b.Z.Min, b.Z.Max };
+         },
+         "Return axis-aligned bounds as [xmin,xmax,ymin,ymax,zmin,zmax].");
+
+  nb::class_<viskores::cont::DataSet>(m, "DataSet")
+    .def(nb::init<>())
+    .def("GetNumberOfFields",
+         &viskores::cont::DataSet::GetNumberOfFields,
+         "Number of fields attached to this DataSet.")
+    .def("GetNumberOfPoints",
+         &viskores::cont::DataSet::GetNumberOfPoints,
+         "Number of points (vertices) in the DataSet.")
+    .def("GetNumberOfCells",
+         &viskores::cont::DataSet::GetNumberOfCells,
+         "Number of cells in the DataSet.")
+    .def("GetNumberOfCoordinateSystems",
+         &viskores::cont::DataSet::GetNumberOfCoordinateSystems,
+         "Number of coordinate systems attached to this DataSet.")
+    .def("AddField",
+         [](viskores::cont::DataSet& self, const viskores::cont::Field& field)
+         { self.AddField(field); },
+         nb::arg("field"),
+         "Add a Field object to the DataSet.")
+    .def("AddPointField",
+         [](viskores::cont::DataSet& self,
+            const std::string& name,
+            const viskores::cont::UnknownArrayHandle& data)
+         { self.AddPointField(name, data); },
+         nb::arg("name"),
+         nb::arg("data"),
+         "Add a point-associated field from an UnknownArrayHandle.")
+    .def("AddCellField",
+         [](viskores::cont::DataSet& self,
+            const std::string& name,
+            const viskores::cont::UnknownArrayHandle& data)
+         { self.AddCellField(name, data); },
+         nb::arg("name"),
+         nb::arg("data"),
+         "Add a cell-associated field from an UnknownArrayHandle.")
+    .def("HasField",
+         [](const viskores::cont::DataSet& self,
+            const std::string& name,
+            viskores::cont::Field::Association assoc)
+         { return self.HasField(name, assoc); },
+         nb::arg("name"),
+         nb::arg("association") = viskores::cont::Field::Association::Any,
+         "Return True if a field with the given name (and optional association) exists.")
+    .def("GetField",
+         [](viskores::cont::DataSet& self,
+            const std::string& name,
+            viskores::cont::Field::Association assoc) -> viskores::cont::Field&
+         { return self.GetField(name, assoc); },
+         nb::arg("name"),
+         nb::arg("association") = viskores::cont::Field::Association::Any,
+         nb::rv_policy::reference_internal,
+         "Retrieve a field by name. Throws if not found.\n"
+         "The returned Field shares storage with the DataSet; the DataSet\n"
+         "must remain alive while the Field is in use.")
+    .def("GetField",
+         [](viskores::cont::DataSet& self, viskores::Id index) -> viskores::cont::Field&
+         { return self.GetField(index); },
+         nb::arg("index"),
+         nb::rv_policy::reference_internal,
+         "Retrieve a field by index (0 to GetNumberOfFields()-1).\n"
+         "The returned Field shares storage with the DataSet.")
+    .def("AddCoordinateSystem",
+         [](viskores::cont::DataSet& self, const viskores::cont::CoordinateSystem& cs)
+         { self.AddCoordinateSystem(cs); },
+         nb::arg("coordinate_system"),
+         "Add a CoordinateSystem to the DataSet.")
+    .def("GetCoordinateSystem",
+         [](const viskores::cont::DataSet& self, viskores::Id index)
+         { return self.GetCoordinateSystem(index); },
+         nb::arg("index") = 0,
+         "Return the CoordinateSystem at the given index (default 0).");
+
+  nb::class_<viskores::cont::DataSetBuilderUniform>(m, "DataSetBuilderUniform")
+    .def_static(
+      "create",
+      [](std::vector<viskores::Id> dims) -> viskores::cont::DataSet
+      {
+        if (dims.size() == 1)
+        {
+          return viskores::cont::DataSetBuilderUniform::Create(dims[0]);
+        }
+        if (dims.size() == 2)
+        {
+          return viskores::cont::DataSetBuilderUniform::Create(
+            viskores::Id2(dims[0], dims[1]));
+        }
+        if (dims.size() == 3)
+        {
+          return viskores::cont::DataSetBuilderUniform::Create(
+            viskores::Id3(dims[0], dims[1], dims[2]));
+        }
+        throw viskores::cont::ErrorBadValue(
+          "DataSetBuilderUniform.create() requires a list of 1, 2, or 3 dimensions.");
+      },
+      nb::arg("dimensions"),
+      "Create a uniform rectilinear DataSet. Pass a list of 1, 2, or 3 integer\n"
+      "dimensions (number of points per axis). Origin is [0,0,0] and spacing\n"
+      "is [1,1,1] by default.");
 }
 
 } // namespace viskores::python::bindings

--- a/python_bindings/src/cont_bindings.cxx
+++ b/python_bindings/src/cont_bindings.cxx
@@ -11,7 +11,6 @@
 #include <viskores/interop/python/ArrayHandleToNumPy.h>
 #include <viskores/interop/python/NumPyToArrayHandle.h>
 
-#include <viskores/cont/ArrayHandleRuntimeVec.h>
 #include <viskores/cont/CoordinateSystem.h>
 #include <viskores/cont/DataSet.h>
 #include <viskores/cont/DataSetBuilderUniform.h>
@@ -36,91 +35,6 @@ std::string UnknownArrayHandleRepr(const viskores::cont::UnknownArrayHandle& sel
   return "viskores.cont.UnknownArrayHandle(values=" +
     std::to_string(self.GetNumberOfValues()) +
     ", components=" + std::to_string(self.GetNumberOfComponentsFlat()) + ")";
-}
-
-// -------------------------------------------------------------------
-// DESIGN QUESTION FOR REVIEW: RuntimeVec vs ArrayHandleBasic<Vec<T,N>>
-// for Python-supplied coordinate arrays.
-//
-// PR #308 established (at Ken's explicit request) that ArrayFromNumPyVectorArray
-// produces ArrayHandleRuntimeVec<ComponentType> for 2D NumPy inputs. This is
-// clean for UnknownArrayHandle interop: one owner class handles all component
-// counts without needing a switch on N.
-//
-// However, CoordinateSystem::GetData() returns:
-//   UncertainArrayHandle<TypeListFieldVec3, VISKORES_DEFAULT_STORAGE_LIST>
-// where VISKORES_DEFAULT_STORAGE_LIST == StorageListCommon, which does NOT include
-// StorageTagRuntimeVec. This means a Python-supplied coordinate array stored as
-// ArrayHandleRuntimeVec will silently fail to dispatch in any filter that calls
-// CastAndCall on coordinate data via CoordinateSystem::GetData().
-//
-// This binding works around that by copying RuntimeVec<Float32/Float64>(3) to
-// ArrayHandle<Vec3f_32/Vec3f_64> before passing to the CoordinateSystem constructor.
-// Is this the right fix? Alternatives we see:
-//   (a) Change ArrayFromNumPyVectorArray to produce ArrayHandleBasic<Vec<T,N>>
-//       for N=2,3,4, reverting the PR #308 RuntimeVec decision for fixed-N arrays.
-//   (b) Keep this copy here and accept that Python-supplied coordinates always
-//       incur one host copy when building a CoordinateSystem.
-//   (c) Add StorageTagRuntimeVec to StorageListCommon (or provide a RuntimeVec-aware
-//       UncertainArrayHandle alias) so filters dispatch through it without copies.
-// -------------------------------------------------------------------
-template <typename ComponentType, viskores::IdComponent N>
-viskores::cont::ArrayHandle<viskores::Vec<ComponentType, N>>
-CopyRuntimeVecToFixedVec(const viskores::cont::ArrayHandleRuntimeVec<ComponentType>& rv)
-{
-  viskores::cont::ArrayHandle<viskores::Vec<ComponentType, N>> dest;
-  dest.Allocate(rv.GetNumberOfValues());
-  auto srcPortal = rv.ReadPortal();
-  auto destPortal = dest.WritePortal();
-  for (viskores::Id i = 0; i < rv.GetNumberOfValues(); ++i)
-  {
-    auto v = srcPortal.Get(i);
-    viskores::Vec<ComponentType, N> vec;
-    for (viskores::IdComponent c = 0; c < N; ++c)
-    {
-      vec[c] = v[c];
-    }
-    destPortal.Set(i, vec);
-  }
-  return dest;
-}
-
-// Convert a Python-supplied UnknownArrayHandle to storage compatible with
-// CoordinateSystem filter dispatch. See the design question comment above.
-viskores::cont::UnknownArrayHandle ToCoordinateCompatibleArray(
-  const viskores::cont::UnknownArrayHandle& input)
-{
-  const viskores::IdComponent nComp = input.GetNumberOfComponentsFlat();
-  if (nComp != 3)
-  {
-    return input;
-  }
-
-  {
-    using RV = viskores::cont::ArrayHandleRuntimeVec<viskores::Float32>;
-    if (input.CanConvert<RV>())
-    {
-      RV rv;
-      input.AsArrayHandle(rv);
-      if (rv.GetNumberOfComponents() == 3)
-      {
-        return CopyRuntimeVecToFixedVec<viskores::Float32, 3>(rv);
-      }
-    }
-  }
-  {
-    using RV = viskores::cont::ArrayHandleRuntimeVec<viskores::Float64>;
-    if (input.CanConvert<RV>())
-    {
-      RV rv;
-      input.AsArrayHandle(rv);
-      if (rv.GetNumberOfComponents() == 3)
-      {
-        return CopyRuntimeVecToFixedVec<viskores::Float64, 3>(rv);
-      }
-    }
-  }
-  return input;
 }
 
 } // namespace
@@ -205,14 +119,11 @@ void BindCont(nb::module_& m)
          [](viskores::cont::CoordinateSystem* self,
             const std::string& name,
             const viskores::cont::UnknownArrayHandle& data) {
-           new (self) viskores::cont::CoordinateSystem(name, ToCoordinateCompatibleArray(data));
+           new (self) viskores::cont::CoordinateSystem(name, data);
          },
          nb::arg("name"),
          nb::arg("data"),
-         "Construct a CoordinateSystem from a name and an UnknownArrayHandle.\n"
-         "Arrays produced by array_from_numpy with 3 float32 or float64\n"
-         "components are copied to ArrayHandle<Vec3f> storage so that filters\n"
-         "can dispatch on them via CoordinateSystem::GetData().")
+         "Construct a CoordinateSystem from a name and an UnknownArrayHandle.")
     .def("GetBounds",
          [](const viskores::cont::CoordinateSystem& self)
          {

--- a/python_bindings/src/viskores_python_bindings.cxx
+++ b/python_bindings/src/viskores_python_bindings.cxx
@@ -12,6 +12,7 @@
 
 #include <nanobind/stl/string.h>
 
+#include <sstream>
 #include <string>
 
 namespace
@@ -19,13 +20,16 @@ namespace
 
 std::string RangeRepr(const viskores::Range& r)
 {
-  return "viskores.Range(Min=" + std::to_string(r.Min) + ", Max=" + std::to_string(r.Max) + ")";
+  std::ostringstream out;
+  out << "viskores.Range" << r;
+  return out.str();
 }
 
 std::string BoundsRepr(const viskores::Bounds& b)
 {
-  return "viskores.Bounds(X=" + RangeRepr(b.X) + ", Y=" + RangeRepr(b.Y) +
-    ", Z=" + RangeRepr(b.Z) + ")";
+  std::ostringstream out;
+  out << "viskores.Bounds" << b;
+  return out.str();
 }
 
 } // namespace
@@ -54,6 +58,13 @@ NB_MODULE(_viskores, m)
     .def_rw("Y", &viskores::Bounds::Y)
     .def_rw("Z", &viskores::Bounds::Z)
     .def("IsNonEmpty", &viskores::Bounds::IsNonEmpty)
+    .def("Center",
+         [](const viskores::Bounds& self)
+         {
+           viskores::Vec3f_64 center = self.Center();
+           return nb::make_tuple(center[0], center[1], center[2]);
+         },
+         "Return the center of the bounds as an (x, y, z) tuple.")
     .def("__repr__", &BoundsRepr);
 
   nb::module_ cont = m.def_submodule("cont");

--- a/python_bindings/src/viskores_python_bindings.cxx
+++ b/python_bindings/src/viskores_python_bindings.cxx
@@ -8,9 +8,53 @@
 
 #include "viskores_python_bindings.h"
 
+#include <viskores/Bounds.h>
+
+#include <nanobind/stl/string.h>
+
+#include <string>
+
+namespace
+{
+
+std::string RangeRepr(const viskores::Range& r)
+{
+  return "viskores.Range(Min=" + std::to_string(r.Min) + ", Max=" + std::to_string(r.Max) + ")";
+}
+
+std::string BoundsRepr(const viskores::Bounds& b)
+{
+  return "viskores.Bounds(X=" + RangeRepr(b.X) + ", Y=" + RangeRepr(b.Y) +
+    ", Z=" + RangeRepr(b.Z) + ")";
+}
+
+} // namespace
+
 NB_MODULE(_viskores, m)
 {
   m.doc() = "Minimal manual Viskores Python bindings.";
+
+  nb::class_<viskores::Range>(m, "Range")
+    .def(nb::init<>())
+    .def(nb::init<viskores::Float64, viskores::Float64>(), nb::arg("min"), nb::arg("max"))
+    .def_rw("Min", &viskores::Range::Min)
+    .def_rw("Max", &viskores::Range::Max)
+    .def("IsNonEmpty", &viskores::Range::IsNonEmpty)
+    .def("Length", &viskores::Range::Length)
+    .def("Center", &viskores::Range::Center)
+    .def("__repr__", &RangeRepr);
+
+  nb::class_<viskores::Bounds>(m, "Bounds")
+    .def(nb::init<>())
+    .def(nb::init<viskores::Range, viskores::Range, viskores::Range>(),
+         nb::arg("x"),
+         nb::arg("y"),
+         nb::arg("z"))
+    .def_rw("X", &viskores::Bounds::X)
+    .def_rw("Y", &viskores::Bounds::Y)
+    .def_rw("Z", &viskores::Bounds::Z)
+    .def("IsNonEmpty", &viskores::Bounds::IsNonEmpty)
+    .def("__repr__", &BoundsRepr);
 
   nb::module_ cont = m.def_submodule("cont");
   viskores::python::bindings::BindCont(cont);

--- a/python_bindings/testing/CMakeLists.txt
+++ b/python_bindings/testing/CMakeLists.txt
@@ -21,3 +21,13 @@ add_test(
 set_tests_properties(PythonBindingsUnknownArrayHandleNumPy PROPERTIES
   ENVIRONMENT "PYTHONPATH=${Viskores_BINARY_DIR}/python_bindings"
 )
+
+add_test(
+  NAME PythonBindingsDataSet
+  COMMAND
+    "${Python_EXECUTABLE}"
+    "${CMAKE_CURRENT_SOURCE_DIR}/PythonBindingsDataSet.py"
+)
+set_tests_properties(PythonBindingsDataSet PROPERTIES
+  ENVIRONMENT "PYTHONPATH=${Viskores_BINARY_DIR}/python_bindings"
+)

--- a/python_bindings/testing/PythonBindingsDataSet.py
+++ b/python_bindings/testing/PythonBindingsDataSet.py
@@ -34,46 +34,48 @@ def check_field_construction():
 # ----- DataSetBuilderUniform ------------------------------------------------
 
 def check_uniform_dataset_1d():
-    ds = viskores.cont.DataSetBuilderUniform.create([5])
+    ds = viskores.cont.DataSetBuilderUniform.Create([5])
     assert ds.GetNumberOfPoints() == 5
     assert ds.GetNumberOfCells() == 4
     assert ds.GetNumberOfCoordinateSystems() == 1
 
 
 def check_uniform_dataset_2d():
-    ds = viskores.cont.DataSetBuilderUniform.create([4, 5])
+    ds = viskores.cont.DataSetBuilderUniform.Create([4, 5])
     assert ds.GetNumberOfPoints() == 20
     assert ds.GetNumberOfCells() == 12
     assert ds.GetNumberOfCoordinateSystems() == 1
 
 
 def check_uniform_dataset_3d():
-    ds = viskores.cont.DataSetBuilderUniform.create([3, 4, 5])
+    ds = viskores.cont.DataSetBuilderUniform.Create([3, 4, 5])
     assert ds.GetNumberOfPoints() == 60
     assert ds.GetNumberOfCells() == 24
     assert ds.GetNumberOfCoordinateSystems() == 1
 
 
 def check_uniform_dataset_rejects_bad_dims():
-    try:
-        viskores.cont.DataSetBuilderUniform.create([])
-    except RuntimeError:
-        pass
-    else:
-        raise AssertionError("Expected empty dimension list to be rejected.")
+    def expect_rejected(dims, message):
+        try:
+            viskores.cont.DataSetBuilderUniform.Create(dims)
+        except RuntimeError:
+            pass
+        else:
+            raise AssertionError(message)
 
-    try:
-        viskores.cont.DataSetBuilderUniform.create([2, 3, 4, 5])
-    except RuntimeError:
-        pass
-    else:
-        raise AssertionError("Expected 4-element dimension list to be rejected.")
+    expect_rejected([], "Expected empty dimension list to be rejected.")
+    expect_rejected([2, 3, 4, 5], "Expected 4-element dimension list to be rejected.")
+    expect_rejected([1], "Expected a single dimension of 1 to be rejected.")
+    expect_rejected([1, 1, 1], "Expected all-1 dimensions to be rejected.")
+    expect_rejected([5, 1], "Expected a trailing dimension of 1 to be rejected.")
+    expect_rejected([2, 0, 3], "Expected a dimension of 0 to be rejected.")
+    expect_rejected([2, -1], "Expected a negative dimension to be rejected.")
 
 
 # ----- DataSet field round-trip ---------------------------------------------
 
 def check_dataset_point_field_roundtrip():
-    ds = viskores.cont.DataSetBuilderUniform.create([3, 4])
+    ds = viskores.cont.DataSetBuilderUniform.Create([3, 4])
     npts = ds.GetNumberOfPoints()
     assert npts == 12
 
@@ -90,7 +92,7 @@ def check_dataset_point_field_roundtrip():
 
 
 def check_dataset_cell_field_roundtrip():
-    ds = viskores.cont.DataSetBuilderUniform.create([3, 4])
+    ds = viskores.cont.DataSetBuilderUniform.Create([3, 4])
     ncells = ds.GetNumberOfCells()
     assert ncells == 6
 
@@ -106,7 +108,7 @@ def check_dataset_cell_field_roundtrip():
 
 
 def check_dataset_field_object():
-    ds = viskores.cont.DataSetBuilderUniform.create([5])
+    ds = viskores.cont.DataSetBuilderUniform.Create([5])
     npts = ds.GetNumberOfPoints()
 
     data = np.arange(npts, dtype=np.int32)
@@ -119,7 +121,7 @@ def check_dataset_field_object():
 
 
 def check_dataset_has_field():
-    ds = viskores.cont.DataSetBuilderUniform.create([5])
+    ds = viskores.cont.DataSetBuilderUniform.Create([5])
     npts = ds.GetNumberOfPoints()
 
     data = np.zeros(npts, dtype=np.float32)
@@ -128,6 +130,37 @@ def check_dataset_has_field():
     assert ds.HasField("u", viskores.cont.FieldAssociation.Points)
     assert not ds.HasField("u", viskores.cont.FieldAssociation.Cells)
     assert not ds.HasField("missing")
+
+
+def check_dataset_get_field_by_index_out_of_range():
+    ds = viskores.cont.DataSetBuilderUniform.Create([5])
+    ds.AddPointField("u", viskores.cont.array_from_numpy(
+        np.zeros(ds.GetNumberOfPoints(), dtype=np.float32), allow_copy=True))
+
+    last_index = ds.GetNumberOfFields() - 1
+    assert ds.GetField(last_index).GetName() == "u"
+
+    for bad_index in (-1, ds.GetNumberOfFields()):
+        try:
+            ds.GetField(bad_index)
+        except RuntimeError:
+            pass
+        else:
+            raise AssertionError(f"Expected out-of-range field index {bad_index} to be rejected.")
+
+
+def check_dataset_get_coordinate_system_out_of_range():
+    ds = viskores.cont.DataSetBuilderUniform.Create([5])
+    assert ds.GetCoordinateSystem(0).GetName()
+
+    for bad_index in (-1, ds.GetNumberOfCoordinateSystems()):
+        try:
+            ds.GetCoordinateSystem(bad_index)
+        except RuntimeError:
+            pass
+        else:
+            raise AssertionError(
+                f"Expected out-of-range coordinate system index {bad_index} to be rejected.")
 
 
 # ----- CoordinateSystem from NumPy ------------------------------------------
@@ -143,10 +176,9 @@ def check_coordinate_system_from_numpy():
     assert cs.GetNumberOfValues() == 4
 
     bounds = cs.GetBounds()
-    assert len(bounds) == 6
-    assert bounds[0] == 0.0 and bounds[1] == 1.0  # X
-    assert bounds[2] == 0.0 and bounds[3] == 1.0  # Y
-    assert bounds[4] == 0.0 and bounds[5] == 0.0  # Z
+    assert bounds.X.Min == 0.0 and bounds.X.Max == 1.0
+    assert bounds.Y.Min == 0.0 and bounds.Y.Max == 1.0
+    assert bounds.Z.Min == 0.0 and bounds.Z.Max == 0.0
 
 
 def check_coordinate_system_from_numpy_float64():
@@ -155,9 +187,9 @@ def check_coordinate_system_from_numpy_float64():
     unknown = viskores.cont.array_from_numpy(coords, allow_copy=True)
     cs = viskores.cont.CoordinateSystem("pts", unknown)
     bounds = cs.GetBounds()
-    assert bounds[0] == 0.0 and bounds[1] == 2.0
-    assert bounds[2] == 0.0 and bounds[3] == 3.0
-    assert bounds[4] == 0.0 and bounds[5] == 4.0
+    assert bounds.X.Min == 0.0 and bounds.X.Max == 2.0
+    assert bounds.Y.Min == 0.0 and bounds.Y.Max == 3.0
+    assert bounds.Z.Min == 0.0 and bounds.Z.Max == 4.0
 
 
 def check_coordinate_system_asnumpy_roundtrip_float32():
@@ -193,6 +225,8 @@ def main():
     check_dataset_cell_field_roundtrip()
     check_dataset_field_object()
     check_dataset_has_field()
+    check_dataset_get_field_by_index_out_of_range()
+    check_dataset_get_coordinate_system_out_of_range()
 
     check_coordinate_system_from_numpy()
     check_coordinate_system_from_numpy_float64()

--- a/python_bindings/testing/PythonBindingsDataSet.py
+++ b/python_bindings/testing/PythonBindingsDataSet.py
@@ -133,10 +133,6 @@ def check_dataset_has_field():
 # ----- CoordinateSystem from NumPy ------------------------------------------
 
 def check_coordinate_system_from_numpy():
-    # Build a set of explicit 3D coordinates from a float32 (N,3) NumPy array
-    # and attach them to a bare DataSet.  The binding must produce storage
-    # compatible with filter dispatch (see design-question comment in
-    # cont_bindings.cxx).
     coords = np.array([[0.0, 0.0, 0.0],
                        [1.0, 0.0, 0.0],
                        [1.0, 1.0, 0.0],
@@ -164,6 +160,26 @@ def check_coordinate_system_from_numpy_float64():
     assert bounds[4] == 0.0 and bounds[5] == 4.0
 
 
+def check_coordinate_system_asnumpy_roundtrip_float32():
+    coords = np.array([[0.0, 0.0, 0.0],
+                       [1.0, 2.0, 3.0],
+                       [4.0, 5.0, 6.0]], dtype=np.float32)
+    unknown = viskores.cont.array_from_numpy(coords, allow_copy=True)
+    cs = viskores.cont.CoordinateSystem("pts", unknown)
+    result = cs.asnumpy()
+    np.testing.assert_array_almost_equal(result, coords)
+
+
+def check_coordinate_system_asnumpy_roundtrip_float64():
+    coords = np.array([[0.0, 0.0, 0.0],
+                       [1.0, 2.0, 3.0],
+                       [4.0, 5.0, 6.0]], dtype=np.float64)
+    unknown = viskores.cont.array_from_numpy(coords, allow_copy=True)
+    cs = viskores.cont.CoordinateSystem("pts", unknown)
+    result = cs.asnumpy()
+    np.testing.assert_array_almost_equal(result, coords)
+
+
 def main():
     check_field_association_values()
     check_field_construction()
@@ -180,6 +196,9 @@ def main():
 
     check_coordinate_system_from_numpy()
     check_coordinate_system_from_numpy_float64()
+
+    check_coordinate_system_asnumpy_roundtrip_float32()
+    check_coordinate_system_asnumpy_roundtrip_float64()
 
 
 if __name__ == "__main__":

--- a/python_bindings/testing/PythonBindingsDataSet.py
+++ b/python_bindings/testing/PythonBindingsDataSet.py
@@ -1,0 +1,186 @@
+##============================================================================
+##  The contents of this file are covered by the Viskores license. See
+##  LICENSE.txt for details.
+##
+##  By contributing to this file, all contributors agree to the Developer
+##  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+##============================================================================
+
+import numpy as np
+
+import viskores
+import viskores.cont
+
+
+# ----- Field and FieldAssociation -------------------------------------------
+
+def check_field_association_values():
+    assoc = viskores.cont.FieldAssociation
+    assert assoc.Points != assoc.Cells
+    assert assoc.Points != assoc.WholeDataSet
+    assert assoc.Points != assoc.Any
+
+
+def check_field_construction():
+    data = np.arange(12, dtype=np.float32)
+    unknown = viskores.cont.array_from_numpy(data)
+    field = viskores.cont.Field("pressure", viskores.cont.FieldAssociation.Points, unknown)
+    assert field.GetName() == "pressure"
+    assert field.GetAssociation() == viskores.cont.FieldAssociation.Points
+    assert field.GetNumberOfValues() == 12
+    np.testing.assert_array_equal(field.asnumpy(), data)
+
+
+# ----- DataSetBuilderUniform ------------------------------------------------
+
+def check_uniform_dataset_1d():
+    ds = viskores.cont.DataSetBuilderUniform.create([5])
+    assert ds.GetNumberOfPoints() == 5
+    assert ds.GetNumberOfCells() == 4
+    assert ds.GetNumberOfCoordinateSystems() == 1
+
+
+def check_uniform_dataset_2d():
+    ds = viskores.cont.DataSetBuilderUniform.create([4, 5])
+    assert ds.GetNumberOfPoints() == 20
+    assert ds.GetNumberOfCells() == 12
+    assert ds.GetNumberOfCoordinateSystems() == 1
+
+
+def check_uniform_dataset_3d():
+    ds = viskores.cont.DataSetBuilderUniform.create([3, 4, 5])
+    assert ds.GetNumberOfPoints() == 60
+    assert ds.GetNumberOfCells() == 24
+    assert ds.GetNumberOfCoordinateSystems() == 1
+
+
+def check_uniform_dataset_rejects_bad_dims():
+    try:
+        viskores.cont.DataSetBuilderUniform.create([])
+    except RuntimeError:
+        pass
+    else:
+        raise AssertionError("Expected empty dimension list to be rejected.")
+
+    try:
+        viskores.cont.DataSetBuilderUniform.create([2, 3, 4, 5])
+    except RuntimeError:
+        pass
+    else:
+        raise AssertionError("Expected 4-element dimension list to be rejected.")
+
+
+# ----- DataSet field round-trip ---------------------------------------------
+
+def check_dataset_point_field_roundtrip():
+    ds = viskores.cont.DataSetBuilderUniform.create([3, 4])
+    npts = ds.GetNumberOfPoints()
+    assert npts == 12
+
+    data = np.linspace(0.0, 1.0, npts, dtype=np.float32)
+    ds.AddPointField("temperature", viskores.cont.array_from_numpy(data, allow_copy=True))
+
+    assert ds.HasField("temperature", viskores.cont.FieldAssociation.Points)
+    assert ds.GetNumberOfFields() >= 1
+
+    field = ds.GetField("temperature", viskores.cont.FieldAssociation.Points)
+    assert field.GetName() == "temperature"
+    assert field.GetAssociation() == viskores.cont.FieldAssociation.Points
+    np.testing.assert_array_almost_equal(field.asnumpy(), data)
+
+
+def check_dataset_cell_field_roundtrip():
+    ds = viskores.cont.DataSetBuilderUniform.create([3, 4])
+    ncells = ds.GetNumberOfCells()
+    assert ncells == 6
+
+    data = np.arange(ncells, dtype=np.float64)
+    ds.AddCellField("pressure", viskores.cont.array_from_numpy(data, allow_copy=True))
+
+    assert ds.HasField("pressure", viskores.cont.FieldAssociation.Cells)
+
+    field = ds.GetField("pressure", viskores.cont.FieldAssociation.Cells)
+    assert field.GetName() == "pressure"
+    assert field.GetAssociation() == viskores.cont.FieldAssociation.Cells
+    np.testing.assert_array_equal(field.asnumpy(), data)
+
+
+def check_dataset_field_object():
+    ds = viskores.cont.DataSetBuilderUniform.create([5])
+    npts = ds.GetNumberOfPoints()
+
+    data = np.arange(npts, dtype=np.int32)
+    unknown = viskores.cont.array_from_numpy(data, allow_copy=True)
+    field = viskores.cont.Field("ids", viskores.cont.FieldAssociation.Points, unknown)
+    ds.AddField(field)
+
+    retrieved = ds.GetField("ids", viskores.cont.FieldAssociation.Points)
+    np.testing.assert_array_equal(retrieved.asnumpy(), data)
+
+
+def check_dataset_has_field():
+    ds = viskores.cont.DataSetBuilderUniform.create([5])
+    npts = ds.GetNumberOfPoints()
+
+    data = np.zeros(npts, dtype=np.float32)
+    ds.AddPointField("u", viskores.cont.array_from_numpy(data, allow_copy=True))
+
+    assert ds.HasField("u", viskores.cont.FieldAssociation.Points)
+    assert not ds.HasField("u", viskores.cont.FieldAssociation.Cells)
+    assert not ds.HasField("missing")
+
+
+# ----- CoordinateSystem from NumPy ------------------------------------------
+
+def check_coordinate_system_from_numpy():
+    # Build a set of explicit 3D coordinates from a float32 (N,3) NumPy array
+    # and attach them to a bare DataSet.  The binding must produce storage
+    # compatible with filter dispatch (see design-question comment in
+    # cont_bindings.cxx).
+    coords = np.array([[0.0, 0.0, 0.0],
+                       [1.0, 0.0, 0.0],
+                       [1.0, 1.0, 0.0],
+                       [0.0, 1.0, 0.0]], dtype=np.float32)
+    unknown = viskores.cont.array_from_numpy(coords, allow_copy=True)
+    cs = viskores.cont.CoordinateSystem("pts", unknown)
+    assert cs.GetName() == "pts"
+    assert cs.GetNumberOfValues() == 4
+
+    bounds = cs.GetBounds()
+    assert len(bounds) == 6
+    assert bounds[0] == 0.0 and bounds[1] == 1.0  # X
+    assert bounds[2] == 0.0 and bounds[3] == 1.0  # Y
+    assert bounds[4] == 0.0 and bounds[5] == 0.0  # Z
+
+
+def check_coordinate_system_from_numpy_float64():
+    coords = np.array([[0.0, 0.0, 0.0],
+                       [2.0, 3.0, 4.0]], dtype=np.float64)
+    unknown = viskores.cont.array_from_numpy(coords, allow_copy=True)
+    cs = viskores.cont.CoordinateSystem("pts", unknown)
+    bounds = cs.GetBounds()
+    assert bounds[0] == 0.0 and bounds[1] == 2.0
+    assert bounds[2] == 0.0 and bounds[3] == 3.0
+    assert bounds[4] == 0.0 and bounds[5] == 4.0
+
+
+def main():
+    check_field_association_values()
+    check_field_construction()
+
+    check_uniform_dataset_1d()
+    check_uniform_dataset_2d()
+    check_uniform_dataset_3d()
+    check_uniform_dataset_rejects_bad_dims()
+
+    check_dataset_point_field_roundtrip()
+    check_dataset_cell_field_roundtrip()
+    check_dataset_field_object()
+    check_dataset_has_field()
+
+    check_coordinate_system_from_numpy()
+    check_coordinate_system_from_numpy_float64()
+
+
+if __name__ == "__main__":
+    main()

--- a/python_bindings/testing/PythonBindingsDataSet.py
+++ b/python_bindings/testing/PythonBindingsDataSet.py
@@ -54,6 +54,17 @@ def check_uniform_dataset_3d():
     assert ds.GetNumberOfCoordinateSystems() == 1
 
 
+def check_uniform_dataset_collapsed_axis():
+    # As in the C++ API, a dimension of 1 collapses that axis.
+    ds = viskores.cont.DataSetBuilderUniform.Create([5, 1])
+    assert ds.GetNumberOfPoints() == 5
+    assert ds.GetNumberOfCells() == 4
+
+    ds = viskores.cont.DataSetBuilderUniform.Create([1, 4, 3])
+    assert ds.GetNumberOfPoints() == 12
+    assert ds.GetNumberOfCells() == 6
+
+
 def check_uniform_dataset_rejects_bad_dims():
     def expect_rejected(dims, message):
         try:
@@ -67,7 +78,6 @@ def check_uniform_dataset_rejects_bad_dims():
     expect_rejected([2, 3, 4, 5], "Expected 4-element dimension list to be rejected.")
     expect_rejected([1], "Expected a single dimension of 1 to be rejected.")
     expect_rejected([1, 1, 1], "Expected all-1 dimensions to be rejected.")
-    expect_rejected([5, 1], "Expected a trailing dimension of 1 to be rejected.")
     expect_rejected([2, 0, 3], "Expected a dimension of 0 to be rejected.")
     expect_rejected([2, -1], "Expected a negative dimension to be rejected.")
 
@@ -163,6 +173,28 @@ def check_dataset_get_coordinate_system_out_of_range():
                 f"Expected out-of-range coordinate system index {bad_index} to be rejected.")
 
 
+# ----- Range and Bounds ------------------------------------------------------
+
+def check_range_and_bounds():
+    r = viskores.Range(1.0, 3.0)
+    assert r.Min == 1.0 and r.Max == 3.0
+    assert r.IsNonEmpty()
+    assert r.Length() == 2.0
+    assert r.Center() == 2.0
+
+    b = viskores.Bounds(viskores.Range(0.0, 2.0),
+                        viskores.Range(0.0, 4.0),
+                        viskores.Range(0.0, 6.0))
+    assert b.IsNonEmpty()
+    assert b.Center() == (1.0, 2.0, 3.0)
+
+    # repr must distinguish values that differ by less than 1e-6.
+    tiny = viskores.Range(0.0, 1e-9)
+    assert repr(tiny).startswith("viskores.Range")
+    assert repr(tiny) != repr(viskores.Range(0.0, 0.0))
+    assert repr(b).startswith("viskores.Bounds")
+
+
 # ----- CoordinateSystem from NumPy ------------------------------------------
 
 def check_coordinate_system_from_numpy():
@@ -219,6 +251,7 @@ def main():
     check_uniform_dataset_1d()
     check_uniform_dataset_2d()
     check_uniform_dataset_3d()
+    check_uniform_dataset_collapsed_axis()
     check_uniform_dataset_rejects_bad_dims()
 
     check_dataset_point_field_roundtrip()
@@ -227,6 +260,8 @@ def main():
     check_dataset_has_field()
     check_dataset_get_field_by_index_out_of_range()
     check_dataset_get_coordinate_system_out_of_range()
+
+    check_range_and_bounds()
 
     check_coordinate_system_from_numpy()
     check_coordinate_system_from_numpy_float64()

--- a/python_bindings/viskores/__init__.py
+++ b/python_bindings/viskores/__init__.py
@@ -6,4 +6,10 @@
 ##  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
 ##============================================================================
 
-__all__ = []
+from ._viskores import Range
+from ._viskores import Bounds
+
+__all__ = [
+    "Range",
+    "Bounds",
+]

--- a/python_bindings/viskores/cont/__init__.py
+++ b/python_bindings/viskores/cont/__init__.py
@@ -9,9 +9,19 @@
 from .._viskores.cont import UnknownArrayHandle
 from .._viskores.cont import array_from_numpy
 from .._viskores.cont import asnumpy
+from .._viskores.cont import FieldAssociation
+from .._viskores.cont import Field
+from .._viskores.cont import CoordinateSystem
+from .._viskores.cont import DataSet
+from .._viskores.cont import DataSetBuilderUniform
 
 __all__ = [
     "UnknownArrayHandle",
     "array_from_numpy",
     "asnumpy",
+    "FieldAssociation",
+    "Field",
+    "CoordinateSystem",
+    "DataSet",
+    "DataSetBuilderUniform",
 ]


### PR DESCRIPTION
## Summary

This PR exposes the core DataSet types to Python, building on the `UnknownArrayHandle` + NumPy interop from PR #308.

New bindings:

- **`viskores.Range` / `viskores.Bounds`** — mirror `viskores::Range` and `viskores::Bounds` with read/write `Min`/`Max` and `X`/`Y`/`Z` members plus `IsNonEmpty()`, `Length()`, and `Center()` accessors.
- **`viskores.cont.FieldAssociation`** — enum mirroring `Field::Association` (`Any`, `WholeDataSet`, `Points`, `Cells`, `Partitions`, `Global`)
- **`viskores.cont.Field(name, association, data)`** — wraps a `UnknownArrayHandle` with a name and association; `.GetData()` and `.asnumpy()` accessors
- **`viskores.cont.CoordinateSystem(name, data)`** — inherits `Field`; `.GetBounds()` returns a `viskores.Bounds`
- **`viskores.cont.DataSet`** — `AddField`, `AddPointField`, `AddCellField`, `HasField`, `GetField`, `AddCoordinateSystem`, `GetCoordinateSystem`, `GetNumberOf{Fields,Points,Cells,CoordinateSystems}`. Indexed accessors validate the index and raise instead of hitting undefined behavior (`VISKORES_ASSERT` is a no-op in release builds).
- **`viskores.cont.DataSetBuilderUniform.Create(dimensions)`** — accepts a 1-, 2-, or 3-element list of point counts, each >= 1. As in the C++ API, a dimension of 1 collapses that axis; dimensions < 1 are rejected because they would produce a dataset whose coordinate array disagrees with its cell set.

`DataSet.GetField()` returns by reference (`nb::rv_policy::reference_internal`); this is safe because `FieldCollection` stores fields in a `std::map`, so inserting new fields does not invalidate references to existing ones, and the policy keeps the DataSet alive while the Field is in use.

## Tests

- `PythonBindingsUnknownArrayHandleNumPy` — existing, still passes
- `PythonBindingsDataSet` — covers `FieldAssociation`, `Field`, uniform dataset creation (1D/2D/3D, collapsed axes, rejected bad dimensions), out-of-range index errors for `GetField`/`GetCoordinateSystem`, point/cell field round-trips, `HasField`, `GetField` by name and index, `Range`/`Bounds` construction and accessors, `CoordinateSystem` construction + `GetBounds()` from float32 and float64 NumPy arrays, and `asnumpy()` roundtrip for both float32 and float64 coordinate arrays

🤖 Generated with [Claude Code](https://claude.com/claude-code)
