### PR TITLE
Fix compile issues with Cuda

### DIFF
--- a/docs/changelog/cuda-13-3.md
+++ b/docs/changelog/cuda-13-3.md
@@ -1,4 +1,4 @@
-## Fix compile issues with Thrust
+## Fix compile issues with CUDA
 
 CUDA 13.3 updated the Thrust library to version 3.3. This version changed the
 use of an internal `is_commutative` traits class that Viskores specialized to
@@ -9,3 +9,10 @@ Thrust moved to using the more general `cuda::is_commutative_v`, and Viskores
 has followed by overloading this particular trait instead. As this class is no
 longer marked as internal, hopefully it will be more stable across CUDA/Thrust
 versions.
+
+CUDA also changed how it handles visibility. Previous to CUDA 11, the nvcc
+compiler did not support the `__attribute__((visibility("default")))` symbol
+modifier. CUDA now does support this modifier, and with the most recent versions
+it is important to add the default visibility to prevent symbols from being
+hidden. Viskores now checks against the CUDA version to ensure that the proper
+attribute (or lack thereof) is used for `VISKORES_ALWAYS_EXPORT`.

--- a/docs/changelog/cuda-13-3.md
+++ b/docs/changelog/cuda-13-3.md
@@ -1,0 +1,11 @@
+## Fix compile issues with Thrust
+
+CUDA 13.3 updated the Thrust library to version 3.3. This version changed the
+use of an internal `is_commutative` traits class that Viskores specialized to
+engage optimized paths of several algorithms. Viskore's use of this no longer
+existing internal class caused compile errors.
+
+Thrust moved to using the more general `cuda::is_commutative_v`, and Viskores
+has followed by overloading this particular trait instead. As this class is no
+longer marked as internal, hopefully it will be more stable across CUDA/Thrust
+versions.

--- a/viskores/Pair.h
+++ b/viskores/Pair.h
@@ -34,7 +34,7 @@ namespace viskores
 /// only in the control environment).
 ///
 template <typename T1, typename T2>
-struct Pair
+struct VISKORES_ALWAYS_EXPORT Pair
 {
   /// The type of the first object.
   ///

--- a/viskores/exec/cuda/internal/WrappedOperators.h
+++ b/viskores/exec/cuda/internal/WrappedOperators.h
@@ -33,6 +33,9 @@ VISKORES_THIRDPARTY_POST_INCLUDE
 #if THRUST_VERSION >= 200500
 #include <cuda/std/type_traits>
 #endif
+#if THRUST_VERSION >= 300300
+#include <cuda/functional>
+#endif
 
 namespace viskores
 {
@@ -199,29 +202,39 @@ struct WrappedBinaryPredicate
 }
 } //namespace viskores::exec::cuda::internal
 
+//
+// We tell Thrust/CUDA that our WrappedBinaryOperator is commutative so that we
+// activate fast paths which are only available when the binary functor is
+// commutative and the T type is is_arithmetic.
+//
+//
+#if THRUST_VERSION >= 300300
+namespace cuda
+{
+template <typename T, typename F>
+inline constexpr bool
+  is_commutative_v<::viskores::exec::cuda::internal::WrappedBinaryOperator<T, F>, T> =
+    ::cuda::std::is_arithmetic<T>::value;
+}
+#else // THRUST_VERSION < 300300
 VISKORES_THRUST_NAMESPACE_BEGIN
 namespace detail
 {
-//
-// We tell Thrust that our WrappedBinaryOperator is commutative so that we
-// activate numerous fast paths inside thrust which are only available when
-// the binary functor is commutative and the T type is is_arithmetic
-//
-//
 #if THRUST_VERSION >= 200500
 template <typename T, typename F>
 struct is_commutative<viskores::exec::cuda::internal::WrappedBinaryOperator<T, F>>
   : public ::cuda::std::is_arithmetic<T>
 {
 };
-#else
+#else  // THRUST_VERSION < 200500
 template <typename T, typename F>
 struct is_commutative<viskores::exec::cuda::internal::WrappedBinaryOperator<T, F>>
   : public ::thrust::detail::is_arithmetic<T>
 {
 };
-#endif
+#endif // THRUST_VERSION < 200500
 }
 VISKORES_THRUST_NAMESPACE_END //namespace thrust::detail
+#endif // THRUST_VERSION < 300300
 
 #endif //viskores_exec_cuda_internal_WrappedOperators_h

--- a/viskores/internal/ExportMacros.h
+++ b/viskores/internal/ExportMacros.h
@@ -33,6 +33,8 @@
 
 #elif defined(VISKORES_CUDA)
 
+#include <cuda.h>
+
 #define VISKORES_EXEC __device__ __host__
 #define VISKORES_EXEC_CONT __device__ __host__
 
@@ -84,7 +86,7 @@
 //
 // Solution:
 // The solution is fairly simple, but annoying. You need to mark every single
-// header only class that is tempgit lated on non value types to be marked as
+// header only class that is templated on non value types to be marked as
 // always exported ( or never pass fvisibility=hidden ).
 //
 // TL;DR:
@@ -93,8 +95,17 @@
 //    resolve to a single type instance
 //  - Be a type ( or component of a types signature ) that can be passed between
 //    dynamic libraries and requires RTTI support ( dynamic_cast ).
-#if defined(VISKORES_MSVC) || defined(VISKORES_CUDA) || defined(VISKORES_DOXYGEN_ONLY)
+#if defined(VISKORES_MSVC) || defined(VISKORES_DOXYGEN_ONLY)
 #define VISKORES_ALWAYS_EXPORT
+#define VISKORES_NEVER_EXPORT
+#elif defined(VISKORES_CUDA)
+// Before CUDA 11.0, the visibility attribute was not supported. Later version
+// require declaring the visibility for exported symbols, but not hidden symbols.
+#if CUDA_VERSION >= 11000
+#define VISKORES_ALWAYS_EXPORT __attribute__((visibility("default")))
+#else
+#define VISKORES_ALWAYS_EXPORT
+#endif
 #define VISKORES_NEVER_EXPORT
 #else
 #define VISKORES_ALWAYS_EXPORT __attribute__((visibility("default")))


### PR DESCRIPTION
## Summary

CUDA 13.3 updates Thrust such that the internal `thrust::detail::is_commutative` trait Viskores specialized is no longer available. This updates the wrapped CUDA binary operator compatibility code to use `cuda::is_commutative_v` for newer Thrust/CCCL versions while keeping the older Thrust specialization for versions that still define it.

This also adds a changelog entry for the CUDA 13.3 compatibility fix.

## Root Cause

The CUDA/Thrust fast-path hook used by `WrappedBinaryOperator` moved away from the old internal `thrust::detail::is_commutative` trait. Specializing that removed trait causes compile failures with the CUDA 13.3-era Thrust headers.

## Validation

- Built the local non-CUDA debug tree successfully with:
  `cmake --build build/Debug --target all -- -j2`
- Ran focused syntax probes against downloaded CCCL 3.2.1 and 3.4.0 headers for the old and new trait forms.

Note: the local `build/Debug` configuration has `Viskores_ENABLE_CUDA=OFF`, so CUDA-enabled CI should exercise the actual CUDA path.