### PR TITLE
Merge Monte Carlo and closed form codes - ContourUncertainUniform uncertainty filter

### DIFF
--- a/viskores/filter/uncertainty/ContourUncertainUniform.h
+++ b/viskores/filter/uncertainty/ContourUncertainUniform.h
@@ -25,6 +25,7 @@
 //  Athawale, T. M., Sane, S., & Johnson, C. R. (2021, October). Uncertainty
 //  Visualization of the Marching Squares and Marching Cubes Topology Cases.
 //  In 2021 IEEE Visualization Conference (VIS) (pp. 106-110). IEEE.
+//  Plan: Merge to ContourUncertainMonteCarlo
 
 #ifndef viskores_filter_uncertainty_ContourUncertainUniform_h
 #define viskores_filter_uncertainty_ContourUncertainUniform_h


### PR DESCRIPTION
Merge Monte Carlo and closed form codes for isosurface uncertainty visualization using the uniform noise model. The filter name is ContourUncertainUniform.