### PR TITLE
Use a global histogram for partitioned HistSampling

### DIFF
--- a/docs/changelog/hist-sampling-global-histogram.md
+++ b/docs/changelog/hist-sampling-global-histogram.md
@@ -1,0 +1,5 @@
+## Use a global histogram for partitioned histogram sampling
+
+`HistSampling` now builds one histogram across all partitions and MPI ranks when run on a
+`PartitionedDataSet`. Sampling probabilities therefore reflect global value frequencies instead
+of treating each partition independently.

--- a/docs/users-guide/provided-filters.rst
+++ b/docs/users-guide/provided-filters.rst
@@ -1144,6 +1144,7 @@ Histogram Sampling
 
 The :class:`viskores::filter::resampling::HistSampling` filter randomly samples the points of an input data set.
 The sampling is random but adaptive to preserve rare field value points.
+For a :class:`viskores::cont::PartitionedDataSet`, the histogram includes all partitions and MPI ranks.
 
 .. doxygenclass:: viskores::filter::resampling::HistSampling
    :members:

--- a/viskores/filter/resampling/HistSampling.cxx
+++ b/viskores/filter/resampling/HistSampling.cxx
@@ -70,18 +70,23 @@ viskores::cont::ArrayHandle<viskores::FloatDefault> CalculatPdf(
 
 viskores::cont::DataSet HistSampling::DoExecute(const viskores::cont::DataSet& input)
 {
-  //computing histogram based on input
-  viskores::filter::density_estimate::Histogram histogram;
-  histogram.SetNumberOfBins(this->NumberOfBins);
-  histogram.SetActiveField(this->GetActiveFieldName());
-  auto histogramOutput = histogram.Execute(input);
-  viskores::cont::ArrayHandle<viskores::Id> binCountArray;
-  viskores::cont::ArrayCopyShallowIfPossible(
-    histogramOutput.GetField(histogram.GetOutputFieldName()).GetData(), binCountArray);
-  viskores::Id totalPoints = input.GetNumberOfPoints();
-  //computing pdf
-  viskores::cont::ArrayHandle<viskores::FloatDefault> probArray;
-  probArray = CalculatPdf(totalPoints, this->SampleFraction, binCountArray);
+  if (!this->InExecutePartitions)
+  {
+    //computing histogram based on input
+    viskores::filter::density_estimate::Histogram histogram;
+    histogram.SetNumberOfBins(this->NumberOfBins);
+    histogram.SetActiveField(this->GetActiveFieldName(), this->GetActiveFieldAssociation());
+    auto histogramOutput = histogram.Execute(input);
+    viskores::cont::ArrayHandle<viskores::Id> binCountArray;
+    viskores::cont::ArrayCopyShallowIfPossible(
+      histogramOutput.GetField(histogram.GetOutputFieldName()).GetData(), binCountArray);
+    viskores::Id totalPoints = input.GetNumberOfPoints();
+    //computing pdf
+    this->Probabilities = CalculatPdf(totalPoints, this->SampleFraction, binCountArray);
+    this->HistogramMinimum = histogram.GetComputedRange().Min;
+    this->HistogramBinDelta = histogram.GetBinDelta();
+  }
+
   // use the acceptance probabilities and random array to create 0-1 array
   // generating random array between 0 to 1
   viskores::cont::ArrayHandle<viskores::Int8> outputArray;
@@ -92,8 +97,8 @@ viskores::cont::DataSet HistSampling::DoExecute(const viskores::cont::DataSet& i
       NumFieldValues, { this->GetSeed() });
     viskores::worklet::DispatcherMapField<viskores::worklet::LookupWorklet>(
       viskores::worklet::LookupWorklet{
-        this->NumberOfBins, histogram.GetComputedRange().Min, histogram.GetBinDelta() })
-      .Invoke(concrete, outputArray, probArray, randArray);
+        this->NumberOfBins, this->HistogramMinimum, this->HistogramBinDelta })
+      .Invoke(concrete, outputArray, this->Probabilities, randArray);
   };
   const auto& inField = this->GetFieldFromDataSet(input);
   this->CastAndCallScalarField(inField, resolveType);
@@ -106,7 +111,49 @@ viskores::cont::DataSet HistSampling::DoExecute(const viskores::cont::DataSet& i
   threshold.SetThresholdAbove(0.5);
   // filter out the results with zero in it
   viskores::cont::DataSet thresholdDataSet = threshold.Execute(sampledDataSet);
+  if (!this->InExecutePartitions)
+  {
+    this->Probabilities.ReleaseResources();
+  }
   return thresholdDataSet;
+}
+
+viskores::cont::PartitionedDataSet HistSampling::DoExecutePartitions(
+  const viskores::cont::PartitionedDataSet& input)
+{
+  if (input.GetGlobalNumberOfPartitions() == 0)
+  {
+    return this->Filter::DoExecutePartitions(input);
+  }
+
+  this->PreExecute(input);
+  auto result = this->Filter::DoExecutePartitions(input);
+  this->PostExecute();
+  return result;
+}
+
+void HistSampling::PreExecute(const viskores::cont::PartitionedDataSet& input)
+{
+  viskores::filter::density_estimate::Histogram histogram;
+  histogram.SetNumberOfBins(this->NumberOfBins);
+  histogram.SetActiveField(this->GetActiveFieldName(), this->GetActiveFieldAssociation());
+  auto histogramOutput = histogram.Execute(input);
+
+  viskores::cont::ArrayHandle<viskores::Id> binCountArray;
+  viskores::cont::ArrayCopyShallowIfPossible(
+    histogramOutput.GetPartition(0).GetField(histogram.GetOutputFieldName()).GetData(),
+    binCountArray);
+  viskores::Id totalPoints = viskores::cont::Algorithm::Reduce(binCountArray, viskores::Id{ 0 });
+  this->Probabilities = CalculatPdf(totalPoints, this->SampleFraction, binCountArray);
+  this->HistogramMinimum = histogram.GetComputedRange().Min;
+  this->HistogramBinDelta = histogram.GetBinDelta();
+  this->InExecutePartitions = true;
+}
+
+void HistSampling::PostExecute()
+{
+  this->InExecutePartitions = false;
+  this->Probabilities.ReleaseResources();
 }
 
 } // namespace resampling

--- a/viskores/filter/resampling/HistSampling.h
+++ b/viskores/filter/resampling/HistSampling.h
@@ -13,6 +13,7 @@
 #include <viskores/filter/resampling/viskores_filter_resampling_export.h>
 
 #include <viskores/Deprecated.h>
+#include <viskores/cont/ArrayHandle.h>
 
 namespace viskores
 {
@@ -33,6 +34,9 @@ namespace resampling
 /// for Large-scale Simulation Data Summarization" by Biswas, Dutta, Pulido, and Ahrens
 /// as published in _In Situ Infrastructures for Enabling Extreme-scale Analysis and
 /// Visualization_ (ISAV 2018).
+///
+/// When the input is a `viskores::cont::PartitionedDataSet`, the histogram includes
+/// all partitions and MPI ranks.
 ///
 /// The cell set of the input data is removed and replaced with a set with a vertex
 /// cell for each point. This effectively converts the data to a point cloud.
@@ -83,9 +87,19 @@ public:
 
 private:
   VISKORES_CONT viskores::cont::DataSet DoExecute(const viskores::cont::DataSet& input) override;
+  VISKORES_CONT viskores::cont::PartitionedDataSet DoExecutePartitions(
+    const viskores::cont::PartitionedDataSet& input) override;
+
+  VISKORES_CONT void PreExecute(const viskores::cont::PartitionedDataSet& input);
+  VISKORES_CONT void PostExecute();
+
   viskores::Id NumberOfBins = 10;
   viskores::FloatDefault SampleFraction = 0.1f;
   viskores::UInt32 Seed = 0;
+  viskores::cont::ArrayHandle<viskores::FloatDefault> Probabilities;
+  viskores::Float64 HistogramMinimum = 0;
+  viskores::Float64 HistogramBinDelta = 0;
+  bool InExecutePartitions = false;
 };
 
 } // namespace resampling

--- a/viskores/filter/resampling/testing/CMakeLists.txt
+++ b/viskores/filter/resampling/testing/CMakeLists.txt
@@ -12,14 +12,29 @@ set(unit_tests
 set(unit_tests_device
   UnitTestHistSampling.cxx
   )
+set(testing_headers
+  TestingHistSampling.h
+  )
+
+set_source_files_properties(${testing_headers} PROPERTIES NOT_A_TEST TRUE)
 
 set(libraries
   viskores_filter_resampling
   )
 
 viskores_unit_tests(
-  SOURCES ${unit_tests}
+  SOURCES ${unit_tests} ${testing_headers}
   DEVICE_SOURCES ${unit_tests_device}
   LIBRARIES ${libraries}
   USE_VISKORES_JOB_POOL
 )
+
+if (Viskores_ENABLE_MPI)
+  viskores_unit_tests(
+    MPI
+    SOURCES ${testing_headers}
+    DEVICE_SOURCES UnitTestHistSamplingMPI.cxx
+    LIBRARIES ${libraries}
+    USE_VISKORES_JOB_POOL
+  )
+endif()

--- a/viskores/filter/resampling/testing/TestingHistSampling.h
+++ b/viskores/filter/resampling/testing/TestingHistSampling.h
@@ -1,0 +1,63 @@
+//============================================================================
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//============================================================================
+
+#ifndef viskores_filter_resampling_testing_TestingHistSampling_h
+#define viskores_filter_resampling_testing_TestingHistSampling_h
+
+#include <viskores/CellShape.h>
+#include <viskores/cont/ArrayHandle.h>
+#include <viskores/cont/ArrayHandleCounting.h>
+#include <viskores/cont/DataSetBuilderExplicit.h>
+
+#include <vector>
+
+namespace viskores
+{
+namespace filter
+{
+namespace resampling
+{
+namespace testing
+{
+
+inline VISKORES_CONT viskores::cont::DataSet MakePointCloudPartition(viskores::Id numberOfPoints,
+                                                                     viskores::Id numberOfZeros,
+                                                                     viskores::Id pointIdOffset)
+{
+  std::vector<viskores::Vec3f> coordinates(static_cast<std::size_t>(numberOfPoints));
+  std::vector<viskores::Id> connectivity(static_cast<std::size_t>(numberOfPoints));
+  for (viskores::Id index = 0; index < numberOfPoints; ++index)
+  {
+    coordinates[static_cast<std::size_t>(index)] =
+      viskores::Vec3f{ static_cast<viskores::FloatDefault>(index), 0.0f, 0.0f };
+    connectivity[static_cast<std::size_t>(index)] = index;
+  }
+  auto dataSet = viskores::cont::DataSetBuilderExplicit::Create(
+    coordinates, viskores::CellShapeTagVertex{}, 1, connectivity);
+
+  viskores::cont::ArrayHandle<viskores::FloatDefault> scalarArray;
+  scalarArray.AllocateAndFill(numberOfPoints, 1.0f);
+  auto scalarPortal = scalarArray.WritePortal();
+  for (viskores::Id index = 0; index < numberOfZeros; ++index)
+  {
+    scalarPortal.Set(index, 0.0f);
+  }
+  dataSet.AddPointField("scalarField", scalarArray);
+
+  dataSet.AddPointField(
+    "pointId",
+    viskores::cont::make_ArrayHandleCounting(pointIdOffset, viskores::Id{ 1 }, numberOfPoints));
+  return dataSet;
+}
+
+} // namespace testing
+} // namespace resampling
+} // namespace filter
+} // namespace viskores
+
+#endif // viskores_filter_resampling_testing_TestingHistSampling_h

--- a/viskores/filter/resampling/testing/UnitTestHistSampling.cxx
+++ b/viskores/filter/resampling/testing/UnitTestHistSampling.cxx
@@ -7,12 +7,15 @@
 //============================================================================
 
 #include <viskores/cont/ArrayCopy.h>
+#include <viskores/cont/ArrayHandleCounting.h>
 #include <viskores/cont/DataSet.h>
 #include <viskores/cont/DataSetBuilderUniform.h>
 #include <viskores/cont/Invoker.h>
+#include <viskores/cont/PartitionedDataSet.h>
 #include <viskores/cont/testing/Testing.h>
 #include <viskores/filter/entity_extraction/ThresholdPoints.h>
 #include <viskores/filter/resampling/HistSampling.h>
+#include <viskores/filter/resampling/testing/TestingHistSampling.h>
 #include <viskores/worklet/WorkletMapField.h>
 namespace
 {
@@ -79,9 +82,52 @@ void TestHistSamplingSingleBlock()
   VISKORES_TEST_ASSERT(thresholdDataSet.GetField("scalarField").GetNumberOfValues() == 7);
 }
 
+void TestHistSamplingPartitionedDataSetUsesGlobalHistogram(bool runMultiThreaded)
+{
+  // Zeros dominate the first partition but are globally rare, so all nine must be retained.
+  viskores::cont::PartitionedDataSet input;
+  input.AppendPartition(viskores::filter::resampling::testing::MakePointCloudPartition(10, 9, 0));
+  input.AppendPartition(viskores::filter::resampling::testing::MakePointCloudPartition(90, 0, 10));
+
+  viskores::filter::resampling::HistSampling histSample;
+  histSample.SetNumberOfBins(2);
+  histSample.SetSampleFraction(0.2f);
+  histSample.SetActiveField("scalarField", viskores::cont::Field::Association::Points);
+  histSample.SetThreadsPerCPU(2);
+  histSample.SetRunMultiThreadedFilter(runMultiThreaded);
+  auto output = histSample.Execute(input);
+
+  VISKORES_TEST_ASSERT(output.GetNumberOfPartitions() == 2);
+  const auto& firstPartition = output.GetPartition(0);
+  viskores::filter::entity_extraction::ThresholdPoints selectGloballyRareValues;
+  selectGloballyRareValues.SetActiveField("scalarField");
+  selectGloballyRareValues.SetCompactPoints(true);
+  selectGloballyRareValues.SetThresholdBelow(0.5);
+  auto globallyRareValues = selectGloballyRareValues.Execute(firstPartition);
+
+  VISKORES_TEST_ASSERT(
+    test_equal_ArrayHandles(globallyRareValues.GetField("pointId").GetData(),
+                            viskores::cont::make_ArrayHandleCounting(
+                              viskores::Id{ 0 }, viskores::Id{ 1 }, viskores::Id{ 9 })));
+}
+
+void TestHistSamplingEmptyPartitionedDataSet()
+{
+  viskores::cont::PartitionedDataSet input;
+
+  viskores::filter::resampling::HistSampling histSample;
+  histSample.SetActiveField("scalarField", viskores::cont::Field::Association::Points);
+  auto output = histSample.Execute(input);
+
+  VISKORES_TEST_ASSERT(output.GetNumberOfPartitions() == 0);
+}
+
 void TestHistSampling()
 {
   TestHistSamplingSingleBlock();
+  TestHistSamplingPartitionedDataSetUsesGlobalHistogram(false);
+  TestHistSamplingPartitionedDataSetUsesGlobalHistogram(true);
+  TestHistSamplingEmptyPartitionedDataSet();
 } // TestHistSampling
 
 }

--- a/viskores/filter/resampling/testing/UnitTestHistSamplingMPI.cxx
+++ b/viskores/filter/resampling/testing/UnitTestHistSamplingMPI.cxx
@@ -1,0 +1,83 @@
+//============================================================================
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//============================================================================
+
+#include <viskores/cont/ArrayHandleCounting.h>
+#include <viskores/cont/EnvironmentTracker.h>
+#include <viskores/cont/PartitionedDataSet.h>
+#include <viskores/cont/testing/Testing.h>
+#include <viskores/filter/entity_extraction/ThresholdPoints.h>
+#include <viskores/filter/resampling/HistSampling.h>
+#include <viskores/filter/resampling/testing/TestingHistSampling.h>
+#include <viskores/thirdparty/diy/environment.h>
+
+namespace
+{
+
+void TestHistSamplingUsesGlobalHistogramAcrossRanks()
+{
+  auto communicator = viskores::cont::EnvironmentTracker::GetCommunicator();
+  viskores::cont::PartitionedDataSet input;
+
+  if (communicator.rank() == 0)
+  {
+    input.AppendPartition(viskores::filter::resampling::testing::MakePointCloudPartition(10, 9, 0));
+  }
+
+  if (communicator.size() == 1 || communicator.rank() == 1)
+  {
+    input.AppendPartition(
+      viskores::filter::resampling::testing::MakePointCloudPartition(90, 0, 10));
+  }
+
+  viskores::filter::resampling::HistSampling histSample;
+  histSample.SetNumberOfBins(2);
+  histSample.SetSampleFraction(0.2f);
+  histSample.SetActiveField("scalarField", viskores::cont::Field::Association::Points);
+  auto output = histSample.Execute(input);
+  VISKORES_TEST_ASSERT(output.GetNumberOfPartitions() == input.GetNumberOfPartitions());
+
+  if (communicator.rank() == 0)
+  {
+    const auto& sampledPartition = output.GetPartition(0);
+    viskores::filter::entity_extraction::ThresholdPoints selectGloballyRareValues;
+    selectGloballyRareValues.SetActiveField("scalarField");
+    selectGloballyRareValues.SetCompactPoints(true);
+    selectGloballyRareValues.SetThresholdBelow(0.5);
+    auto globallyRareValues = selectGloballyRareValues.Execute(sampledPartition);
+
+    VISKORES_TEST_ASSERT(
+      test_equal_ArrayHandles(globallyRareValues.GetField("pointId").GetData(),
+                              viskores::cont::make_ArrayHandleCounting(
+                                viskores::Id{ 0 }, viskores::Id{ 1 }, viskores::Id{ 9 })));
+  }
+}
+
+void TestHistSamplingGloballyEmptyInput()
+{
+  viskores::cont::PartitionedDataSet input;
+
+  viskores::filter::resampling::HistSampling histSample;
+  histSample.SetActiveField("scalarField", viskores::cont::Field::Association::Points);
+  auto output = histSample.Execute(input);
+
+  VISKORES_TEST_ASSERT(output.GetNumberOfPartitions() == 0);
+}
+
+void TestHistSamplingMPI()
+{
+  TestHistSamplingUsesGlobalHistogramAcrossRanks();
+  TestHistSamplingGloballyEmptyInput();
+}
+
+} // anonymous namespace
+
+int UnitTestHistSamplingMPI(int argc, char* argv[])
+{
+  viskoresdiy::mpi::environment environment(argc, argv);
+  return viskores::cont::testing::Testing::Run(TestHistSamplingMPI, argc, argv);
+}


### PR DESCRIPTION
This addresses #374.

### Summary

- Compute one histogram across all partitions and MPI ranks before applying `HistSampling`.
- Reuse the base partition scheduler when applying the shared sampling probabilities.
- Preserve empty `PartitionedDataSet` behavior, including ranks with no local partitions.
- Document the global partitioned behavior and add local, threaded, empty-input, and MPI coverage.

### Implementation

`HistSampling::DoExecutePartitions` now builds a distributed histogram, derives one acceptance-probability array from its global bin counts, and delegates partition processing to the base filter machinery.

A collective partition-count check returns early only when the input is empty across every rank. A rank with no local partitions therefore still participates in the histogram collectives when another rank has data. This adds one scalar all-reduce per partitioned execution in MPI builds, separate from the existing global range and histogram reductions.

Single-`DataSet` behavior is unchanged.

### Testing

- `UnitTestHistSampling`, including partition-independent rarity, threaded execution, and empty input
- `UnitTestHistSamplingMPI` with three ranks, including uneven partition distribution, a rank with no local partitions, and globally empty input
- 100 repeated serial-device threaded runs and 20 repeated three-rank MPI runs on a compute node
