### PR TITLE
Fix ANARI loaded-device lifetime

### DIFF
--- a/docs/changelog/anari-loaded-device-lifetime.md
+++ b/docs/changelog/anari-loaded-device-lifetime.md
@@ -1,0 +1,23 @@
+## Keep dynamically loaded ANARI devices valid
+
+`viskores::interop::anari::ANARILoadDevice` now returns a move-only
+`ANARILoadedDevice` owner instead of a raw `anari_cpp::Device`. The owner keeps
+the dynamic ANARI library loaded for the lifetime of its device, then releases
+the device before unloading the library.
+
+Keep the returned owner alive while using its raw device handle:
+
+```cpp
+auto loadedDevice = viskores::interop::anari::ANARILoadDevice("helide");
+if (loadedDevice)
+{
+  auto device = loadedDevice.GetDevice();
+  // Use device, releasing all objects before loadedDevice is destroyed.
+}
+```
+
+Code using the previous return type must retain the `ANARILoadedDevice`, call
+`GetDevice()` when a raw handle is needed, and stop releasing the device
+directly. An implicit conversion to a raw handle is intentionally unavailable:
+such a conversion would allow a temporary owner to unload the library while
+the raw handle remains in use.

--- a/viskores/interop/anari/ANARILoadDevice.cxx
+++ b/viskores/interop/anari/ANARILoadDevice.cxx
@@ -12,6 +12,8 @@
 
 #include <viskores/rendering/anari-device/ViskoresDevice.h>
 
+#include <utility>
+
 namespace
 {
 
@@ -57,14 +59,67 @@ namespace interop
 namespace anari
 {
 
-anari_cpp::Device ANARILoadDevice(const std::string& libraryName)
+ANARILoadedDevice::ANARILoadedDevice(anari_cpp::Library library, anari_cpp::Device device) noexcept
+  : LibraryHandle(library)
+  , DeviceHandle(device)
+{
+}
+
+ANARILoadedDevice::~ANARILoadedDevice()
+{
+  this->Reset();
+}
+
+ANARILoadedDevice::ANARILoadedDevice(ANARILoadedDevice&& other) noexcept
+  : LibraryHandle(std::exchange(other.LibraryHandle, nullptr))
+  , DeviceHandle(std::exchange(other.DeviceHandle, nullptr))
+{
+}
+
+ANARILoadedDevice& ANARILoadedDevice::operator=(ANARILoadedDevice&& other) noexcept
+{
+  if (this != &other)
+  {
+    this->Reset();
+    this->LibraryHandle = std::exchange(other.LibraryHandle, nullptr);
+    this->DeviceHandle = std::exchange(other.DeviceHandle, nullptr);
+  }
+  return *this;
+}
+
+ANARILoadedDevice::operator bool() const noexcept
+{
+  return this->DeviceHandle != nullptr;
+}
+
+anari_cpp::Device ANARILoadedDevice::GetDevice() const noexcept
+{
+  return this->DeviceHandle;
+}
+
+void ANARILoadedDevice::Reset() noexcept
+{
+  if (this->DeviceHandle != nullptr)
+  {
+    anari_cpp::release(this->DeviceHandle, this->DeviceHandle);
+    this->DeviceHandle = nullptr;
+  }
+  if (this->LibraryHandle != nullptr)
+  {
+    anari_cpp::unloadLibrary(this->LibraryHandle);
+    this->LibraryHandle = nullptr;
+  }
+}
+
+ANARILoadedDevice ANARILoadDevice(const std::string& libraryName)
 {
   if (libraryName == "viskores")
   {
     VISKORES_LOG_F(viskores::cont::LogLevel::Info,
                    "Directly loading internal ANARI device named `viskores`");
-    return reinterpret_cast<anari_cpp::Device>(
+    auto device = reinterpret_cast<anari_cpp::Device>(
       new viskores_device::ViskoresDevice(AnariStatusFunc, nullptr));
+    return ANARILoadedDevice(nullptr, device);
   }
   else
   {
@@ -76,16 +131,17 @@ anari_cpp::Device ANARILoadDevice(const std::string& libraryName)
     {
       VISKORES_LOG_S(viskores::cont::LogLevel::Info,
                      "Failed to load ANARI library named `" << libraryName << "`");
-      return nullptr;
+      return {};
     }
     anari_cpp::Device device = anari_cpp::newDevice(library, "default");
-    anari_cpp::unloadLibrary(library);
     if (device == nullptr)
     {
       VISKORES_LOG_S(viskores::cont::LogLevel::Info,
                      "Failed to load ANARI device from library named `" << libraryName << "`");
+      anari_cpp::unloadLibrary(library);
+      return {};
     }
-    return device;
+    return ANARILoadedDevice(library, device);
   }
 }
 

--- a/viskores/interop/anari/ANARILoadDevice.h
+++ b/viskores/interop/anari/ANARILoadDevice.h
@@ -12,6 +12,8 @@
 #include <viskores/interop/anari/ViskoresANARITypes.h>
 #include <viskores/interop/anari/viskores_anari_export.h>
 
+#include <string>
+
 namespace viskores
 {
 namespace interop
@@ -19,14 +21,17 @@ namespace interop
 namespace anari
 {
 
+class ANARILoadedDevice;
+
 /// @brief Loads an ANARI device from the library of the provided name.
 ///
 /// Given the name of an ANARI device library, attempts to find the associated
 /// library (named `anari_library_` plus the provided `libraryName` with the
 /// standard shared object library prefix and extension for the current system),
-/// opens it, and returns an ANARI device object. This is a convenience function
-/// that essentially uses `anari::loadLibrary` to open the library and
-/// `anari::newDevice` to create the device.
+/// opens it, and returns an object that owns both the ANARI device and its
+/// library. This is a convenience function that essentially uses
+/// `anari::loadLibrary` to open the library and `anari::newDevice` to create
+/// the device.
 ///
 /// An additional feature of this method is that if you provide the string
 /// `viskores` for `libraryName`, this function will be able to load the device
@@ -40,9 +45,51 @@ namespace anari
 /// so the ANARI logging can be controlled through Viskores' configuration.
 ///
 /// @param libraryName The name of the library to load.
-/// @return An open ANARI device or `nullptr` if the library cannot be opened.
-VISKORES_ANARI_EXPORT VISKORES_CONT anari_cpp::Device ANARILoadDevice(
-  const std::string& libraryName);
+/// @return An owning loaded device, or an invalid object if the library or
+/// device cannot be opened.
+VISKORES_ANARI_EXPORT VISKORES_CONT ANARILoadedDevice
+ANARILoadDevice(const std::string& libraryName);
+
+/// @brief Owns an ANARI device and the library from which it was loaded.
+///
+/// This move-only object releases its device before unloading the associated
+/// dynamic library. The raw device returned by `GetDevice` is valid only while
+/// this object remains alive. All objects and additional retained references
+/// associated with the raw device must be released before this object.
+class VISKORES_ANARI_EXPORT ANARILoadedDevice
+{
+public:
+  /// Creates an invalid loaded device.
+  VISKORES_CONT ANARILoadedDevice() noexcept = default;
+
+  /// Releases the device, then unloads its dynamic library, if any.
+  VISKORES_CONT ~ANARILoadedDevice();
+
+  /// Loaded devices cannot be copied because they uniquely own their handles.
+  ANARILoadedDevice(const ANARILoadedDevice&) = delete;
+  ANARILoadedDevice& operator=(const ANARILoadedDevice&) = delete;
+
+  /// Transfers ownership from another loaded device.
+  VISKORES_CONT ANARILoadedDevice(ANARILoadedDevice&& other) noexcept;
+
+  /// Releases current ownership and transfers ownership from another loaded device.
+  VISKORES_CONT ANARILoadedDevice& operator=(ANARILoadedDevice&& other) noexcept;
+
+  /// Returns whether this object owns a valid ANARI device.
+  VISKORES_CONT explicit operator bool() const noexcept;
+
+  /// Returns the non-owning raw ANARI device handle.
+  VISKORES_CONT anari_cpp::Device GetDevice() const noexcept;
+
+private:
+  friend ANARILoadedDevice ANARILoadDevice(const std::string& libraryName);
+
+  VISKORES_CONT ANARILoadedDevice(anari_cpp::Library library, anari_cpp::Device device) noexcept;
+  VISKORES_CONT void Reset() noexcept;
+
+  anari_cpp::Library LibraryHandle = nullptr;
+  anari_cpp::Device DeviceHandle = nullptr;
+};
 
 }
 }

--- a/viskores/interop/anari/testing/ANARITestCommon.h
+++ b/viskores/interop/anari/testing/ANARITestCommon.h
@@ -49,7 +49,7 @@ static void setColorMap(anari_cpp::Device d, viskores::interop::anari::ANARIMapp
   mapper.SetANARIColorMapOpacityScale(0.5f);
 }
 
-static anari_cpp::Device loadANARIDevice()
+static viskores::interop::anari::ANARILoadedDevice loadANARIDevice()
 {
   viskores::testing::FloatingPointExceptionTrapDisable();
   auto* libraryName = std::getenv("VISKORES_TEST_ANARI_LIBRARY");

--- a/viskores/interop/anari/testing/CMakeLists.txt
+++ b/viskores/interop/anari/testing/CMakeLists.txt
@@ -18,6 +18,7 @@
 
 viskores_unit_tests(
 SOURCES
+  UnitTestANARILoadDevice.cxx
   UnitTestANARIMapperGlyphs.cxx
   UnitTestANARIMapperPoints.cxx
   UnitTestANARIMapperTriangles.cxx

--- a/viskores/interop/anari/testing/UnitTestANARIGeometryCylinder.cxx
+++ b/viskores/interop/anari/testing/UnitTestANARIGeometryCylinder.cxx
@@ -19,7 +19,8 @@ void RenderTests()
 {
   // Initialize ANARI /////////////////////////////////////////////////////////
 
-  auto d = loadANARIDevice();
+  auto loadedDevice = loadANARIDevice();
+  auto d = loadedDevice.GetDevice();
 
   const char** extensions = nullptr;
   anariGetProperty(d, d, "extension", ANARI_STRING_LIST, &extensions, sizeof(char**), ANARI_WAIT);
@@ -128,7 +129,6 @@ void RenderTests()
   // Cleanup //////////////////////////////////////////////////////////////////
 
   anari_cpp::release(d, world);
-  anari_cpp::release(d, d);
 }
 
 } // namespace

--- a/viskores/interop/anari/testing/UnitTestANARIGeometryQuad.cxx
+++ b/viskores/interop/anari/testing/UnitTestANARIGeometryQuad.cxx
@@ -19,7 +19,8 @@ void RenderTests()
 {
   // Initialize ANARI /////////////////////////////////////////////////////////
 
-  auto d = loadANARIDevice();
+  auto loadedDevice = loadANARIDevice();
+  auto d = loadedDevice.GetDevice();
 
   // Create ANARI quad geometry //////////////////////////////////////////////
 
@@ -110,7 +111,6 @@ void RenderTests()
   // Cleanup //////////////////////////////////////////////////////////////////
 
   anari_cpp::release(d, world);
-  anari_cpp::release(d, d);
 }
 
 } // namespace

--- a/viskores/interop/anari/testing/UnitTestANARIGeometrySphere.cxx
+++ b/viskores/interop/anari/testing/UnitTestANARIGeometrySphere.cxx
@@ -139,7 +139,8 @@ void RenderTests()
 {
   // Initialize ANARI /////////////////////////////////////////////////////////
 
-  auto d = loadANARIDevice();
+  auto loadedDevice = loadANARIDevice();
+  auto d = loadedDevice.GetDevice();
 
   const char** extensions = nullptr;
   anariGetProperty(d, d, "extension", ANARI_STRING_LIST, &extensions, sizeof(char**), ANARI_WAIT);
@@ -181,10 +182,6 @@ void RenderTests()
                        "interop/anari/sphere-unindexed.png",
                        viskores::Vec2ui_32(512, 512));
   anari_cpp::release(d, unindexedWorld);
-
-  // Cleanup //////////////////////////////////////////////////////////////////
-
-  anari_cpp::release(d, d);
 }
 
 } // namespace

--- a/viskores/interop/anari/testing/UnitTestANARILoadDevice.cxx
+++ b/viskores/interop/anari/testing/UnitTestANARILoadDevice.cxx
@@ -1,0 +1,46 @@
+//============================================================================
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//============================================================================
+
+#include <viskores/interop/anari/ANARILoadDevice.h>
+
+#include <viskores/testing/Testing.h>
+
+#include <cstdlib>
+#include <string>
+
+namespace
+{
+
+void TestANARILoadDeviceLifetime()
+{
+  const char* libraryName = std::getenv("VISKORES_TEST_ANARI_LIBRARY");
+  if ((libraryName == nullptr) || (std::string(libraryName) == "viskores"))
+  {
+    VISKORES_TEST_SKIP("Set VISKORES_TEST_ANARI_LIBRARY to the name of an external ANARI library.");
+  }
+
+  auto loadedDevice = viskores::interop::anari::ANARILoadDevice(libraryName);
+  VISKORES_TEST_ASSERT(static_cast<bool>(loadedDevice),
+                       "Failed to load the requested external ANARI device.");
+
+  auto device = loadedDevice.GetDevice();
+  viskores::Int32 version = -1;
+  VISKORES_TEST_ASSERT(anari_cpp::getProperty(device, device, "version", version),
+                       "Failed to query the loaded ANARI device.");
+
+  auto world = anari_cpp::newObject<anari_cpp::World>(device);
+  VISKORES_TEST_ASSERT(world != nullptr, "Failed to create an object on the loaded ANARI device.");
+  anari_cpp::release(device, world);
+}
+
+} // anonymous namespace
+
+int UnitTestANARILoadDevice(int argc, char* argv[])
+{
+  return viskores::testing::Testing::Run(TestANARILoadDeviceLifetime, argc, argv);
+}

--- a/viskores/interop/anari/testing/UnitTestANARIMapperGlyphs.cxx
+++ b/viskores/interop/anari/testing/UnitTestANARIMapperGlyphs.cxx
@@ -36,7 +36,8 @@ void RenderTests()
 {
   // Initialize ANARI /////////////////////////////////////////////////////////
 
-  auto d = loadANARIDevice();
+  auto loadedDevice = loadANARIDevice();
+  auto d = loadedDevice.GetDevice();
 
   // Check for the KHR_GEOMETRY_CONE extension.
 
@@ -92,7 +93,6 @@ void RenderTests()
   // Cleanup //////////////////////////////////////////////////////////////////
 
   anari_cpp::release(d, world);
-  anari_cpp::release(d, d);
 }
 
 } // namespace

--- a/viskores/interop/anari/testing/UnitTestANARIMapperPoints.cxx
+++ b/viskores/interop/anari/testing/UnitTestANARIMapperPoints.cxx
@@ -36,7 +36,8 @@ void RenderTests()
 {
   // Initialize ANARI /////////////////////////////////////////////////////////
 
-  auto d = loadANARIDevice();
+  auto loadedDevice = loadANARIDevice();
+  auto d = loadedDevice.GetDevice();
 
   // Create Viskores datasets /////////////////////////////////////////////////////
 
@@ -81,7 +82,6 @@ void RenderTests()
   // Cleanup //////////////////////////////////////////////////////////////////
 
   anari_cpp::release(d, world);
-  anari_cpp::release(d, d);
 }
 
 } // namespace

--- a/viskores/interop/anari/testing/UnitTestANARIMapperTriangles.cxx
+++ b/viskores/interop/anari/testing/UnitTestANARIMapperTriangles.cxx
@@ -36,7 +36,8 @@ void RenderTests()
 {
   // Initialize ANARI /////////////////////////////////////////////////////////
 
-  auto d = loadANARIDevice();
+  auto loadedDevice = loadANARIDevice();
+  auto d = loadedDevice.GetDevice();
 
   // Create Viskores datasets /////////////////////////////////////////////////////
 
@@ -82,7 +83,6 @@ void RenderTests()
   // Cleanup //////////////////////////////////////////////////////////////////
 
   anari_cpp::release(d, world);
-  anari_cpp::release(d, d);
 }
 
 } // namespace

--- a/viskores/interop/anari/testing/UnitTestANARIMapperVolume.cxx
+++ b/viskores/interop/anari/testing/UnitTestANARIMapperVolume.cxx
@@ -36,7 +36,8 @@ void RenderTests()
 {
   // Initialize ANARI /////////////////////////////////////////////////////////
 
-  auto d = loadANARIDevice();
+  auto loadedDevice = loadANARIDevice();
+  auto d = loadedDevice.GetDevice();
 
   // Create Viskores datasets /////////////////////////////////////////////////////
 
@@ -71,7 +72,6 @@ void RenderTests()
   // Cleanup //////////////////////////////////////////////////////////////////
 
   anari_cpp::release(d, world);
-  anari_cpp::release(d, d);
 }
 
 } // namespace

--- a/viskores/interop/anari/testing/UnitTestANARIScene.cxx
+++ b/viskores/interop/anari/testing/UnitTestANARIScene.cxx
@@ -40,7 +40,8 @@ void RenderTests()
 {
   // Initialize ANARI /////////////////////////////////////////////////////////
 
-  auto d = loadANARIDevice();
+  auto loadedDevice = loadANARIDevice();
+  auto d = loadedDevice.GetDevice();
 
   // Create Viskores datasets /////////////////////////////////////////////////////
 
@@ -104,10 +105,6 @@ void RenderTests()
                        viskores::Vec3f_32(0.32, -0.53, -0.79),
                        viskores::Vec3f_32(-0.20, -0.85, 0.49),
                        "interop/anari/scene.png");
-
-  // Cleanup //////////////////////////////////////////////////////////////////
-
-  anari_cpp::release(d, d);
 }
 
 } // namespace


### PR DESCRIPTION
Keep dynamically loaded libraries alive in a move-only owner until the owned device is released. The previous loader unloaded the module before returning its device, leaving the live handle backed by an unloaded implementation.

Update ANARI test callers and add an optional real-backend lifetime regression.