### PR TITLE
Add rotational and linear extrusion

### DIFF
--- a/docs/changelog/add-rotational-extrusion.md
+++ b/docs/changelog/add-rotational-extrusion.md
@@ -1,0 +1,14 @@
+## Add extrusion filters
+
+Added `viskores::filter::geometry_refinement::ExtrusionLinear` and
+`viskores::filter::geometry_refinement::ExtrusionRotational`, which sweep a
+triangulated profile to produce wedge cells. The filters support configurable
+plane count, optional input triangulation, compact or explicit output topology,
+and point/cell field mapping from the input profile to the generated volume.
+Both filters share `ExtrusionAbstract` as the common base for shared extrusion
+controls and execution setup.
+
+`ExtrusionLinear` translates the profile along a direction, and
+`ExtrusionRotational` revolves the profile around an axis with configurable
+center, sweep angle, closed sweeps, and axis-point validation. Full `2*pi`
+rotational sweeps default to closed unless explicitly overridden.

--- a/docs/users-guide/provided-filters.rst
+++ b/docs/users-guide/provided-filters.rst
@@ -766,6 +766,41 @@ It is also useful to treat data as a collection of sample points rather than an 
 .. doxygenclass:: viskores::filter::geometry_refinement::ConvertToPointCloud
    :members:
 
+Extrusion
+------------------------------
+
+.. index::
+   double: extrusion; filter
+   single: linear extrusion
+   single: rotational extrusion
+
+Extrusion filters create a volume by sweeping a triangulated profile over a sequence of generated profile planes and connecting corresponding triangles with wedge cells.
+The filters operate on triangles, but non-triangular input can be converted by enabling input triangulation.
+Point and cell fields are replicated from the input profile onto the generated points and wedge cells.
+
+The :class:`viskores::filter::geometry_refinement::ExtrusionLinear` filter translates the profile along a direction.
+The sweep is controlled by the direction, distance, and number of planes.
+A linear extrusion is always open.
+
+The :class:`viskores::filter::geometry_refinement::ExtrusionRotational` filter revolves the profile around an axis.
+The sweep is controlled by the axis, center, sweep angle, number of planes, and whether the sweep is closed.
+Full ``2*pi`` rotational sweeps are closed by default, and partial sweeps are open by default.
+The filter allows profile points on the rotation axis by default, which can create degenerate wedge cells along the axis.
+This behavior can be disabled to reject inputs that touch the rotation axis.
+
+Both filters return explicit wedge cells by default.
+They can also use a compact :class:`viskores::cont::CellSetExtrude` representation, which can use less memory but requires downstream consumers that support that cell-set type.
+Generated wedge cells use a point ordering consistent with the direction of the sweep.
+
+.. doxygenclass:: viskores::filter::geometry_refinement::ExtrusionAbstract
+   :members:
+
+.. doxygenclass:: viskores::filter::geometry_refinement::ExtrusionLinear
+   :members:
+
+.. doxygenclass:: viskores::filter::geometry_refinement::ExtrusionRotational
+   :members:
+
 Shrink
 ------------------------------
 

--- a/viskores/filter/geometry_refinement/CMakeLists.txt
+++ b/viskores/filter/geometry_refinement/CMakeLists.txt
@@ -17,6 +17,9 @@
 ##============================================================================
 set(geometry_refinement_headers
   ConvertToPointCloud.h
+  ExtrusionAbstract.h
+  ExtrusionLinear.h
+  ExtrusionRotational.h
   Shrink.h
   SplitSharpEdges.h
   Tetrahedralize.h
@@ -27,6 +30,8 @@ set(geometry_refinement_headers
 
 set(geometry_refinement_sources
   ConvertToPointCloud.cxx
+  ExtrusionLinear.cxx
+  ExtrusionRotational.cxx
   Shrink.cxx
   SplitSharpEdges.cxx
   Tetrahedralize.cxx
@@ -35,9 +40,14 @@ set(geometry_refinement_sources
   VertexClustering.cxx
   )
 
+set(geometry_refinement_template_sources
+  ExtrusionAbstract.hxx
+  )
+
 viskores_library(
   NAME viskores_filter_geometry_refinement
   HEADERS ${geometry_refinement_headers}
+  TEMPLATE_SOURCES ${geometry_refinement_template_sources}
   DEVICE_SOURCES ${geometry_refinement_sources}
   USE_VISKORES_JOB_POOL
 )

--- a/viskores/filter/geometry_refinement/ExtrusionAbstract.h
+++ b/viskores/filter/geometry_refinement/ExtrusionAbstract.h
@@ -1,0 +1,74 @@
+//============================================================================
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//============================================================================
+
+#ifndef viskores_filter_geometry_refinement_ExtrusionAbstract_h
+#define viskores_filter_geometry_refinement_ExtrusionAbstract_h
+
+#include <viskores/Math.h>
+#include <viskores/filter/Filter.h>
+#include <viskores/filter/geometry_refinement/viskores_filter_geometry_refinement_export.h>
+
+#include <string>
+
+namespace viskores
+{
+namespace filter
+{
+namespace geometry_refinement
+{
+
+/// @brief Base class for extrusion filters.
+///
+/// `ExtrusionAbstract` provides common controls for filters that create a sequence of
+/// extruded profile planes and connect adjacent planes into an output cell set. Current
+/// subclasses support triangulated profiles and wedge-cell output.
+class VISKORES_FILTER_GEOMETRY_REFINEMENT_EXPORT ExtrusionAbstract : public viskores::filter::Filter
+{
+public:
+  /// @brief Set the number of profile planes.
+  VISKORES_CONT void SetNumberOfPlanes(viskores::Id planes) { this->NumberOfPlanes = planes; }
+  /// @copydoc SetNumberOfPlanes
+  VISKORES_CONT viskores::Id GetNumberOfPlanes() const { return this->NumberOfPlanes; }
+
+  /// @brief Triangulate the input before extrusion.
+  VISKORES_CONT void SetTriangulateInput(bool on) { this->TriangulateInput = on; }
+  /// @copydoc SetTriangulateInput
+  VISKORES_CONT bool GetTriangulateInput() const { return this->TriangulateInput; }
+
+  /// @brief Use compact `viskores::cont::CellSetExtrude` topology for the output.
+  ///
+  /// The default is `false`, which returns explicit wedge cells. Compact output
+  /// uses less memory but requires downstream consumers that support
+  /// `viskores::cont::CellSetExtrude`.
+  VISKORES_CONT void SetCompactOutput(bool on) { this->CompactOutput = on; }
+  /// @copydoc SetCompactOutput
+  VISKORES_CONT bool GetCompactOutput() const { return this->CompactOutput; }
+
+protected:
+  template <typename MakeCoordinateWorklet,
+            typename MakeOrientationWorklet,
+            typename ValidateCoordinates>
+  VISKORES_CONT viskores::cont::DataSet ExecuteTriangleExtrusion(
+    const viskores::cont::DataSet& input,
+    const std::string& filterName,
+    bool closeSweep,
+    MakeCoordinateWorklet makeCoordinateWorklet,
+    MakeOrientationWorklet makeOrientationWorklet,
+    ValidateCoordinates validateCoordinates);
+
+private:
+  viskores::Id NumberOfPlanes = 16;
+  bool TriangulateInput = false;
+  bool CompactOutput = false;
+};
+
+} // namespace geometry_refinement
+} // namespace filter
+} // namespace viskores
+
+#endif // viskores_filter_geometry_refinement_ExtrusionAbstract_h

--- a/viskores/filter/geometry_refinement/ExtrusionAbstract.hxx
+++ b/viskores/filter/geometry_refinement/ExtrusionAbstract.hxx
@@ -1,0 +1,354 @@
+//============================================================================
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//============================================================================
+
+#ifndef viskores_filter_geometry_refinement_ExtrusionAbstract_hxx
+#define viskores_filter_geometry_refinement_ExtrusionAbstract_hxx
+
+#include <viskores/filter/geometry_refinement/ExtrusionAbstract.h>
+
+#include <viskores/BinaryOperators.h>
+#include <viskores/CellShape.h>
+#include <viskores/cont/Algorithm.h>
+#include <viskores/cont/ArrayCopy.h>
+#include <viskores/cont/ArrayHandleCounting.h>
+#include <viskores/cont/ArrayHandleGroupVec.h>
+#include <viskores/cont/ArrayHandleIndex.h>
+#include <viskores/cont/ArrayHandleTransform.h>
+#include <viskores/cont/CellSetExplicit.h>
+#include <viskores/cont/CellSetExtrude.h>
+#include <viskores/cont/CellSetSingleType.h>
+#include <viskores/cont/ErrorFilterExecution.h>
+#include <viskores/filter/MapFieldPermutation.h>
+#include <viskores/filter/geometry_refinement/Triangulate.h>
+#include <viskores/filter/geometry_refinement/worklet/Extrusion.h>
+
+#include <limits>
+#include <type_traits>
+
+namespace viskores
+{
+namespace filter
+{
+namespace geometry_refinement
+{
+namespace internal
+{
+
+struct IsShapeTriangle
+{
+  VISKORES_EXEC_CONT
+  bool operator()(viskores::UInt8 shape) const { return shape == viskores::CELL_SHAPE_TRIANGLE; }
+};
+
+struct IsThreeIndices
+{
+  template <typename ValueType>
+  VISKORES_EXEC_CONT bool operator()(ValueType count) const
+  {
+    return count == 3;
+  }
+};
+
+struct BinaryAnd
+{
+  VISKORES_EXEC_CONT
+  bool operator()(bool u, bool v) const { return u && v; }
+};
+
+template <typename ConnectivityArrayType>
+VISKORES_CONT void ValidateConnectivityRange(const ConnectivityArrayType& connectivity,
+                                             viskores::Id numberOfPoints,
+                                             const std::string& filterName)
+{
+  const viskores::Vec<viskores::Id, 2> range = viskores::cont::Algorithm::Reduce(
+    connectivity,
+    viskores::make_Vec(std::numeric_limits<viskores::Id>::max(),
+                       std::numeric_limits<viskores::Id>::lowest()),
+    viskores::MinAndMax<viskores::Id>{});
+  if ((range[0] < 0) || (range[1] >= numberOfPoints))
+  {
+    throw viskores::cont::ErrorFilterExecution(
+      filterName + ": triangle connectivity contains an invalid point id.");
+  }
+}
+
+VISKORES_CONT inline viskores::cont::ArrayHandle<viskores::Id> MakeTriangleConnectivity(
+  const viskores::cont::UnknownCellSet& unknownCellSet,
+  const std::string& filterName)
+{
+  if (unknownCellSet.GetNumberOfCells() <= 0)
+  {
+    throw viskores::cont::ErrorFilterExecution(filterName + ": input has no cells.");
+  }
+  if (unknownCellSet.GetNumberOfPoints() <= 0)
+  {
+    throw viskores::cont::ErrorFilterExecution(filterName + ": input has no points.");
+  }
+
+  viskores::cont::ArrayHandle<viskores::Id> connectivity;
+
+  if (unknownCellSet.CanConvert<viskores::cont::CellSetSingleType<>>())
+  {
+    const auto cellSet = unknownCellSet.AsCellSet<viskores::cont::CellSetSingleType<>>();
+    if (cellSet.GetCellShapeAsId() != viskores::CellShapeTagTriangle::Id)
+    {
+      throw viskores::cont::ErrorFilterExecution(filterName + ": input cells must be triangles.");
+    }
+    connectivity = cellSet.GetConnectivityArray(viskores::TopologyElementTagCell{},
+                                                viskores::TopologyElementTagPoint{});
+  }
+  else if (unknownCellSet.CanConvert<viskores::cont::CellSetExplicit<>>())
+  {
+    const auto cellSet = unknownCellSet.AsCellSet<viskores::cont::CellSetExplicit<>>();
+    const auto shapes = cellSet.GetShapesArray(viskores::TopologyElementTagCell{},
+                                               viskores::TopologyElementTagPoint{});
+    const bool allTriangleShapes = viskores::cont::Algorithm::Reduce(
+      viskores::cont::make_ArrayHandleTransform(shapes, IsShapeTriangle{}), true, BinaryAnd{});
+    const auto numIndices = cellSet.GetNumIndicesArray(viskores::TopologyElementTagCell{},
+                                                       viskores::TopologyElementTagPoint{});
+    const bool allTriangleCounts = viskores::cont::Algorithm::Reduce(
+      viskores::cont::make_ArrayHandleTransform(numIndices, IsThreeIndices{}), true, BinaryAnd{});
+    if (!allTriangleShapes || !allTriangleCounts)
+    {
+      throw viskores::cont::ErrorFilterExecution(filterName + ": input cells must be triangles.");
+    }
+    connectivity = cellSet.GetConnectivityArray(viskores::TopologyElementTagCell{},
+                                                viskores::TopologyElementTagPoint{});
+  }
+  else
+  {
+    throw viskores::cont::ErrorFilterExecution(
+      filterName + ": input cell set must be explicit triangle topology.");
+  }
+
+  ValidateConnectivityRange(connectivity, unknownCellSet.GetNumberOfPoints(), filterName);
+  return connectivity;
+}
+
+VISKORES_CONT inline void ValidateCellSetExtrudeLimits(viskores::Id numberOfPoints,
+                                                       viskores::Id numberOfPlanes,
+                                                       viskores::Id connectivitySize,
+                                                       const std::string& filterName)
+{
+  const viskores::Id maxInt32 =
+    static_cast<viskores::Id>(std::numeric_limits<viskores::Int32>::max());
+  if ((numberOfPoints > maxInt32) || (numberOfPlanes > maxInt32) || (connectivitySize > maxInt32))
+  {
+    throw viskores::cont::ErrorFilterExecution(
+      filterName + ": compact CellSetExtrude output exceeds Int32 topology limits.");
+  }
+}
+
+VISKORES_CONT inline viskores::cont::ArrayHandle<viskores::Int32> MakeInt32Connectivity(
+  const viskores::cont::ArrayHandle<viskores::Id>& connectivity)
+{
+  viskores::cont::ArrayHandle<viskores::Int32> connectivity32;
+  viskores::cont::ArrayCopy(connectivity, connectivity32);
+  return connectivity32;
+}
+
+VISKORES_CONT inline viskores::cont::ArrayHandle<viskores::Int32> MakeIdentityNextNode(
+  viskores::Id numberOfPoints)
+{
+  viskores::cont::ArrayHandle<viskores::Int32> nextNode;
+  viskores::cont::Algorithm::Copy(viskores::cont::make_ArrayHandleCounting(
+                                    viskores::Int32{ 0 }, viskores::Int32{ 1 }, numberOfPoints),
+                                  nextNode);
+  return nextNode;
+}
+
+VISKORES_CONT inline bool HasPointFields(const viskores::cont::DataSet& input)
+{
+  const viskores::IdComponent numberOfFields = input.GetNumberOfFields();
+  for (viskores::IdComponent fieldIndex = 0; fieldIndex < numberOfFields; ++fieldIndex)
+  {
+    if (input.GetField(fieldIndex).IsPointField())
+    {
+      return true;
+    }
+  }
+  return false;
+}
+
+VISKORES_CONT inline bool HasCellFields(const viskores::cont::DataSet& input)
+{
+  const viskores::IdComponent numberOfFields = input.GetNumberOfFields();
+  for (viskores::IdComponent fieldIndex = 0; fieldIndex < numberOfFields; ++fieldIndex)
+  {
+    if (input.GetField(fieldIndex).IsCellField())
+    {
+      return true;
+    }
+  }
+  return false;
+}
+
+VISKORES_CONT inline bool MapExtrudedField(
+  viskores::cont::DataSet& result,
+  const viskores::cont::Field& field,
+  const viskores::cont::ArrayHandle<viskores::Id>& pointPermutation,
+  const viskores::cont::ArrayHandle<viskores::Id>& cellPermutation)
+{
+  if (field.IsPointField())
+  {
+    return viskores::filter::MapFieldPermutation(field, pointPermutation, result);
+  }
+  else if (field.IsCellField())
+  {
+    return viskores::filter::MapFieldPermutation(field, cellPermutation, result);
+  }
+  else if (field.IsWholeDataSetField())
+  {
+    result.AddField(field);
+    return true;
+  }
+  else
+  {
+    return false;
+  }
+}
+
+} // namespace internal
+
+template <typename MakeCoordinateWorklet,
+          typename MakeOrientationWorklet,
+          typename ValidateCoordinates>
+VISKORES_CONT viskores::cont::DataSet ExtrusionAbstract::ExecuteTriangleExtrusion(
+  const viskores::cont::DataSet& input,
+  const std::string& filterName,
+  bool closeSweep,
+  MakeCoordinateWorklet makeCoordinateWorklet,
+  MakeOrientationWorklet makeOrientationWorklet,
+  ValidateCoordinates validateCoordinates)
+{
+  if (closeSweep)
+  {
+    if (this->NumberOfPlanes < 3)
+    {
+      throw viskores::cont::ErrorFilterExecution(filterName +
+                                                 ": closed sweeps require at least 3 planes.");
+    }
+  }
+  else if (this->NumberOfPlanes < 2)
+  {
+    throw viskores::cont::ErrorFilterExecution(filterName +
+                                               ": open sweeps require at least 2 planes.");
+  }
+
+  viskores::cont::DataSet workingInput = input;
+  if (this->TriangulateInput)
+  {
+    viskores::filter::geometry_refinement::Triangulate triangulate;
+    workingInput = triangulate.Execute(input);
+  }
+
+  const auto& inputCoordinates =
+    workingInput.GetCoordinateSystem(this->GetActiveCoordinateSystemIndex());
+  const viskores::Id numberOfPoints = workingInput.GetCellSet().GetNumberOfPoints();
+  if (inputCoordinates.GetData().GetNumberOfValues() != numberOfPoints)
+  {
+    throw viskores::cont::ErrorFilterExecution(
+      filterName + ": coordinate count does not match cell set point count.");
+  }
+
+  viskores::cont::ArrayHandle<viskores::Id> connectivity =
+    internal::MakeTriangleConnectivity(workingInput.GetCellSet(), filterName);
+  const viskores::Id numberOfCellsPerPlane = connectivity.GetNumberOfValues() / 3;
+  viskores::cont::ArrayHandle<viskores::Id> orientedConnectivity;
+  const viskores::Id numberOfOutputPoints = this->NumberOfPlanes * numberOfPoints;
+  const viskores::Id numberOfOutputCells =
+    (closeSweep ? this->NumberOfPlanes : (this->NumberOfPlanes - 1)) * numberOfCellsPerPlane;
+
+  viskores::cont::UnknownArrayHandle outputCoordinates;
+  auto resolveCoordinates = [&](const auto& concreteCoordinates)
+  {
+    using CoordinateArrayType = std::decay_t<decltype(concreteCoordinates)>;
+    using CoordinateType = typename CoordinateArrayType::ValueType;
+
+    validateCoordinates(concreteCoordinates);
+
+    viskores::cont::ArrayHandle<CoordinateType> generatedCoordinates;
+    this->Invoke(makeCoordinateWorklet(numberOfPoints),
+                 viskores::cont::ArrayHandleIndex(numberOfOutputPoints),
+                 concreteCoordinates,
+                 generatedCoordinates);
+    outputCoordinates = generatedCoordinates;
+
+    this->Invoke(makeOrientationWorklet(),
+                 viskores::cont::make_ArrayHandleGroupVec<3>(connectivity),
+                 concreteCoordinates,
+                 viskores::cont::make_ArrayHandleGroupVec<3>(orientedConnectivity));
+  };
+  this->CastAndCallVecField<3>(inputCoordinates.GetData(), resolveCoordinates);
+
+  // Match ExternalFaces: check field associations before creating maps that may not be used.
+  const bool hasPointFields = internal::HasPointFields(workingInput);
+  const bool hasCellFields = internal::HasCellFields(workingInput);
+
+  viskores::cont::ArrayHandle<viskores::Id> pointPermutation;
+  if (hasPointFields)
+  {
+    viskores::cont::Algorithm::Copy(
+      viskores::cont::make_ArrayHandleTransform(
+        viskores::cont::ArrayHandleIndex(numberOfOutputPoints),
+        viskores::worklet::ExtrusionOutputToInputPlane{ numberOfPoints }),
+      pointPermutation);
+  }
+
+  viskores::cont::ArrayHandle<viskores::Id> cellPermutation;
+  if (hasCellFields)
+  {
+    viskores::cont::Algorithm::Copy(
+      viskores::cont::make_ArrayHandleTransform(
+        viskores::cont::ArrayHandleIndex(numberOfOutputCells),
+        viskores::worklet::ExtrusionOutputToInputPlane{ numberOfCellsPerPlane }),
+      cellPermutation);
+  }
+
+  auto mapper = [&](auto& result, const auto& field)
+  { return internal::MapExtrudedField(result, field, pointPermutation, cellPermutation); };
+
+  if (this->CompactOutput)
+  {
+    internal::ValidateCellSetExtrudeLimits(
+      numberOfPoints, this->NumberOfPlanes, orientedConnectivity.GetNumberOfValues(), filterName);
+    viskores::cont::ArrayHandle<viskores::Int32> connectivity32 =
+      internal::MakeInt32Connectivity(orientedConnectivity);
+    viskores::cont::ArrayHandle<viskores::Int32> nextNode =
+      internal::MakeIdentityNextNode(numberOfPoints);
+    viskores::cont::CellSetExtrude outputCells(connectivity32,
+                                               static_cast<viskores::Int32>(numberOfPoints),
+                                               static_cast<viskores::Int32>(this->NumberOfPlanes),
+                                               nextNode,
+                                               closeSweep);
+    return this->CreateResultCoordinateSystem(
+      workingInput, outputCells, inputCoordinates.GetName(), outputCoordinates, mapper);
+  }
+  else
+  {
+    viskores::cont::ArrayHandle<viskores::Id> explicitConnectivity;
+    this->Invoke(
+      viskores::worklet::ExtrudedCellSetToExplicitWedgeConnectivity{
+        numberOfCellsPerPlane, numberOfPoints, this->NumberOfPlanes },
+      viskores::cont::ArrayHandleIndex(numberOfOutputCells * 6),
+      orientedConnectivity,
+      explicitConnectivity);
+
+    viskores::cont::CellSetSingleType<> explicitCells;
+    explicitCells.Fill(numberOfOutputPoints, viskores::CELL_SHAPE_WEDGE, 6, explicitConnectivity);
+
+    return this->CreateResultCoordinateSystem(
+      workingInput, explicitCells, inputCoordinates.GetName(), outputCoordinates, mapper);
+  }
+}
+
+} // namespace geometry_refinement
+} // namespace filter
+} // namespace viskores
+
+#endif // viskores_filter_geometry_refinement_ExtrusionAbstract_hxx

--- a/viskores/filter/geometry_refinement/ExtrusionLinear.cxx
+++ b/viskores/filter/geometry_refinement/ExtrusionLinear.cxx
@@ -1,0 +1,62 @@
+//============================================================================
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//============================================================================
+
+#include <viskores/filter/geometry_refinement/ExtrusionAbstract.hxx>
+#include <viskores/filter/geometry_refinement/ExtrusionLinear.h>
+#include <viskores/filter/geometry_refinement/worklet/ExtrusionLinear.h>
+
+namespace viskores
+{
+namespace filter
+{
+namespace geometry_refinement
+{
+
+VISKORES_CONT viskores::cont::DataSet ExtrusionLinear::DoExecute(
+  const viskores::cont::DataSet& input)
+{
+  const viskores::Vec3f_64 direction{ this->Direction };
+  const viskores::Float64 directionMagnitude2 = viskores::MagnitudeSquared(direction);
+  if (directionMagnitude2 <= 0)
+  {
+    throw viskores::cont::ErrorFilterExecution("ExtrusionLinear: direction must be nonzero.");
+  }
+
+  const viskores::Float64 inverseDirectionMagnitude = viskores::RSqrt(directionMagnitude2);
+  const viskores::Vec3f_64 normalizedDirection64 = direction * inverseDirectionMagnitude;
+  const viskores::Vec3f normalizedDirection(
+    static_cast<viskores::FloatDefault>(normalizedDirection64[0]),
+    static_cast<viskores::FloatDefault>(normalizedDirection64[1]),
+    static_cast<viskores::FloatDefault>(normalizedDirection64[2]));
+  const viskores::Vec3f sweep = normalizedDirection * this->Distance;
+
+  auto makeCoordinateWorklet = [&](viskores::Id numberOfPoints)
+  {
+    return viskores::worklet::ExtrusionLinearCoordinates{
+      normalizedDirection, this->Distance, this->GetNumberOfPlanes(), numberOfPoints
+    };
+  };
+
+  auto makeOrientationWorklet = [&]()
+  {
+    return viskores::worklet::OrientExtrudedTriangleConnectivity<
+      viskores::worklet::ExtrusionLinearSweep>{ viskores::worklet::ExtrusionLinearSweep{ sweep } };
+  };
+
+  auto validateCoordinates = [](const auto&) {};
+
+  return this->ExecuteTriangleExtrusion(input,
+                                        "ExtrusionLinear",
+                                        false,
+                                        makeCoordinateWorklet,
+                                        makeOrientationWorklet,
+                                        validateCoordinates);
+}
+} // namespace geometry_refinement
+} // namespace filter
+} // namespace viskores

--- a/viskores/filter/geometry_refinement/ExtrusionLinear.h
+++ b/viskores/filter/geometry_refinement/ExtrusionLinear.h
@@ -1,0 +1,55 @@
+//============================================================================
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//============================================================================
+
+#ifndef viskores_filter_geometry_refinement_ExtrusionLinear_h
+#define viskores_filter_geometry_refinement_ExtrusionLinear_h
+
+#include <viskores/filter/geometry_refinement/ExtrusionAbstract.h>
+#include <viskores/filter/geometry_refinement/viskores_filter_geometry_refinement_export.h>
+
+namespace viskores
+{
+namespace filter
+{
+namespace geometry_refinement
+{
+
+/// @brief Extrude a triangulated profile along a direction into wedge cells.
+///
+/// `ExtrusionLinear` creates a sequence of translated copies of the input points
+/// along a direction and connects adjacent triangle copies with wedge cells.
+class VISKORES_FILTER_GEOMETRY_REFINEMENT_EXPORT ExtrusionLinear
+  : public viskores::filter::geometry_refinement::ExtrusionAbstract
+{
+public:
+  VISKORES_CONT ExtrusionLinear() { this->SetNumberOfPlanes(2); }
+
+  /// @brief Set the extrusion direction.
+  ///
+  /// The direction vector is normalized before use. Use `SetDistance` to set
+  /// the spacing between adjacent planes.
+  VISKORES_CONT void SetDirection(viskores::Vec3f direction) { this->Direction = direction; }
+  /// @copydoc SetDirection
+  VISKORES_CONT viskores::Vec3f GetDirection() const { return this->Direction; }
+
+  /// @brief Set the extrusion distance along the normalized direction.
+  VISKORES_CONT void SetDistance(viskores::FloatDefault distance) { this->Distance = distance; }
+  /// @copydoc SetDistance
+  VISKORES_CONT viskores::FloatDefault GetDistance() const { return this->Distance; }
+
+private:
+  VISKORES_CONT viskores::cont::DataSet DoExecute(const viskores::cont::DataSet& input) override;
+
+  viskores::Vec3f Direction = { 0, 0, 1 };
+  viskores::FloatDefault Distance = 1;
+};
+} // namespace geometry_refinement
+} // namespace filter
+} // namespace viskores
+
+#endif // viskores_filter_geometry_refinement_ExtrusionLinear_h

--- a/viskores/filter/geometry_refinement/ExtrusionRotational.cxx
+++ b/viskores/filter/geometry_refinement/ExtrusionRotational.cxx
@@ -1,0 +1,152 @@
+//============================================================================
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//============================================================================
+
+#include <viskores/filter/geometry_refinement/ExtrusionAbstract.hxx>
+#include <viskores/filter/geometry_refinement/ExtrusionRotational.h>
+#include <viskores/filter/geometry_refinement/worklet/ExtrusionRotational.h>
+
+#include <viskores/cont/Algorithm.h>
+#include <viskores/cont/ArrayHandleTransform.h>
+
+namespace
+{
+
+VISKORES_CONT bool NearlyFullSweep(viskores::FloatDefault angle)
+{
+  constexpr viskores::Float64 tolerance = 1.0e-6;
+  const viskores::Float64 fullSweep = viskores::TwoPi<viskores::Float64>();
+  const viskores::Float64 absAngle = viskores::Abs(static_cast<viskores::Float64>(angle));
+  return viskores::Abs(absAngle - fullSweep) <= tolerance;
+}
+
+struct IsPointOnAxis
+{
+  viskores::Vec3f_64 Axis;
+  viskores::Vec3f_64 Center;
+  viskores::Float64 Tolerance2;
+
+  template <typename PointType>
+  VISKORES_EXEC_CONT bool operator()(const PointType& pointValue) const
+  {
+    const viskores::Vec3f_64 relativeP = viskores::Vec3f_64{ pointValue } - this->Center;
+
+    const viskores::Float64 dot = viskores::Dot(this->Axis, relativeP);
+    const viskores::Vec3f_64 perpendicular = relativeP - (dot * this->Axis);
+    const viskores::Float64 perpendicularMagnitude2 = viskores::MagnitudeSquared(perpendicular);
+
+    return perpendicularMagnitude2 <= this->Tolerance2;
+  }
+};
+
+template <typename CoordinateArrayType>
+VISKORES_CONT void ValidateAxisPoints(const CoordinateArrayType& coordinates,
+                                      viskores::Vec3f_64 axis,
+                                      viskores::Vec3f_64 center,
+                                      viskores::Float64 tolerance)
+{
+  const bool hasAxisPoint = viskores::cont::Algorithm::Reduce(
+    viskores::cont::make_ArrayHandleTransform(coordinates,
+                                              IsPointOnAxis{ axis, center, tolerance * tolerance }),
+    false,
+    viskores::LogicalOr{});
+  if (hasAxisPoint)
+  {
+    throw viskores::cont::ErrorFilterExecution(
+      "ExtrusionRotational: input contains a point on the rotation axis.");
+  }
+}
+
+} // anonymous namespace
+
+namespace viskores
+{
+namespace filter
+{
+namespace geometry_refinement
+{
+
+VISKORES_CONT ExtrusionRotational::ExtrusionRotational()
+{
+  this->CloseSweep = NearlyFullSweep(this->SweepAngle);
+}
+
+VISKORES_CONT void ExtrusionRotational::SetSweepAngle(viskores::FloatDefault radians)
+{
+  this->SweepAngle = radians;
+  if (!this->CloseSweepExplicitlySet)
+  {
+    this->CloseSweep = NearlyFullSweep(radians);
+  }
+}
+
+VISKORES_CONT void ExtrusionRotational::SetCloseSweep(bool close)
+{
+  this->CloseSweep = close;
+  this->CloseSweepExplicitlySet = true;
+}
+
+VISKORES_CONT viskores::cont::DataSet ExtrusionRotational::DoExecute(
+  const viskores::cont::DataSet& input)
+{
+  const viskores::Float64 axisMagnitude2 = viskores::MagnitudeSquared(this->Axis);
+  if (axisMagnitude2 <= 0)
+  {
+    throw viskores::cont::ErrorFilterExecution("ExtrusionRotational: axis must be nonzero.");
+  }
+  if (this->AxisPointTolerance < 0)
+  {
+    throw viskores::cont::ErrorFilterExecution(
+      "ExtrusionRotational: axis point tolerance must be nonnegative.");
+  }
+  if (this->GetCloseSweep() && !NearlyFullSweep(this->SweepAngle))
+  {
+    throw viskores::cont::ErrorFilterExecution(
+      "ExtrusionRotational: closed sweeps require a full 2*pi sweep angle.");
+  }
+
+  const viskores::Float64 inverseAxisMagnitude = viskores::RSqrt(axisMagnitude2);
+  const viskores::Vec3f_64 normalizedAxis = this->Axis * inverseAxisMagnitude;
+
+  auto makeCoordinateWorklet = [&](viskores::Id numberOfPoints)
+  {
+    return viskores::worklet::ExtrusionRotationalCoordinates{
+      normalizedAxis, this->Center,         this->SweepAngle, this->GetNumberOfPlanes(),
+      numberOfPoints, this->GetCloseSweep()
+    };
+  };
+
+  auto makeOrientationWorklet = [&]()
+  {
+    const viskores::Float64 denominator = static_cast<viskores::Float64>(
+      this->GetCloseSweep() ? this->GetNumberOfPlanes() : (this->GetNumberOfPlanes() - 1));
+    const viskores::Float64 stepAngle =
+      static_cast<viskores::Float64>(this->SweepAngle) / denominator;
+
+    return viskores::worklet::OrientExtrudedTriangleConnectivity<
+      viskores::worklet::ExtrusionRotationalSweep>{ viskores::worklet::ExtrusionRotationalSweep{
+      normalizedAxis, this->Center, viskores::Cos(stepAngle), viskores::Sin(stepAngle) } };
+  };
+
+  auto validateCoordinates = [&](const auto& coordinates)
+  {
+    if (!this->AllowAxisPoints)
+    {
+      ValidateAxisPoints(coordinates, normalizedAxis, this->Center, this->AxisPointTolerance);
+    }
+  };
+
+  return this->ExecuteTriangleExtrusion(input,
+                                        "ExtrusionRotational",
+                                        this->GetCloseSweep(),
+                                        makeCoordinateWorklet,
+                                        makeOrientationWorklet,
+                                        validateCoordinates);
+}
+} // namespace geometry_refinement
+} // namespace filter
+} // namespace viskores

--- a/viskores/filter/geometry_refinement/ExtrusionRotational.h
+++ b/viskores/filter/geometry_refinement/ExtrusionRotational.h
@@ -1,0 +1,89 @@
+//============================================================================
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//============================================================================
+
+#ifndef viskores_filter_geometry_refinement_ExtrusionRotational_h
+#define viskores_filter_geometry_refinement_ExtrusionRotational_h
+
+#include <viskores/Math.h>
+#include <viskores/filter/geometry_refinement/ExtrusionAbstract.h>
+#include <viskores/filter/geometry_refinement/viskores_filter_geometry_refinement_export.h>
+
+namespace viskores
+{
+namespace filter
+{
+namespace geometry_refinement
+{
+
+/// @brief Revolve a triangulated profile into wedge cells.
+///
+/// `ExtrusionRotational` creates a series of rotated copies of the input points around an
+/// axis and connects adjacent triangle copies with wedge cells. By default, the
+/// output is an explicit wedge cell set for broad downstream compatibility.
+class VISKORES_FILTER_GEOMETRY_REFINEMENT_EXPORT ExtrusionRotational
+  : public viskores::filter::geometry_refinement::ExtrusionAbstract
+{
+public:
+  VISKORES_CONT ExtrusionRotational();
+
+  /// @brief Set the axis direction used for rotation.
+  VISKORES_CONT void SetAxis(viskores::Vec3f_64 axis) { this->Axis = axis; }
+  /// @copydoc SetAxis
+  VISKORES_CONT viskores::Vec3f_64 GetAxis() const { return this->Axis; }
+
+  /// @brief Set a point on the rotation axis.
+  VISKORES_CONT void SetCenter(viskores::Vec3f_64 center) { this->Center = center; }
+  /// @copydoc SetCenter
+  VISKORES_CONT viskores::Vec3f_64 GetCenter() const { return this->Center; }
+
+  /// @brief Set the total sweep angle in radians.
+  ///
+  /// Unless `SetCloseSweep` has been called explicitly, full 2*pi sweeps are
+  /// closed and non-full sweeps are open.
+  VISKORES_CONT void SetSweepAngle(viskores::FloatDefault radians);
+  /// @copydoc SetSweepAngle
+  VISKORES_CONT viskores::FloatDefault GetSweepAngle() const { return this->SweepAngle; }
+
+  /// @brief Explicitly specify whether the last plane connects back to the first.
+  VISKORES_CONT void SetCloseSweep(bool close);
+  /// @copydoc SetCloseSweep
+  VISKORES_CONT bool GetCloseSweep() const { return this->CloseSweep; }
+
+  /// @brief Allow points on the rotation axis, which can produce degenerate wedges.
+  ///
+  /// This is enabled by default to support solid-of-revolution inputs whose
+  /// profile touches the rotation axis. Disable it to reject axis-touching
+  /// profiles instead of producing degenerate wedges along the axis.
+  VISKORES_CONT void SetAllowAxisPoints(bool on) { this->AllowAxisPoints = on; }
+  /// @copydoc SetAllowAxisPoints
+  VISKORES_CONT bool GetAllowAxisPoints() const { return this->AllowAxisPoints; }
+
+  /// @brief Set the absolute distance tolerance used to detect points on the rotation axis.
+  VISKORES_CONT void SetAxisPointTolerance(viskores::Float64 tolerance)
+  {
+    this->AxisPointTolerance = tolerance;
+  }
+  /// @copydoc SetAxisPointTolerance
+  VISKORES_CONT viskores::Float64 GetAxisPointTolerance() const { return this->AxisPointTolerance; }
+
+private:
+  VISKORES_CONT viskores::cont::DataSet DoExecute(const viskores::cont::DataSet& input) override;
+
+  viskores::Vec3f_64 Axis = { 0.0, 0.0, 1.0 };
+  viskores::Vec3f_64 Center = { 0.0, 0.0, 0.0 };
+  viskores::FloatDefault SweepAngle = viskores::TwoPi<viskores::FloatDefault>();
+  bool CloseSweep = false;
+  bool CloseSweepExplicitlySet = false;
+  bool AllowAxisPoints = true;
+  viskores::Float64 AxisPointTolerance = 1.0e-6;
+};
+} // namespace geometry_refinement
+} // namespace filter
+} // namespace viskores
+
+#endif // viskores_filter_geometry_refinement_ExtrusionRotational_h

--- a/viskores/filter/geometry_refinement/testing/CMakeLists.txt
+++ b/viskores/filter/geometry_refinement/testing/CMakeLists.txt
@@ -18,6 +18,8 @@
 
 set(unit_tests
   UnitTestConvertToPointCloud.cxx
+  UnitTestExtrusionLinear.cxx
+  UnitTestExtrusionRotational.cxx
   UnitTestShrinkFilter.cxx
   UnitTestSplitSharpEdgesFilter.cxx
   UnitTestTetrahedralizeFilter.cxx

--- a/viskores/filter/geometry_refinement/testing/UnitTestExtrusionLinear.cxx
+++ b/viskores/filter/geometry_refinement/testing/UnitTestExtrusionLinear.cxx
@@ -1,0 +1,290 @@
+//============================================================================
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//============================================================================
+
+#include <viskores/CellShape.h>
+#include <viskores/cont/CellSetExtrude.h>
+#include <viskores/cont/CellSetSingleType.h>
+#include <viskores/cont/DataSetBuilderExplicit.h>
+#include <viskores/cont/ErrorFilterExecution.h>
+#include <viskores/cont/testing/Testing.h>
+#include <viskores/filter/geometry_refinement/ExtrusionLinear.h>
+
+#include <array>
+#include <functional>
+#include <vector>
+
+namespace
+{
+
+using ExplicitWedgeCellSet = viskores::cont::CellSetSingleType<>;
+
+viskores::cont::DataSet MakeTriangleDataSet()
+{
+  const std::vector<viskores::Vec3f> coordinates{ { 0.0f, 0.0f, 0.0f }, { 1.0f, 0.0f, 0.0f },
+                                                  { 0.0f, 1.0f, 0.0f }, { 2.0f, 0.0f, 0.0f },
+                                                  { 3.0f, 0.0f, 0.0f }, { 2.0f, 1.0f, 0.0f } };
+  const std::vector<viskores::UInt8> shapes{ viskores::CELL_SHAPE_TRIANGLE,
+                                             viskores::CELL_SHAPE_TRIANGLE };
+  const std::vector<viskores::IdComponent> numIndices{ 3, 3 };
+  const std::vector<viskores::Id> connectivity{ 0, 1, 2, 3, 5, 4 };
+
+  viskores::cont::DataSetBuilderExplicit builder;
+  viskores::cont::DataSet dataSet =
+    builder.Create(coordinates, shapes, numIndices, connectivity, "coords");
+
+  dataSet.AddPointField("pointvar",
+                        std::vector<viskores::Float32>{ 10.0f, 20.0f, 30.0f, 40.0f, 50.0f, 60.0f });
+  dataSet.AddCellField("cellvar", std::vector<viskores::Float32>{ 70.0f, 80.0f });
+  return dataSet;
+}
+
+viskores::cont::DataSet MakeQuadDataSet()
+{
+  const std::vector<viskores::Vec3f> coordinates{
+    { 0.0f, 0.0f, 0.0f }, { 1.0f, 0.0f, 0.0f }, { 1.0f, 1.0f, 0.0f }, { 0.0f, 1.0f, 0.0f }
+  };
+  const std::vector<viskores::UInt8> shapes{ viskores::CELL_SHAPE_QUAD };
+  const std::vector<viskores::IdComponent> numIndices{ 4 };
+  const std::vector<viskores::Id> connectivity{ 0, 1, 2, 3 };
+
+  viskores::cont::DataSetBuilderExplicit builder;
+  return builder.Create(coordinates, shapes, numIndices, connectivity, "coords");
+}
+
+bool ThrowsFilterExecution(const std::function<void()>& function)
+{
+  try
+  {
+    function();
+  }
+  catch (const viskores::cont::ErrorFilterExecution&)
+  {
+    return true;
+  }
+  return false;
+}
+
+void AssertCellPointIds(const viskores::cont::DataSet& dataSet,
+                        viskores::Id cellId,
+                        const std::array<viskores::Id, 6>& expected)
+{
+  std::array<viskores::Id, 6> actual;
+  dataSet.GetCellSet().GetCellPointIds(cellId, actual.data());
+  for (viskores::IdComponent index = 0; index < 6; ++index)
+  {
+    VISKORES_TEST_ASSERT(actual[static_cast<std::size_t>(index)] ==
+                           expected[static_cast<std::size_t>(index)],
+                         "Wrong wedge point id.");
+  }
+}
+
+viskores::Float64 SignedWedgeVolume(const viskores::cont::DataSet& dataSet, viskores::Id cellId)
+{
+  std::array<viskores::Id, 6> pointIds;
+  dataSet.GetCellSet().GetCellPointIds(cellId, pointIds.data());
+
+  viskores::cont::ArrayHandle<viskores::Vec3f> coordinates;
+  dataSet.GetCoordinateSystem().GetData().AsArrayHandle(coordinates);
+  auto coordinatePortal = coordinates.ReadPortal();
+
+  const viskores::Vec3f point0 = coordinatePortal.Get(pointIds[0]);
+  const viskores::Vec3f point1 = coordinatePortal.Get(pointIds[1]);
+  const viskores::Vec3f point2 = coordinatePortal.Get(pointIds[2]);
+  const viskores::Vec3f point3 = coordinatePortal.Get(pointIds[3]);
+  const viskores::Vec3f point4 = coordinatePortal.Get(pointIds[4]);
+  const viskores::Vec3f point5 = coordinatePortal.Get(pointIds[5]);
+
+  viskores::Float64 volume =
+    viskores::Dot(viskores::Cross(point1 - point0, point2 - point0), point3 - point0);
+  volume += viskores::Dot(viskores::Cross(point4 - point1, point5 - point1), point3 - point1);
+  volume += viskores::Dot(viskores::Cross(point5 - point1, point2 - point1), point3 - point1);
+  return volume;
+}
+
+void AssertPositiveWedgeVolumes(const viskores::cont::DataSet& dataSet)
+{
+  for (viskores::Id cellId = 0; cellId < dataSet.GetNumberOfCells(); ++cellId)
+  {
+    VISKORES_TEST_ASSERT(SignedWedgeVolume(dataSet, cellId) > 0.0,
+                         "Output wedge should have positive orientation.");
+  }
+}
+
+void TestDefaultOutput()
+{
+  std::cout << "Testing default linear extrusion output" << std::endl;
+
+  viskores::filter::geometry_refinement::ExtrusionLinear filter;
+  viskores::cont::DataSet output = filter.Execute(MakeTriangleDataSet());
+
+  VISKORES_TEST_ASSERT(output.GetNumberOfPoints() == 12, "Wrong default output point count.");
+  VISKORES_TEST_ASSERT(output.GetNumberOfCells() == 2, "Wrong default output cell count.");
+  VISKORES_TEST_ASSERT(output.GetCellSet().IsType<ExplicitWedgeCellSet>(),
+                       "Default output cell set is not explicit single-type topology.");
+
+  const auto cellSet = output.GetCellSet().AsCellSet<ExplicitWedgeCellSet>();
+  VISKORES_TEST_ASSERT(cellSet.GetCellShapeAsId() == viskores::CELL_SHAPE_WEDGE,
+                       "Default output cells should be wedges.");
+  VISKORES_TEST_ASSERT(cellSet.GetNumberOfPointsInCell(0) == 6,
+                       "Output wedges should have 6 points.");
+  AssertCellPointIds(output, 0, { 0, 1, 2, 6, 7, 8 });
+  AssertCellPointIds(output, 1, { 3, 4, 5, 9, 10, 11 });
+  AssertPositiveWedgeVolumes(output);
+}
+
+void TestMultiplePlanes()
+{
+  std::cout << "Testing multiple linear extrusion planes" << std::endl;
+
+  viskores::filter::geometry_refinement::ExtrusionLinear filter;
+  filter.SetNumberOfPlanes(4);
+  filter.SetDirection({ 0.0f, 0.0f, 2.0f });
+  filter.SetDistance(3.0f);
+
+  viskores::cont::DataSet output = filter.Execute(MakeTriangleDataSet());
+  VISKORES_TEST_ASSERT(output.GetNumberOfPoints() == 24, "Wrong output point count.");
+  VISKORES_TEST_ASSERT(output.GetNumberOfCells() == 6, "Wrong output cell count.");
+
+  viskores::cont::ArrayHandle<viskores::Vec3f> coordinates;
+  output.GetCoordinateSystem().GetData().AsArrayHandle(coordinates);
+  auto portal = coordinates.ReadPortal();
+
+  VISKORES_TEST_ASSERT(test_equal(portal.Get(0), viskores::Vec3f(0.0f, 0.0f, 0.0f)),
+                       "First plane coordinate is wrong.");
+  VISKORES_TEST_ASSERT(test_equal(portal.Get(6), viskores::Vec3f(0.0f, 0.0f, 1.0f)),
+                       "Second plane coordinate is wrong.");
+  VISKORES_TEST_ASSERT(test_equal(portal.Get(18), viskores::Vec3f(0.0f, 0.0f, 3.0f)),
+                       "Final plane coordinate is wrong.");
+  AssertPositiveWedgeVolumes(output);
+}
+
+void TestCompactOutput()
+{
+  std::cout << "Testing compact linear extrusion output" << std::endl;
+
+  viskores::filter::geometry_refinement::ExtrusionLinear filter;
+  filter.SetCompactOutput(true);
+  filter.SetNumberOfPlanes(4);
+
+  viskores::cont::DataSet output = filter.Execute(MakeTriangleDataSet());
+  VISKORES_TEST_ASSERT(output.GetNumberOfPoints() == 24, "Wrong compact output point count.");
+  VISKORES_TEST_ASSERT(output.GetNumberOfCells() == 6, "Wrong compact output cell count.");
+  VISKORES_TEST_ASSERT(output.GetCellSet().IsType<viskores::cont::CellSetExtrude>(),
+                       "Compact output cell set is not CellSetExtrude.");
+
+  const auto cellSet = output.GetCellSet().AsCellSet<viskores::cont::CellSetExtrude>();
+  VISKORES_TEST_ASSERT(!cellSet.GetIsPeriodic(), "Linear compact output should not be periodic.");
+  VISKORES_TEST_ASSERT(cellSet.GetCellShape(0) == viskores::CELL_SHAPE_WEDGE,
+                       "Compact output cells should be wedges.");
+  AssertCellPointIds(output, 0, { 0, 1, 2, 6, 7, 8 });
+  AssertCellPointIds(output, 1, { 3, 4, 5, 9, 10, 11 });
+  AssertPositiveWedgeVolumes(output);
+}
+
+void TestFieldReplication()
+{
+  std::cout << "Testing linear extrusion field replication" << std::endl;
+
+  viskores::filter::geometry_refinement::ExtrusionLinear filter;
+  filter.SetNumberOfPlanes(4);
+
+  viskores::cont::DataSet output = filter.Execute(MakeTriangleDataSet());
+
+  viskores::cont::ArrayHandle<viskores::Float32> pointField =
+    output.GetField("pointvar")
+      .GetData()
+      .AsArrayHandle<viskores::cont::ArrayHandle<viskores::Float32>>();
+  auto pointPortal = pointField.ReadPortal();
+  VISKORES_TEST_ASSERT(pointPortal.GetNumberOfValues() == 24, "Wrong point field size.");
+  for (viskores::Id plane = 0; plane < 4; ++plane)
+  {
+    for (viskores::Id point = 0; point < 6; ++point)
+    {
+      VISKORES_TEST_ASSERT(test_equal(pointPortal.Get((plane * 6) + point),
+                                      static_cast<viskores::Float32>((point + 1) * 10)),
+                           "Wrong replicated point field value.");
+    }
+  }
+
+  viskores::cont::ArrayHandle<viskores::Float32> cellField =
+    output.GetField("cellvar")
+      .GetData()
+      .AsArrayHandle<viskores::cont::ArrayHandle<viskores::Float32>>();
+  auto cellPortal = cellField.ReadPortal();
+  VISKORES_TEST_ASSERT(cellPortal.GetNumberOfValues() == 6, "Wrong cell field size.");
+  for (viskores::Id plane = 0; plane < 3; ++plane)
+  {
+    VISKORES_TEST_ASSERT(test_equal(cellPortal.Get((plane * 2) + 0), 70.0f),
+                         "Wrong replicated cell field value.");
+    VISKORES_TEST_ASSERT(test_equal(cellPortal.Get((plane * 2) + 1), 80.0f),
+                         "Wrong replicated cell field value.");
+  }
+}
+
+void TestTriangulateInput()
+{
+  std::cout << "Testing optional triangulation for linear extrusion" << std::endl;
+
+  VISKORES_TEST_ASSERT(ThrowsFilterExecution(
+                         []()
+                         {
+                           viskores::filter::geometry_refinement::ExtrusionLinear filter;
+                           filter.SetNumberOfPlanes(4);
+                           filter.Execute(MakeQuadDataSet());
+                         }),
+                       "Quad input should fail without triangulation.");
+
+  viskores::filter::geometry_refinement::ExtrusionLinear filter;
+  filter.SetNumberOfPlanes(4);
+  filter.SetTriangulateInput(true);
+  viskores::cont::DataSet output = filter.Execute(MakeQuadDataSet());
+  VISKORES_TEST_ASSERT(output.GetNumberOfPoints() == 16, "Wrong triangulated output point count.");
+  VISKORES_TEST_ASSERT(output.GetNumberOfCells() == 6, "Wrong triangulated output cell count.");
+}
+
+void TestValidation()
+{
+  std::cout << "Testing linear extrusion validation failures" << std::endl;
+
+  VISKORES_TEST_ASSERT(ThrowsFilterExecution(
+                         []()
+                         {
+                           viskores::filter::geometry_refinement::ExtrusionLinear filter;
+                           filter.SetDirection({ 0.0f, 0.0f, 0.0f });
+                           filter.Execute(MakeTriangleDataSet());
+                         }),
+                       "Zero direction should fail.");
+
+  VISKORES_TEST_ASSERT(ThrowsFilterExecution(
+                         []()
+                         {
+                           viskores::filter::geometry_refinement::ExtrusionLinear filter;
+                           filter.SetNumberOfPlanes(1);
+                           filter.Execute(MakeTriangleDataSet());
+                         }),
+                       "Invalid plane count should fail.");
+}
+
+struct TestingExtrusionLinear
+{
+  void operator()() const
+  {
+    TestDefaultOutput();
+    TestMultiplePlanes();
+    TestCompactOutput();
+    TestFieldReplication();
+    TestTriangulateInput();
+    TestValidation();
+  }
+};
+} // anonymous namespace
+
+int UnitTestExtrusionLinear(int argc, char* argv[])
+{
+  return viskores::cont::testing::Testing::Run(TestingExtrusionLinear{}, argc, argv);
+}

--- a/viskores/filter/geometry_refinement/testing/UnitTestExtrusionRotational.cxx
+++ b/viskores/filter/geometry_refinement/testing/UnitTestExtrusionRotational.cxx
@@ -1,0 +1,413 @@
+//============================================================================
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//============================================================================
+
+#include <viskores/CellShape.h>
+#include <viskores/cont/CellSetExtrude.h>
+#include <viskores/cont/CellSetSingleType.h>
+#include <viskores/cont/DataSetBuilderExplicit.h>
+#include <viskores/cont/ErrorFilterExecution.h>
+#include <viskores/cont/testing/Testing.h>
+#include <viskores/filter/geometry_refinement/ExtrusionRotational.h>
+
+#include <array>
+#include <functional>
+#include <vector>
+
+namespace
+{
+
+using ExplicitWedgeCellSet = viskores::cont::CellSetSingleType<>;
+
+viskores::cont::DataSet MakeTriangleDataSet(bool includeAxisPoint = false)
+{
+  std::vector<viskores::Vec3f> coordinates;
+  if (includeAxisPoint)
+  {
+    coordinates = { { 0.0f, 0.0f, 0.0f }, { 2.0f, 0.0f, 0.0f }, { 1.0f, 0.0f, 1.0f },
+                    { 3.0f, 0.0f, 0.0f }, { 4.0f, 0.0f, 0.0f }, { 3.0f, 0.0f, 1.0f } };
+  }
+  else
+  {
+    coordinates = { { 1.0f, 0.0f, 0.0f }, { 2.0f, 0.0f, 0.0f }, { 1.0f, 0.0f, 1.0f },
+                    { 3.0f, 0.0f, 0.0f }, { 4.0f, 0.0f, 0.0f }, { 3.0f, 0.0f, 1.0f } };
+  }
+
+  const std::vector<viskores::UInt8> shapes{ viskores::CELL_SHAPE_TRIANGLE,
+                                             viskores::CELL_SHAPE_TRIANGLE };
+  const std::vector<viskores::IdComponent> numIndices{ 3, 3 };
+  const std::vector<viskores::Id> connectivity{ 0, 1, 2, 3, 5, 4 };
+
+  viskores::cont::DataSetBuilderExplicit builder;
+  viskores::cont::DataSet dataSet =
+    builder.Create(coordinates, shapes, numIndices, connectivity, "coords");
+
+  dataSet.AddPointField("pointvar",
+                        std::vector<viskores::Float32>{ 10.0f, 20.0f, 30.0f, 40.0f, 50.0f, 60.0f });
+  dataSet.AddCellField("cellvar", std::vector<viskores::Float32>{ 70.0f, 80.0f });
+  return dataSet;
+}
+
+viskores::cont::DataSet MakeQuadDataSet()
+{
+  const std::vector<viskores::Vec3f> coordinates{
+    { 1.0f, 0.0f, 0.0f }, { 2.0f, 0.0f, 0.0f }, { 2.0f, 0.0f, 1.0f }, { 1.0f, 0.0f, 1.0f }
+  };
+  const std::vector<viskores::UInt8> shapes{ viskores::CELL_SHAPE_QUAD };
+  const std::vector<viskores::IdComponent> numIndices{ 4 };
+  const std::vector<viskores::Id> connectivity{ 0, 1, 2, 3 };
+
+  viskores::cont::DataSetBuilderExplicit builder;
+  return builder.Create(coordinates, shapes, numIndices, connectivity, "coords");
+}
+
+bool ThrowsFilterExecution(const std::function<void()>& function)
+{
+  try
+  {
+    function();
+  }
+  catch (const viskores::cont::ErrorFilterExecution&)
+  {
+    return true;
+  }
+  return false;
+}
+
+void AssertCellPointIds(const viskores::cont::DataSet& dataSet,
+                        viskores::Id cellId,
+                        const std::array<viskores::Id, 6>& expected)
+{
+  std::array<viskores::Id, 6> actual;
+  dataSet.GetCellSet().GetCellPointIds(cellId, actual.data());
+  for (viskores::IdComponent index = 0; index < 6; ++index)
+  {
+    VISKORES_TEST_ASSERT(actual[static_cast<std::size_t>(index)] ==
+                           expected[static_cast<std::size_t>(index)],
+                         "Wrong wedge point id.");
+  }
+}
+
+viskores::Float64 SignedWedgeVolume(const viskores::cont::DataSet& dataSet, viskores::Id cellId)
+{
+  std::array<viskores::Id, 6> pointIds;
+  dataSet.GetCellSet().GetCellPointIds(cellId, pointIds.data());
+
+  viskores::cont::ArrayHandle<viskores::Vec3f> coordinates;
+  dataSet.GetCoordinateSystem().GetData().AsArrayHandle(coordinates);
+  auto coordinatePortal = coordinates.ReadPortal();
+
+  const viskores::Vec3f point0 = coordinatePortal.Get(pointIds[0]);
+  const viskores::Vec3f point1 = coordinatePortal.Get(pointIds[1]);
+  const viskores::Vec3f point2 = coordinatePortal.Get(pointIds[2]);
+  const viskores::Vec3f point3 = coordinatePortal.Get(pointIds[3]);
+  const viskores::Vec3f point4 = coordinatePortal.Get(pointIds[4]);
+  const viskores::Vec3f point5 = coordinatePortal.Get(pointIds[5]);
+
+  viskores::Float64 volume =
+    viskores::Dot(viskores::Cross(point1 - point0, point2 - point0), point3 - point0);
+  volume += viskores::Dot(viskores::Cross(point4 - point1, point5 - point1), point3 - point1);
+  volume += viskores::Dot(viskores::Cross(point5 - point1, point2 - point1), point3 - point1);
+  return volume;
+}
+
+void AssertPositiveWedgeVolumes(const viskores::cont::DataSet& dataSet)
+{
+  for (viskores::Id cellId = 0; cellId < dataSet.GetNumberOfCells(); ++cellId)
+  {
+    VISKORES_TEST_ASSERT(SignedWedgeVolume(dataSet, cellId) > 0.0,
+                         "Output wedge should have positive orientation.");
+  }
+}
+
+void TestSweepAngleCloseSweepDefaults()
+{
+  std::cout << "Testing sweep angle close-sweep defaults" << std::endl;
+
+  viskores::filter::geometry_refinement::ExtrusionRotational filter;
+  VISKORES_TEST_ASSERT(filter.GetCloseSweep(), "Default full sweep should be closed.");
+
+  filter.SetSweepAngle(viskores::Pi<viskores::FloatDefault>() / 2.0f);
+  VISKORES_TEST_ASSERT(!filter.GetCloseSweep(), "Partial sweep should default open.");
+
+  filter.SetSweepAngle(viskores::TwoPi<viskores::FloatDefault>());
+  VISKORES_TEST_ASSERT(filter.GetCloseSweep(), "Full sweep should default closed.");
+
+  viskores::filter::geometry_refinement::ExtrusionRotational explicitOpenFilter;
+  explicitOpenFilter.SetCloseSweep(false);
+  explicitOpenFilter.SetSweepAngle(viskores::TwoPi<viskores::FloatDefault>());
+  VISKORES_TEST_ASSERT(!explicitOpenFilter.GetCloseSweep(),
+                       "Explicit open sweep should not be overwritten by full sweep angle.");
+
+  viskores::filter::geometry_refinement::ExtrusionRotational explicitClosedFilter;
+  explicitClosedFilter.SetCloseSweep(true);
+  explicitClosedFilter.SetSweepAngle(viskores::Pi<viskores::FloatDefault>() / 2.0f);
+  VISKORES_TEST_ASSERT(explicitClosedFilter.GetCloseSweep(),
+                       "Explicit closed sweep should not be overwritten by partial sweep angle.");
+}
+
+void TestClosedFullSweep()
+{
+  std::cout << "Testing closed full sweep" << std::endl;
+
+  viskores::filter::geometry_refinement::ExtrusionRotational filter;
+  filter.SetNumberOfPlanes(4);
+  filter.SetSweepAngle(viskores::TwoPi<viskores::FloatDefault>());
+  filter.SetCloseSweep(true);
+
+  viskores::cont::DataSet output = filter.Execute(MakeTriangleDataSet());
+  VISKORES_TEST_ASSERT(output.GetNumberOfPoints() == 24, "Wrong number of output points.");
+  VISKORES_TEST_ASSERT(output.GetNumberOfCells() == 8, "Wrong number of output cells.");
+  VISKORES_TEST_ASSERT(output.GetCellSet().IsType<ExplicitWedgeCellSet>(),
+                       "Default output cell set is not explicit single-type topology.");
+
+  const auto cellSet = output.GetCellSet().AsCellSet<ExplicitWedgeCellSet>();
+  VISKORES_TEST_ASSERT(cellSet.GetCellShapeAsId() == viskores::CELL_SHAPE_WEDGE,
+                       "Default output cells should be wedges.");
+  VISKORES_TEST_ASSERT(cellSet.GetCellShape(0) == viskores::CELL_SHAPE_WEDGE,
+                       "Output cells should be wedges.");
+  VISKORES_TEST_ASSERT(cellSet.GetNumberOfPointsInCell(0) == 6,
+                       "Output wedges should have 6 points.");
+  AssertCellPointIds(output, 0, { 0, 2, 1, 6, 8, 7 });
+  AssertCellPointIds(output, 1, { 3, 5, 4, 9, 11, 10 });
+  AssertCellPointIds(output, 6, { 18, 20, 19, 0, 2, 1 });
+  AssertCellPointIds(output, 7, { 21, 23, 22, 3, 5, 4 });
+  AssertPositiveWedgeVolumes(output);
+}
+
+void TestCompactOutput()
+{
+  std::cout << "Testing compact output" << std::endl;
+
+  viskores::filter::geometry_refinement::ExtrusionRotational filter;
+  filter.SetCompactOutput(true);
+  filter.SetNumberOfPlanes(4);
+  filter.SetSweepAngle(viskores::TwoPi<viskores::FloatDefault>());
+  filter.SetCloseSweep(true);
+
+  viskores::cont::DataSet output = filter.Execute(MakeTriangleDataSet());
+  VISKORES_TEST_ASSERT(output.GetNumberOfPoints() == 24, "Wrong compact output point count.");
+  VISKORES_TEST_ASSERT(output.GetNumberOfCells() == 8, "Wrong compact output cell count.");
+  VISKORES_TEST_ASSERT(output.GetCellSet().IsType<viskores::cont::CellSetExtrude>(),
+                       "Compact output cell set is not CellSetExtrude.");
+
+  const auto cellSet = output.GetCellSet().AsCellSet<viskores::cont::CellSetExtrude>();
+  VISKORES_TEST_ASSERT(cellSet.GetIsPeriodic(), "Closed compact sweep should be periodic.");
+  VISKORES_TEST_ASSERT(cellSet.GetCellShape(0) == viskores::CELL_SHAPE_WEDGE,
+                       "Compact output cells should be wedges.");
+  VISKORES_TEST_ASSERT(cellSet.GetNumberOfPointsInCell(0) == 6,
+                       "Compact output wedges should have 6 points.");
+  AssertCellPointIds(output, 0, { 0, 2, 1, 6, 8, 7 });
+  AssertCellPointIds(output, 1, { 3, 5, 4, 9, 11, 10 });
+  AssertCellPointIds(output, 6, { 18, 20, 19, 0, 2, 1 });
+  AssertCellPointIds(output, 7, { 21, 23, 22, 3, 5, 4 });
+  AssertPositiveWedgeVolumes(output);
+}
+
+void TestOpenPartialSweep()
+{
+  std::cout << "Testing open partial sweep" << std::endl;
+
+  viskores::filter::geometry_refinement::ExtrusionRotational filter;
+  filter.SetNumberOfPlanes(3);
+  filter.SetSweepAngle(viskores::Pi<viskores::FloatDefault>() / 2.0f);
+  filter.SetCloseSweep(false);
+
+  viskores::cont::DataSet output = filter.Execute(MakeTriangleDataSet());
+  VISKORES_TEST_ASSERT(output.GetNumberOfPoints() == 18, "Wrong number of output points.");
+  VISKORES_TEST_ASSERT(output.GetNumberOfCells() == 4, "Wrong number of output cells.");
+
+  const auto cellSet = output.GetCellSet().AsCellSet<ExplicitWedgeCellSet>();
+  VISKORES_TEST_ASSERT(cellSet.GetCellShapeAsId() == viskores::CELL_SHAPE_WEDGE,
+                       "Open output cells should be wedges.");
+  AssertPositiveWedgeVolumes(output);
+}
+
+void TestCoordinates()
+{
+  std::cout << "Testing generated coordinates" << std::endl;
+
+  viskores::filter::geometry_refinement::ExtrusionRotational filter;
+  filter.SetNumberOfPlanes(3);
+  filter.SetSweepAngle(viskores::Pi<viskores::FloatDefault>() / 2.0f);
+  filter.SetCloseSweep(false);
+
+  viskores::cont::DataSet output = filter.Execute(MakeTriangleDataSet());
+  viskores::cont::ArrayHandle<viskores::Vec3f> coordinates;
+  output.GetCoordinateSystem().GetData().AsArrayHandle(coordinates);
+  auto portal = coordinates.ReadPortal();
+
+  VISKORES_TEST_ASSERT(test_equal(portal.Get(0), viskores::Vec3f(1.0f, 0.0f, 0.0f)),
+                       "Plane 0 coordinate is wrong.");
+  VISKORES_TEST_ASSERT(
+    test_equal(portal.Get(6), viskores::Vec3f(viskores::Sqrt(0.5f), viskores::Sqrt(0.5f), 0.0f)),
+    "Middle plane coordinate is wrong.");
+  VISKORES_TEST_ASSERT(test_equal(portal.Get(12), viskores::Vec3f(0.0f, 1.0f, 0.0f)),
+                       "Final plane coordinate is wrong.");
+}
+
+void TestOffsetAxisCoordinates()
+{
+  std::cout << "Testing generated coordinates around an offset axis" << std::endl;
+
+  viskores::filter::geometry_refinement::ExtrusionRotational filter;
+  filter.SetNumberOfPlanes(2);
+  filter.SetSweepAngle(viskores::Pi<viskores::FloatDefault>() / 2.0f);
+  filter.SetCloseSweep(false);
+  filter.SetCenter({ 1.0f, 0.0f, 0.0f });
+
+  viskores::cont::DataSet output = filter.Execute(MakeTriangleDataSet());
+  viskores::cont::ArrayHandle<viskores::Vec3f> coordinates;
+  output.GetCoordinateSystem().GetData().AsArrayHandle(coordinates);
+  auto portal = coordinates.ReadPortal();
+
+  VISKORES_TEST_ASSERT(test_equal(portal.Get(0), viskores::Vec3f(1.0f, 0.0f, 0.0f)),
+                       "Axis point coordinate is wrong.");
+  VISKORES_TEST_ASSERT(test_equal(portal.Get(7), viskores::Vec3f(1.0f, 1.0f, 0.0f)),
+                       "Offset-axis rotation coordinate is wrong.");
+}
+
+void TestFieldReplication()
+{
+  std::cout << "Testing field replication" << std::endl;
+
+  viskores::filter::geometry_refinement::ExtrusionRotational filter;
+  filter.SetNumberOfPlanes(4);
+  filter.SetCloseSweep(true);
+
+  viskores::cont::DataSet output = filter.Execute(MakeTriangleDataSet());
+
+  viskores::cont::ArrayHandle<viskores::Float32> pointField =
+    output.GetField("pointvar")
+      .GetData()
+      .AsArrayHandle<viskores::cont::ArrayHandle<viskores::Float32>>();
+  auto pointPortal = pointField.ReadPortal();
+  VISKORES_TEST_ASSERT(pointPortal.GetNumberOfValues() == 24, "Wrong point field size.");
+  for (viskores::Id plane = 0; plane < 4; ++plane)
+  {
+    for (viskores::Id point = 0; point < 6; ++point)
+    {
+      VISKORES_TEST_ASSERT(test_equal(pointPortal.Get((plane * 6) + point),
+                                      static_cast<viskores::Float32>((point + 1) * 10)),
+                           "Wrong replicated point field value.");
+    }
+  }
+
+  viskores::cont::ArrayHandle<viskores::Float32> cellField =
+    output.GetField("cellvar")
+      .GetData()
+      .AsArrayHandle<viskores::cont::ArrayHandle<viskores::Float32>>();
+  auto cellPortal = cellField.ReadPortal();
+  VISKORES_TEST_ASSERT(cellPortal.GetNumberOfValues() == 8, "Wrong cell field size.");
+  for (viskores::Id plane = 0; plane < 4; ++plane)
+  {
+    VISKORES_TEST_ASSERT(test_equal(cellPortal.Get((plane * 2) + 0), 70.0f),
+                         "Wrong replicated cell field value.");
+    VISKORES_TEST_ASSERT(test_equal(cellPortal.Get((plane * 2) + 1), 80.0f),
+                         "Wrong replicated cell field value.");
+  }
+}
+
+void TestTriangulateInput()
+{
+  std::cout << "Testing optional triangulation" << std::endl;
+
+  VISKORES_TEST_ASSERT(ThrowsFilterExecution(
+                         []()
+                         {
+                           viskores::filter::geometry_refinement::ExtrusionRotational filter;
+                           filter.SetNumberOfPlanes(4);
+                           filter.Execute(MakeQuadDataSet());
+                         }),
+                       "Quad input should fail without triangulation.");
+
+  viskores::filter::geometry_refinement::ExtrusionRotational filter;
+  filter.SetNumberOfPlanes(4);
+  filter.SetTriangulateInput(true);
+  viskores::cont::DataSet output = filter.Execute(MakeQuadDataSet());
+  VISKORES_TEST_ASSERT(output.GetNumberOfPoints() == 16, "Wrong triangulated output point count.");
+  VISKORES_TEST_ASSERT(output.GetNumberOfCells() == 8, "Wrong triangulated output cell count.");
+}
+
+void TestValidation()
+{
+  std::cout << "Testing validation failures" << std::endl;
+
+  VISKORES_TEST_ASSERT(ThrowsFilterExecution(
+                         []()
+                         {
+                           viskores::filter::geometry_refinement::ExtrusionRotational filter;
+                           filter.SetAxis({ 0.0f, 0.0f, 0.0f });
+                           filter.Execute(MakeTriangleDataSet());
+                         }),
+                       "Zero axis should fail.");
+
+  VISKORES_TEST_ASSERT(ThrowsFilterExecution(
+                         []()
+                         {
+                           viskores::filter::geometry_refinement::ExtrusionRotational filter;
+                           filter.SetCloseSweep(false);
+                           filter.SetNumberOfPlanes(1);
+                           filter.Execute(MakeTriangleDataSet());
+                         }),
+                       "Invalid open plane count should fail.");
+
+  VISKORES_TEST_ASSERT(ThrowsFilterExecution(
+                         []()
+                         {
+                           viskores::filter::geometry_refinement::ExtrusionRotational filter;
+                           filter.SetCloseSweep(true);
+                           filter.SetSweepAngle(viskores::Pi<viskores::FloatDefault>());
+                           filter.Execute(MakeTriangleDataSet());
+                         }),
+                       "Closed non-full sweep should fail.");
+
+  VISKORES_TEST_ASSERT(ThrowsFilterExecution(
+                         []()
+                         {
+                           viskores::filter::geometry_refinement::ExtrusionRotational filter;
+                           filter.SetAxisPointTolerance(-1.0);
+                           filter.Execute(MakeTriangleDataSet());
+                         }),
+                       "Negative axis point tolerance should fail.");
+
+  viskores::filter::geometry_refinement::ExtrusionRotational filter;
+  filter.SetNumberOfPlanes(4);
+  viskores::cont::DataSet output = filter.Execute(MakeTriangleDataSet(true));
+  VISKORES_TEST_ASSERT(output.GetNumberOfCells() == 8, "Axis points should be allowed by default.");
+
+  VISKORES_TEST_ASSERT(ThrowsFilterExecution(
+                         []()
+                         {
+                           viskores::filter::geometry_refinement::ExtrusionRotational strictFilter;
+                           strictFilter.SetAllowAxisPoints(false);
+                           strictFilter.Execute(MakeTriangleDataSet(true));
+                         }),
+                       "Axis point should fail when axis points are disallowed.");
+}
+
+struct TestingExtrusionRotational
+{
+  void operator()() const
+  {
+    TestSweepAngleCloseSweepDefaults();
+    TestClosedFullSweep();
+    TestCompactOutput();
+    TestOpenPartialSweep();
+    TestCoordinates();
+    TestOffsetAxisCoordinates();
+    TestFieldReplication();
+    TestTriangulateInput();
+    TestValidation();
+  }
+};
+} // anonymous namespace
+
+int UnitTestExtrusionRotational(int argc, char* argv[])
+{
+  return viskores::cont::testing::Testing::Run(TestingExtrusionRotational{}, argc, argv);
+}

--- a/viskores/filter/geometry_refinement/worklet/CMakeLists.txt
+++ b/viskores/filter/geometry_refinement/worklet/CMakeLists.txt
@@ -17,6 +17,9 @@
 ##============================================================================
 
 set(headers
+  Extrusion.h
+  ExtrusionLinear.h
+  ExtrusionRotational.h
   Shrink.h
   SplitSharpEdges.h
   Tetrahedralize.h

--- a/viskores/filter/geometry_refinement/worklet/Extrusion.h
+++ b/viskores/filter/geometry_refinement/worklet/Extrusion.h
@@ -1,0 +1,121 @@
+//============================================================================
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//============================================================================
+
+#ifndef viskores_worklet_Extrusion_h
+#define viskores_worklet_Extrusion_h
+
+#include <viskores/Math.h>
+#include <viskores/worklet/WorkletMapField.h>
+
+namespace viskores
+{
+namespace worklet
+{
+
+struct ExtrusionOutputToInputPlane
+{
+  viskores::Id NumberOfIdsPerPlane = 0;
+
+  VISKORES_EXEC_CONT
+  viskores::Id operator()(viskores::Id outputId) const
+  {
+    return outputId % this->NumberOfIdsPerPlane;
+  }
+};
+
+template <typename SweepFunctor>
+class OrientExtrudedTriangleConnectivity : public viskores::worklet::WorkletMapField
+{
+public:
+  using ControlSignature = void(FieldIn baseConnectivity,
+                                WholeArrayIn baseCoordinates,
+                                FieldOut output);
+  using ExecutionSignature = void(_1, _2, _3);
+
+  VISKORES_CONT
+  explicit OrientExtrudedTriangleConnectivity(SweepFunctor sweep)
+    : Sweep(sweep)
+  {
+  }
+
+  template <typename ConnectivityType, typename CoordinatePortalType>
+  VISKORES_EXEC void operator()(const ConnectivityType& baseConnectivity,
+                                const CoordinatePortalType& baseCoordinates,
+                                viskores::Id3& output) const
+  {
+    using CoordinateType = typename CoordinatePortalType::ValueType;
+    using ComponentType = typename CoordinateType::ComponentType;
+
+    const viskores::Id pointId0 = baseConnectivity[0];
+    const viskores::Id pointId1 = baseConnectivity[1];
+    const viskores::Id pointId2 = baseConnectivity[2];
+
+    const viskores::Vec<ComponentType, 3> point0 = baseCoordinates.Get(pointId0);
+    const viskores::Vec<ComponentType, 3> point1 = baseCoordinates.Get(pointId1);
+    const viskores::Vec<ComponentType, 3> point2 = baseCoordinates.Get(pointId2);
+
+    const viskores::Vec<ComponentType, 3> normal =
+      viskores::Cross(point1 - point0, point2 - point0);
+    const viskores::Vec<ComponentType, 3> sweep = this->Sweep(point0, point1, point2);
+    const bool flip = viskores::Dot(normal, sweep) < ComponentType{ 0 };
+
+    output[0] = pointId0;
+    output[1] = flip ? pointId2 : pointId1;
+    output[2] = flip ? pointId1 : pointId2;
+  }
+
+private:
+  SweepFunctor Sweep;
+};
+
+// The extrusion filters generate each plane with the same point ordering, so
+// explicit output uses identity point correspondence between adjacent planes.
+class ExtrudedCellSetToExplicitWedgeConnectivity : public viskores::worklet::WorkletMapField
+{
+public:
+  using ControlSignature = void(FieldIn flatConnectivityId,
+                                WholeArrayIn baseConnectivity,
+                                FieldOut output);
+  using ExecutionSignature = void(_1, _2, _3);
+
+  VISKORES_CONT
+  ExtrudedCellSetToExplicitWedgeConnectivity(viskores::Id numberOfCellsPerPlane,
+                                             viskores::Id numberOfPointsPerPlane,
+                                             viskores::Id numberOfPlanes)
+    : NumberOfCellsPerPlane(numberOfCellsPerPlane)
+    , NumberOfPointsPerPlane(numberOfPointsPerPlane)
+    , NumberOfPlanes(numberOfPlanes)
+  {
+  }
+
+  template <typename ConnectivityPortalType>
+  VISKORES_EXEC void operator()(viskores::Id flatConnectivityId,
+                                const ConnectivityPortalType& baseConnectivity,
+                                viskores::Id& output) const
+  {
+    const viskores::Id cellId = flatConnectivityId / 6;
+    const viskores::Id localPointId = flatConnectivityId % 6;
+    const viskores::Id triangleId = cellId % this->NumberOfCellsPerPlane;
+    const viskores::Id plane0 = cellId / this->NumberOfCellsPerPlane;
+    const viskores::Id plane1 = (plane0 < (this->NumberOfPlanes - 1)) ? (plane0 + 1) : 0;
+    const viskores::Id basePointId = baseConnectivity.Get((triangleId * 3) + (localPointId % 3));
+
+    output = (localPointId < 3) ? ((plane0 * this->NumberOfPointsPerPlane) + basePointId)
+                                : ((plane1 * this->NumberOfPointsPerPlane) + basePointId);
+  }
+
+private:
+  viskores::Id NumberOfCellsPerPlane;
+  viskores::Id NumberOfPointsPerPlane;
+  viskores::Id NumberOfPlanes;
+};
+
+}
+} // namespace viskores::worklet
+
+#endif // viskores_worklet_Extrusion_h

--- a/viskores/filter/geometry_refinement/worklet/ExtrusionLinear.h
+++ b/viskores/filter/geometry_refinement/worklet/ExtrusionLinear.h
@@ -1,0 +1,93 @@
+//============================================================================
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//============================================================================
+
+#ifndef viskores_worklet_ExtrusionLinear_h
+#define viskores_worklet_ExtrusionLinear_h
+
+#include <viskores/Math.h>
+#include <viskores/filter/geometry_refinement/worklet/Extrusion.h>
+#include <viskores/worklet/WorkletMapField.h>
+
+namespace viskores
+{
+namespace worklet
+{
+
+class ExtrusionLinearSweep
+{
+public:
+  VISKORES_CONT
+  explicit ExtrusionLinearSweep(viskores::Vec3f sweep)
+    : Sweep(sweep)
+  {
+  }
+
+  template <typename ComponentType>
+  VISKORES_EXEC viskores::Vec<ComponentType, 3> operator()(
+    const viskores::Vec<ComponentType, 3>&,
+    const viskores::Vec<ComponentType, 3>&,
+    const viskores::Vec<ComponentType, 3>&) const
+  {
+    return viskores::Vec<ComponentType, 3>(static_cast<ComponentType>(this->Sweep[0]),
+                                           static_cast<ComponentType>(this->Sweep[1]),
+                                           static_cast<ComponentType>(this->Sweep[2]));
+  }
+
+private:
+  viskores::Vec3f Sweep;
+};
+
+class ExtrusionLinearCoordinates : public viskores::worklet::WorkletMapField
+{
+public:
+  using ControlSignature = void(FieldIn flatPointId, WholeArrayIn baseCoordinates, FieldOut output);
+  using ExecutionSignature = void(_1, _2, _3);
+
+  VISKORES_CONT
+  ExtrusionLinearCoordinates(viskores::Vec3f direction,
+                             viskores::FloatDefault distance,
+                             viskores::Id numberOfPlanes,
+                             viskores::Id numberOfPointsPerPlane)
+    : Direction(direction)
+    , Distance(distance)
+    , NumberOfPlanes(numberOfPlanes)
+    , NumberOfPointsPerPlane(numberOfPointsPerPlane)
+  {
+  }
+
+  template <typename CoordinatePortalType, typename OutputPointType>
+  VISKORES_EXEC void operator()(viskores::Id flatPointId,
+                                const CoordinatePortalType& baseCoordinates,
+                                OutputPointType& output) const
+  {
+    using ComponentType = typename OutputPointType::ComponentType;
+
+    const viskores::Id pointInPlane = flatPointId % this->NumberOfPointsPerPlane;
+    const viskores::Id planeIndex = flatPointId / this->NumberOfPointsPerPlane;
+    const ComponentType denominator = static_cast<ComponentType>(this->NumberOfPlanes - 1);
+    const ComponentType distance = static_cast<ComponentType>(this->Distance) *
+      static_cast<ComponentType>(planeIndex) / denominator;
+
+    const viskores::Vec<ComponentType, 3> direction(static_cast<ComponentType>(this->Direction[0]),
+                                                    static_cast<ComponentType>(this->Direction[1]),
+                                                    static_cast<ComponentType>(this->Direction[2]));
+    const viskores::Vec<ComponentType, 3> point = baseCoordinates.Get(pointInPlane);
+
+    output = point + (direction * distance);
+  }
+
+private:
+  viskores::Vec3f Direction;
+  viskores::FloatDefault Distance;
+  viskores::Id NumberOfPlanes;
+  viskores::Id NumberOfPointsPerPlane;
+};
+}
+} // namespace viskores::worklet
+
+#endif // viskores_worklet_ExtrusionLinear_h

--- a/viskores/filter/geometry_refinement/worklet/ExtrusionRotational.h
+++ b/viskores/filter/geometry_refinement/worklet/ExtrusionRotational.h
@@ -1,0 +1,133 @@
+//============================================================================
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//============================================================================
+
+#ifndef viskores_worklet_ExtrusionRotational_h
+#define viskores_worklet_ExtrusionRotational_h
+
+#include <viskores/Math.h>
+#include <viskores/filter/geometry_refinement/worklet/Extrusion.h>
+#include <viskores/worklet/WorkletMapField.h>
+
+namespace viskores
+{
+namespace worklet
+{
+
+class ExtrusionRotationalSweep
+{
+public:
+  VISKORES_CONT
+  ExtrusionRotationalSweep(viskores::Vec3f_64 axis,
+                           viskores::Vec3f_64 center,
+                           viskores::Float64 cosStep,
+                           viskores::Float64 sinStep)
+    : Axis(axis)
+    , Center(center)
+    , CosStep(cosStep)
+    , SinStep(sinStep)
+  {
+  }
+
+  template <typename ComponentType>
+  VISKORES_EXEC viskores::Vec<ComponentType, 3> operator()(
+    const viskores::Vec<ComponentType, 3>& point0,
+    const viskores::Vec<ComponentType, 3>& point1,
+    const viskores::Vec<ComponentType, 3>& point2) const
+  {
+    const viskores::Vec<ComponentType, 3> axis(static_cast<ComponentType>(this->Axis[0]),
+                                               static_cast<ComponentType>(this->Axis[1]),
+                                               static_cast<ComponentType>(this->Axis[2]));
+    const viskores::Vec<ComponentType, 3> center(static_cast<ComponentType>(this->Center[0]),
+                                                 static_cast<ComponentType>(this->Center[1]),
+                                                 static_cast<ComponentType>(this->Center[2]));
+
+    const viskores::Vec<ComponentType, 3> centroid =
+      (point0 + point1 + point2) / static_cast<ComponentType>(3);
+    const viskores::Vec<ComponentType, 3> shifted = centroid - center;
+    const viskores::Vec<ComponentType, 3> parallel = viskores::Dot(axis, shifted) * axis;
+    const viskores::Vec<ComponentType, 3> perpendicular = shifted - parallel;
+    const viskores::Vec<ComponentType, 3> nextPerpendicular =
+      (perpendicular * static_cast<ComponentType>(this->CosStep)) +
+      (viskores::Cross(axis, perpendicular) * static_cast<ComponentType>(this->SinStep));
+
+    return nextPerpendicular - perpendicular;
+  }
+
+private:
+  viskores::Vec3f_64 Axis;
+  viskores::Vec3f_64 Center;
+  viskores::Float64 CosStep;
+  viskores::Float64 SinStep;
+};
+
+class ExtrusionRotationalCoordinates : public viskores::worklet::WorkletMapField
+{
+public:
+  using ControlSignature = void(FieldIn flatPointId, WholeArrayIn baseCoordinates, FieldOut output);
+  using ExecutionSignature = void(_1, _2, _3);
+
+  VISKORES_CONT
+  ExtrusionRotationalCoordinates(viskores::Vec3f_64 axis,
+                                 viskores::Vec3f_64 center,
+                                 viskores::FloatDefault sweepAngle,
+                                 viskores::Id numberOfPlanes,
+                                 viskores::Id numberOfPointsPerPlane,
+                                 bool periodic)
+    : Axis(axis)
+    , Center(center)
+    , SweepAngle(sweepAngle)
+    , NumberOfPlanes(numberOfPlanes)
+    , NumberOfPointsPerPlane(numberOfPointsPerPlane)
+    , Periodic(periodic)
+  {
+  }
+
+  template <typename CoordinatePortalType, typename OutputPointType>
+  VISKORES_EXEC void operator()(viskores::Id flatPointId,
+                                const CoordinatePortalType& baseCoordinates,
+                                OutputPointType& output) const
+  {
+    using ComponentType = typename OutputPointType::ComponentType;
+
+    const viskores::Id pointInPlane = flatPointId % this->NumberOfPointsPerPlane;
+    const viskores::Id planeIndex = flatPointId / this->NumberOfPointsPerPlane;
+    const ComponentType denominator = static_cast<ComponentType>(
+      this->Periodic ? this->NumberOfPlanes : (this->NumberOfPlanes - 1));
+    const ComponentType theta = static_cast<ComponentType>(this->SweepAngle) *
+      static_cast<ComponentType>(planeIndex) / denominator;
+
+    const viskores::Vec<ComponentType, 3> axis(static_cast<ComponentType>(this->Axis[0]),
+                                               static_cast<ComponentType>(this->Axis[1]),
+                                               static_cast<ComponentType>(this->Axis[2]));
+    const viskores::Vec<ComponentType, 3> center(static_cast<ComponentType>(this->Center[0]),
+                                                 static_cast<ComponentType>(this->Center[1]),
+                                                 static_cast<ComponentType>(this->Center[2]));
+
+    const viskores::Vec<ComponentType, 3> point = baseCoordinates.Get(pointInPlane);
+    const viskores::Vec<ComponentType, 3> shifted = point - center;
+    const viskores::Vec<ComponentType, 3> parallel = viskores::Dot(axis, shifted) * axis;
+    const viskores::Vec<ComponentType, 3> perpendicular = shifted - parallel;
+    const viskores::Vec<ComponentType, 3> rotated = center + parallel +
+      (perpendicular * viskores::Cos(theta)) +
+      (viskores::Cross(axis, perpendicular) * viskores::Sin(theta));
+
+    output = rotated;
+  }
+
+private:
+  viskores::Vec3f_64 Axis;
+  viskores::Vec3f_64 Center;
+  viskores::FloatDefault SweepAngle;
+  viskores::Id NumberOfPlanes;
+  viskores::Id NumberOfPointsPerPlane;
+  bool Periodic;
+};
+}
+} // namespace viskores::worklet
+
+#endif // viskores_worklet_ExtrusionRotational_h


### PR DESCRIPTION
This branch adds `LinearExtrusion` and `RotationalExtrusion` filters to `viskores::filter::geometry_refinement`. (as requested in https://github.com/Viskores/viskores/issues/331 ) 

Both filters sweep a triangulated 2D profile into wedge cells. The shared `AbstractExtrusion` implementation handles input validation, optional triangulation, compact or explicit output topology, and point/cell field mapping. Its implementation lives in `AbstractExtrusion.hxx`. Separate worklets generate the linear and rotational coordinates. 

For now, this assumes triangle cells as extrusion profiles, but I think this can be extended to other cell types with minimal changes. 

`LinearExtrusion` translates the profile along a direction for a specific distance. `RotationalExtrusion` revolves the profile around an axis with configurable center, sweep angle, and behavior for closed-sweep (connecting ending plane with the starting plane). Full `2*pi` rotational sweeps default to closed unless explicitly overridden.

This also adds unit coverage for both extrusion filters and a changelog note.

Full test suites passed. 

🤖 Assisted by OpenAI Codex