### PR TITLE
Fix rendering issue with viewport changes - backport v12

### DIFF
--- a/docs/changelog/viewport-change.md
+++ b/docs/changelog/viewport-change.md
@@ -1,0 +1,5 @@
+## Fixed rendering issue with viewport changes
+
+Viskores had an issue with setting the viewport properly when not in 3D camera
+mode. The camera now properly resizes the viewport when using 2D camera
+projections.

--- a/viskores/rendering/Camera.cxx
+++ b/viskores/rendering/Camera.cxx
@@ -378,8 +378,9 @@ viskores::rendering::raytracing::Camera Camera::CreateRaytracingCamera(viskores:
   rayCamera.SetIsOrthogonalProjection(this->GetMode() == Mode::TwoD);
   rayCamera.SetCamera3D(this->Camera3D);
   rayCamera.SetCamera2D(this->Camera2D);
-  rayCamera.SetViewport(
-    this->ViewportLeft, this->ViewportRight, this->ViewportBottom, this->ViewportTop);
+  viskores::Float32 left, right, bottom, top;
+  this->GetRealViewport(width, height, left, right, bottom, top);
+  rayCamera.SetViewport(left, right, bottom, top);
   return rayCamera;
 }
 


### PR DESCRIPTION
Viskores had an issue with setting the viewport properly when not in 3D camera mode. The camera now properly resizes the viewport when using 2D camera projections.