### PR TITLE
Support decreasing rectilinear coordinate axes

### DIFF
--- a/docs/changelog/rectilinear-coordinate-monotonicity.md
+++ b/docs/changelog/rectilinear-coordinate-monotonicity.md
@@ -1,0 +1,5 @@
+## Support decreasing rectilinear coordinate axes
+
+Rectilinear cell location and spline evaluation now support strictly monotonic
+coordinate axes in either direction. Non-monotonic axes, including duplicate
+coordinates, are rejected with `ErrorBadValue`.

--- a/viskores/cont/ArrayIsMonotonic.cxx
+++ b/viskores/cont/ArrayIsMonotonic.cxx
@@ -22,6 +22,8 @@
 #include <viskores/cont/viskores_cont_export.h>
 #include <viskores/worklet/WorkletMapField.h>
 
+#include <viskores/BinaryOperators.h>
+
 namespace viskores
 {
 namespace cont
@@ -62,8 +64,8 @@ struct MonotonicDecreasing : public viskores::worklet::WorkletMapField
       result = input.Get(idx) <= input.Get(idx - 1);
   }
 };
-} //anonymous namespace
 
+} //anonymous namespace
 
 VISKORES_CONT_EXPORT
 bool ArrayIsMonotonicIncreasing(const viskores::cont::UnknownArrayHandle& input)

--- a/viskores/cont/CMakeLists.txt
+++ b/viskores/cont/CMakeLists.txt
@@ -216,6 +216,7 @@ set(device_sources
   ConvertNumComponentsToOffsets.cxx
   Field.cxx
   internal/ArrayCopyUnknown.cxx
+  internal/ArrayGetMonotonicity.cxx
   internal/ArrayRangeComputeUtils.cxx
   internal/Buffer.cxx
   internal/MapArrayPermutation.cxx

--- a/viskores/cont/CellLocatorRectilinearGrid.cxx
+++ b/viskores/cont/CellLocatorRectilinearGrid.cxx
@@ -20,6 +20,8 @@
 #include <viskores/cont/ArrayHandleCartesianProduct.h>
 #include <viskores/cont/CellLocatorRectilinearGrid.h>
 #include <viskores/cont/CellSetStructured.h>
+#include <viskores/cont/ErrorBadValue.h>
+#include <viskores/cont/internal/ArrayGetMonotonicity.h>
 
 #include <viskores/exec/CellLocatorRectilinearGrid.h>
 
@@ -35,6 +37,18 @@ void CellLocatorRectilinearGrid::Build()
 
   if (!coords.GetData().IsType<RectilinearType>())
     throw viskores::cont::ErrorBadType("Coordinates are not rectilinear type.");
+
+  RectilinearType rectilinearCoords = coords.GetData().AsArrayHandle<RectilinearType>();
+  using Monotonicity = viskores::cont::internal::ArrayMonotonicity;
+  if (viskores::cont::internal::ArrayGetStrictMonotonicity(rectilinearCoords.GetFirstArray()) ==
+        Monotonicity::NotMonotonic ||
+      viskores::cont::internal::ArrayGetStrictMonotonicity(rectilinearCoords.GetSecondArray()) ==
+        Monotonicity::NotMonotonic ||
+      viskores::cont::internal::ArrayGetStrictMonotonicity(rectilinearCoords.GetThirdArray()) ==
+        Monotonicity::NotMonotonic)
+  {
+    throw viskores::cont::ErrorBadValue("Rectilinear coordinate axes must be strictly monotonic.");
+  }
 
   if (cellSet.CanConvert<Structured2DType>())
   {

--- a/viskores/cont/CellLocatorRectilinearGrid.h
+++ b/viskores/cont/CellLocatorRectilinearGrid.h
@@ -33,6 +33,7 @@ namespace cont
 /// For this cell locator to work, it has to be given a cell set of type
 /// `viskores::cont::CellSetStructured` and a coordinate system using a
 /// `viskores::cont::ArrayHandleCartesianProduct` for its data.
+/// Each active coordinate axis must be strictly monotonic, either increasing or decreasing.
 class VISKORES_CONT_EXPORT CellLocatorRectilinearGrid : public viskores::cont::CellLocatorBase
 {
   using Structured2DType = viskores::cont::CellSetStructured<2>;

--- a/viskores/cont/SplineEvaluateRectilinearGrid.cxx
+++ b/viskores/cont/SplineEvaluateRectilinearGrid.cxx
@@ -17,9 +17,10 @@
 //============================================================================
 
 #include <viskores/cont/ArrayCopy.h>
-#include <viskores/cont/ArrayIsMonotonic.h>
 #include <viskores/cont/CellSetStructured.h>
+#include <viskores/cont/ErrorBadValue.h>
 #include <viskores/cont/SplineEvaluateRectilinearGrid.h>
+#include <viskores/cont/internal/ArrayGetMonotonicity.h>
 
 namespace viskores
 {
@@ -38,12 +39,15 @@ viskores::exec::SplineEvaluateRectilinearGrid SplineEvaluateRectilinearGrid::Pre
 
   viskores::cont::CoordinateSystem coordSystem = this->DataSet.GetCoordinateSystem();
   RectCoordsType coords = coordSystem.GetData().template AsArrayHandle<RectCoordsType>();
-  if (!viskores::cont::ArrayIsMonotonicIncreasing(coords.GetFirstArray()) ||
-      !viskores::cont::ArrayIsMonotonicIncreasing(coords.GetSecondArray()) ||
-      !viskores::cont::ArrayIsMonotonicIncreasing(coords.GetThirdArray()))
-
+  using Monotonicity = viskores::cont::internal::ArrayMonotonicity;
+  if (viskores::cont::internal::ArrayGetStrictMonotonicity(coords.GetFirstArray()) ==
+        Monotonicity::NotMonotonic ||
+      viskores::cont::internal::ArrayGetStrictMonotonicity(coords.GetSecondArray()) ==
+        Monotonicity::NotMonotonic ||
+      viskores::cont::internal::ArrayGetStrictMonotonicity(coords.GetThirdArray()) ==
+        Monotonicity::NotMonotonic)
   {
-    throw viskores::cont::ErrorBadType("Coordinates are not monotonic increasing.");
+    throw viskores::cont::ErrorBadValue("Rectilinear coordinate axes must be strictly monotonic.");
   }
 
   viskores::cont::ArrayHandle<viskores::FloatDefault> fieldArray;

--- a/viskores/cont/SplineEvaluateRectilinearGrid.h
+++ b/viskores/cont/SplineEvaluateRectilinearGrid.h
@@ -36,6 +36,7 @@ namespace cont
 /// means the data set must use `viskores::cont::ArrayHandleCartesianProduct` for its
 /// coordinate system. This evaluator will throw an error if the data set does not meet
 /// these requirements.
+/// Each active coordinate axis must be strictly monotonic, either increasing or decreasing.
 ///
 /// Right now, this evaluator only supports scalar fields on 3D uniform grids. The field to be
 /// evaluated is specified by name.

--- a/viskores/cont/internal/ArrayGetMonotonicity.cxx
+++ b/viskores/cont/internal/ArrayGetMonotonicity.cxx
@@ -1,0 +1,87 @@
+//============================================================================
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//============================================================================
+
+#include <viskores/cont/Algorithm.h>
+#include <viskores/cont/ArrayHandle.h>
+#include <viskores/cont/ErrorBadType.h>
+#include <viskores/cont/Invoker.h>
+#include <viskores/cont/UnknownArrayHandle.h>
+#include <viskores/cont/internal/ArrayGetMonotonicity.h>
+#include <viskores/worklet/WorkletMapField.h>
+
+#include <viskores/BinaryOperators.h>
+
+namespace viskores
+{
+namespace cont
+{
+
+namespace
+{
+
+struct StrictMonotonicity : public viskores::worklet::WorkletMapField
+{
+  using ControlSignature = void(WholeArrayIn, FieldOut);
+  using ExecutionSignature = void(InputIndex, _1, _2);
+
+  template <typename ArrayType>
+  VISKORES_EXEC void operator()(const viskores::Id& idx,
+                                const ArrayType& input,
+                                viskores::UInt8& result) const
+  {
+    // Bit 0 tracks increasing order; bit 1 tracks decreasing order.
+    if (idx == 0)
+      result = 0x3;
+    else if (input.Get(idx) > input.Get(idx - 1))
+      result = 0x1;
+    else if (input.Get(idx) < input.Get(idx - 1))
+      result = 0x2;
+    else
+      result = 0x0;
+  }
+};
+
+} // anonymous namespace
+
+namespace internal
+{
+
+VISKORES_CONT_EXPORT
+ArrayMonotonicity ArrayGetStrictMonotonicity(const viskores::cont::UnknownArrayHandle& input)
+{
+  if (input.GetNumberOfComponentsFlat() != 1)
+  {
+    throw viskores::cont::ErrorBadType(
+      "ArrayGetStrictMonotonicity only supported for scalar arrays.");
+  }
+
+  if (input.GetNumberOfValues() < 2)
+    return ArrayMonotonicity::Increasing;
+
+  viskores::cont::ArrayHandle<viskores::UInt8> result;
+  auto resolveType = [&](auto recombineVec)
+  {
+    VISKORES_ASSERT(recombineVec.GetNumberOfComponents() == 1);
+    auto componentArray = recombineVec.GetComponentArray(0);
+    viskores::cont::Invoker invoke;
+    invoke(StrictMonotonicity{}, componentArray, result);
+  };
+  input.CastAndCallWithExtractedArray(resolveType);
+
+  viskores::UInt8 monotonicity =
+    viskores::cont::Algorithm::Reduce(result, viskores::UInt8(0x3), viskores::BitwiseAnd{});
+  if (monotonicity == 0x1)
+    return ArrayMonotonicity::Increasing;
+  if (monotonicity == 0x2)
+    return ArrayMonotonicity::Decreasing;
+  return ArrayMonotonicity::NotMonotonic;
+}
+
+} // namespace internal
+} // namespace cont
+} // namespace viskores

--- a/viskores/cont/internal/ArrayGetMonotonicity.h
+++ b/viskores/cont/internal/ArrayGetMonotonicity.h
@@ -1,0 +1,41 @@
+//============================================================================
+//  The contents of this file are covered by the Viskores license. See
+//  LICENSE.txt for details.
+//
+//  By contributing to this file, all contributors agree to the Developer
+//  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+//============================================================================
+
+#ifndef viskores_cont_internal_ArrayGetMonotonicity_h
+#define viskores_cont_internal_ArrayGetMonotonicity_h
+
+#include <viskores/cont/viskores_cont_export.h>
+
+namespace viskores
+{
+namespace cont
+{
+
+class UnknownArrayHandle;
+
+namespace internal
+{
+
+enum class ArrayMonotonicity
+{
+  NotMonotonic,
+  Increasing,
+  Decreasing
+};
+
+/// Classifies an array as strictly increasing, strictly decreasing, or not monotonic.
+/// Repeated values and direction changes are not monotonic.
+/// Arrays with fewer than two values are classified as increasing.
+VISKORES_CONT_EXPORT ArrayMonotonicity
+ArrayGetStrictMonotonicity(const viskores::cont::UnknownArrayHandle& input);
+
+} // namespace internal
+} // namespace cont
+} // namespace viskores
+
+#endif // viskores_cont_internal_ArrayGetMonotonicity_h

--- a/viskores/cont/internal/CMakeLists.txt
+++ b/viskores/cont/internal/CMakeLists.txt
@@ -18,6 +18,7 @@
 
 set(headers
   ArrayCopyUnknown.h
+  ArrayGetMonotonicity.h
   ArrayHandleExecutionManager.h
   ArrayPortalFromIterators.h
   ArrayRangeComputeUtils.h

--- a/viskores/cont/testing/UnitTestCellLocatorRectilinearGrid.cxx
+++ b/viskores/cont/testing/UnitTestCellLocatorRectilinearGrid.cxx
@@ -22,6 +22,7 @@
 #include <viskores/cont/CellLocatorRectilinearGrid.h>
 #include <viskores/cont/DataSet.h>
 #include <viskores/cont/DataSetBuilderRectilinear.h>
+#include <viskores/cont/ErrorBadValue.h>
 #include <viskores/cont/Invoker.h>
 
 #include <viskores/cont/testing/Testing.h>
@@ -136,6 +137,26 @@ private:
   viskores::Id3 Dims;
 };
 
+class FindCellWorklet : public viskores::worklet::WorkletMapField
+{
+public:
+  using ControlSignature = void(FieldIn pointIn,
+                                ExecObject locator,
+                                FieldOut cellId,
+                                FieldOut parametric);
+  using ExecutionSignature = void(_1, _2, _3, _4);
+
+  template <typename PointType, typename LocatorType>
+  VISKORES_EXEC void operator()(const PointType& pointIn,
+                                const LocatorType& locator,
+                                viskores::Id& cellId,
+                                PointType& parametric) const
+  {
+    if (locator.FindCell(pointIn, cellId, parametric) != viskores::ErrorCode::Success)
+      cellId = -1;
+  }
+};
+
 void TestTest()
 {
   viskores::cont::Invoker invoke;
@@ -207,9 +228,111 @@ void TestTest()
   }
 }
 
+void TestMixedAxisDirections()
+{
+  std::vector<viskores::Float32> x = { 0.0f, 1.0f, 3.0f, 4.0f };
+  std::vector<viskores::Float32> y = { 4.0f, 2.0f, 0.0f };
+  std::vector<viskores::Float32> z = { 6.0f, 5.0f, 3.0f, 1.0f, 0.0f };
+  auto dataSet = viskores::cont::DataSetBuilderRectilinear::Create(x, y, z);
+
+  viskores::cont::CellLocatorRectilinearGrid locator;
+  locator.SetCoordinates(dataSet.GetCoordinateSystem());
+  locator.SetCellSet(dataSet.GetCellSet());
+
+  using PointType = viskores::Vec3f;
+  std::vector<PointType> pointsVector{ PointType{ 2.0f, 3.0f, 4.0f },
+                                       PointType{ 0.0f, 4.0f, 6.0f },
+                                       PointType{ 4.0f, 0.0f, 0.0f },
+                                       PointType{ 2.0f, 5.0f, 4.0f } };
+  auto points = viskores::cont::make_ArrayHandle(pointsVector, viskores::CopyFlag::Off);
+
+  viskores::cont::ArrayHandle<viskores::Id> cellIds;
+  viskores::cont::ArrayHandle<PointType> parametric;
+  viskores::cont::Invoker invoke;
+  invoke(FindCellWorklet{}, points, locator, cellIds, parametric);
+
+  auto cellIdsPortal = cellIds.ReadPortal();
+  auto parametricPortal = parametric.ReadPortal();
+  VISKORES_TEST_ASSERT(cellIdsPortal.Get(0) == 7);
+  VISKORES_TEST_ASSERT(test_equal(parametricPortal.Get(0), PointType(0.5f)));
+  VISKORES_TEST_ASSERT(cellIdsPortal.Get(1) == 0);
+  VISKORES_TEST_ASSERT(test_equal(parametricPortal.Get(1), PointType(0.0f)));
+  VISKORES_TEST_ASSERT(cellIdsPortal.Get(2) == 23);
+  VISKORES_TEST_ASSERT(test_equal(parametricPortal.Get(2), PointType(1.0f)));
+  VISKORES_TEST_ASSERT(cellIdsPortal.Get(3) == -1);
+}
+
+void TestMixedAxisDirections2D()
+{
+  std::vector<viskores::Float32> x = { 0.0f, 1.0f, 3.0f };
+  std::vector<viskores::Float32> y = { 4.0f, 2.0f, 0.0f };
+  auto dataSet = viskores::cont::DataSetBuilderRectilinear::Create(x, y);
+
+  viskores::cont::CellLocatorRectilinearGrid locator;
+  locator.SetCoordinates(dataSet.GetCoordinateSystem());
+  locator.SetCellSet(dataSet.GetCellSet());
+
+  using PointType = viskores::Vec3f;
+  std::vector<PointType> pointsVector{ PointType{ 2.0f, 3.0f, 0.0f },
+                                       PointType{ 3.0f, 0.0f, 0.0f },
+                                       PointType{ 2.0f, 5.0f, 0.0f } };
+  auto points = viskores::cont::make_ArrayHandle(pointsVector, viskores::CopyFlag::Off);
+
+  viskores::cont::ArrayHandle<viskores::Id> cellIds;
+  viskores::cont::ArrayHandle<PointType> parametric;
+  viskores::cont::Invoker invoke;
+  invoke(FindCellWorklet{}, points, locator, cellIds, parametric);
+
+  auto cellIdsPortal = cellIds.ReadPortal();
+  auto parametricPortal = parametric.ReadPortal();
+  VISKORES_TEST_ASSERT(cellIdsPortal.Get(0) == 1);
+  VISKORES_TEST_ASSERT(test_equal(parametricPortal.Get(0)[0], 0.5f));
+  VISKORES_TEST_ASSERT(test_equal(parametricPortal.Get(0)[1], 0.5f));
+  VISKORES_TEST_ASSERT(cellIdsPortal.Get(1) == 3);
+  VISKORES_TEST_ASSERT(test_equal(parametricPortal.Get(1)[0], 1.0f));
+  VISKORES_TEST_ASSERT(test_equal(parametricPortal.Get(1)[1], 1.0f));
+  VISKORES_TEST_ASSERT(cellIdsPortal.Get(2) == -1);
+}
+
+void TestInvalidAxes()
+{
+  auto checkInvalid = [](const std::vector<viskores::Float32>& x)
+  {
+    std::vector<viskores::Float32> y = { 0.0f, 1.0f, 2.0f };
+    std::vector<viskores::Float32> z = { 0.0f, 1.0f, 2.0f };
+    auto dataSet = viskores::cont::DataSetBuilderRectilinear::Create(x, y, z);
+
+    viskores::cont::CellLocatorRectilinearGrid locator;
+    locator.SetCoordinates(dataSet.GetCoordinateSystem());
+    locator.SetCellSet(dataSet.GetCellSet());
+
+    bool threw = false;
+    try
+    {
+      locator.Update();
+    }
+    catch (const viskores::cont::ErrorBadValue&)
+    {
+      threw = true;
+    }
+    VISKORES_TEST_ASSERT(threw, "Invalid rectilinear axis did not throw ErrorBadValue.");
+  };
+
+  checkInvalid({ 0.0f, 2.0f, 1.0f, 3.0f });
+  checkInvalid({ 0.0f, 1.0f, 1.0f, 2.0f });
+}
+
+void TestCellLocatorRectilinearGrid()
+{
+  TestTest();
+  TestMixedAxisDirections();
+  TestMixedAxisDirections2D();
+  TestInvalidAxes();
+}
+
 } // anonymous namespace
 
 int UnitTestCellLocatorRectilinearGrid(int argc, char* argv[])
 {
-  return viskores::cont::testing::Testing::Run(TestTest, argc, argv);
+  return viskores::cont::testing::Testing::Run(TestCellLocatorRectilinearGrid, argc, argv);
 }

--- a/viskores/cont/testing/UnitTestSplineEvaluate.cxx
+++ b/viskores/cont/testing/UnitTestSplineEvaluate.cxx
@@ -16,11 +16,13 @@
 //  PURPOSE.  See the above copyright notice for more information.
 //============================================================================
 
+#include <algorithm>
 #include <random>
 #include <string>
 
 #include <viskores/Math.h>
 #include <viskores/cont/DataSet.h>
+#include <viskores/cont/ErrorBadValue.h>
 #include <viskores/cont/Invoker.h>
 #include <viskores/cont/SplineEvaluateRectilinearGrid.h>
 #include <viskores/cont/SplineEvaluateUniformGrid.h>
@@ -180,6 +182,23 @@ std::vector<viskores::cont::DataSet> MakeRectDataSet3D(const std::vector<viskore
   return dataSets;
 }
 
+viskores::cont::DataSet MakeMixedDirectionRectDataSet3D(const viskores::Id3& dims)
+{
+  auto xcoords = fillCoords(dims[0], [](viskores::FloatDefault t) { return t * t; });
+  auto ycoords = fillCoordsExp(dims[1]);
+  auto zcoords =
+    fillCoords(dims[2], [](viskores::FloatDefault t) { return 1 - (1 - t) * (1 - t); });
+  std::reverse(xcoords.begin(), xcoords.end());
+  std::reverse(zcoords.begin(), zcoords.end());
+
+  auto dataSet = viskores::cont::DataSetBuilderRectilinear::Create(xcoords, ycoords, zcoords);
+  viskores::cont::ArrayHandle<viskores::FloatDefault> fieldArray;
+  viskores::cont::Invoker invoker;
+  invoker(GenerateData{}, dataSet.GetCoordinateSystem(), fieldArray);
+  dataSet.AddPointField("field", fieldArray);
+  return dataSet;
+}
+
 viskores::cont::ArrayHandle<viskores::FloatDefault> CreateLinearInterpolationResult(
   const viskores::cont::DataSet& ds,
   const viskores::cont::ArrayHandle<viskores::Vec3f>& points)
@@ -275,6 +294,7 @@ void DoSplineEvalTest()
 
   auto dsUniform = MakeDataSet3D(dims);
   auto dsRect = MakeRectDataSet3D(dims);
+  auto dsMixedDirection = MakeMixedDirectionRectDataSet3D({ 100, 100, 100 });
 
   // Compare spline to linear interpolation on 50 points.
   auto pointData = CreateRandomVec3f(50);
@@ -296,6 +316,8 @@ void DoSplineEvalTest()
     viskores::cont::SplineEvaluateRectilinearGrid evalRect(ds, "field");
     CompareToLinear(evalRect, pointData, expectedValues, ds);
   }
+  viskores::cont::SplineEvaluateRectilinearGrid evalMixedDirection(dsMixedDirection, "field");
+  CompareToLinear(evalMixedDirection, pointData, expectedValues, dsMixedDirection);
 
   //compare values for a few points.
   pointData = CreateRandomVec3f(10);
@@ -318,6 +340,31 @@ void DoSplineEvalTest()
     viskores::cont::SplineEvaluateRectilinearGrid evalRect(ds, "field");
     CompareResults(evalRect, pointData, expectedValues, 1e-3);
   }
+  CompareResults(evalMixedDirection, pointData, expectedValues, 1e-3);
+
+  auto invalidDataSet = MakeMixedDirectionRectDataSet3D({ 5, 5, 5 });
+  using RectilinearType = viskores::cont::ArrayHandleCartesianProduct<
+    viskores::cont::ArrayHandle<viskores::FloatDefault>,
+    viskores::cont::ArrayHandle<viskores::FloatDefault>,
+    viskores::cont::ArrayHandle<viskores::FloatDefault>>;
+  auto invalidCoords =
+    invalidDataSet.GetCoordinateSystem().GetData().AsArrayHandle<RectilinearType>();
+  auto invalidAxis = invalidCoords.GetFirstArray();
+  auto repeatedValue = invalidAxis.ReadPortal().Get(1);
+  invalidAxis.WritePortal().Set(2, repeatedValue);
+
+  bool threw = false;
+  try
+  {
+    viskores::cont::SplineEvaluateRectilinearGrid invalidEvaluator(invalidDataSet, "field");
+    viskores::cont::ArrayHandle<viskores::FloatDefault> results;
+    invoker(EvalWorklet{}, pointData, invalidEvaluator, results);
+  }
+  catch (const viskores::cont::ErrorBadValue&)
+  {
+    threw = true;
+  }
+  VISKORES_TEST_ASSERT(threw, "Repeated rectilinear coordinate did not throw ErrorBadValue.");
 }
 } // anonymous namespace
 

--- a/viskores/exec/CellLocatorRectilinearGrid.h
+++ b/viskores/exec/CellLocatorRectilinearGrid.h
@@ -84,17 +84,29 @@ public:
     auto coordsContPortal = coords.ReadPortal();
     RectilinearPortalType coordsExecPortal = coords.PrepareForInput(device, token);
     this->AxisPortals[0] = coordsExecPortal.GetFirstPortal();
-    this->MinPoint[0] = coordsContPortal.GetFirstPortal().Get(0);
-    this->MaxPoint[0] = coordsContPortal.GetFirstPortal().Get(this->PointDimensions[0] - 1);
+    auto firstPoint = coordsContPortal.GetFirstPortal().Get(0);
+    auto lastPoint = coordsContPortal.GetFirstPortal().Get(this->PointDimensions[0] - 1);
+    this->MinPoint[0] = firstPoint < lastPoint ? firstPoint : lastPoint;
+    this->MaxPoint[0] = firstPoint < lastPoint ? lastPoint : firstPoint;
+    this->LastPoint[0] = lastPoint;
+    this->AxisReversed[0] = lastPoint < firstPoint;
 
     this->AxisPortals[1] = coordsExecPortal.GetSecondPortal();
-    this->MinPoint[1] = coordsContPortal.GetSecondPortal().Get(0);
-    this->MaxPoint[1] = coordsContPortal.GetSecondPortal().Get(this->PointDimensions[1] - 1);
+    firstPoint = coordsContPortal.GetSecondPortal().Get(0);
+    lastPoint = coordsContPortal.GetSecondPortal().Get(this->PointDimensions[1] - 1);
+    this->MinPoint[1] = firstPoint < lastPoint ? firstPoint : lastPoint;
+    this->MaxPoint[1] = firstPoint < lastPoint ? lastPoint : firstPoint;
+    this->LastPoint[1] = lastPoint;
+    this->AxisReversed[1] = lastPoint < firstPoint;
     if (dimensions == 3)
     {
       this->AxisPortals[2] = coordsExecPortal.GetThirdPortal();
-      this->MinPoint[2] = coordsContPortal.GetThirdPortal().Get(0);
-      this->MaxPoint[2] = coordsContPortal.GetThirdPortal().Get(this->PointDimensions[2] - 1);
+      firstPoint = coordsContPortal.GetThirdPortal().Get(0);
+      lastPoint = coordsContPortal.GetThirdPortal().Get(this->PointDimensions[2] - 1);
+      this->MinPoint[2] = firstPoint < lastPoint ? firstPoint : lastPoint;
+      this->MaxPoint[2] = firstPoint < lastPoint ? lastPoint : firstPoint;
+      this->LastPoint[2] = lastPoint;
+      this->AxisReversed[2] = lastPoint < firstPoint;
     }
   }
 
@@ -231,11 +243,10 @@ private:
     for (viskores::Int32 dim = 0; dim < this->Dimensions; ++dim)
     {
       //
-      // When searching for points, we consider the max value of the cell
-      // to be apart of the next cell. If the point falls on the boundary of the
-      // data set, then it is technically inside a cell. This checks for that case
+      // Shared points belong to the next logical cell. The final grid point belongs
+      // to the last cell, so handle it explicitly.
       //
-      if (point[dim] == MaxPoint[dim])
+      if (point[dim] == this->LastPoint[dim])
       {
         logicalCell[dim] = this->PointDimensions[dim] - 2;
         if (parametric != nullptr)
@@ -251,7 +262,8 @@ private:
       {
         viskores::Id midIndex = (minIndex + maxIndex) / 2;
         viskores::FloatDefault midVal = this->AxisPortals[dim].Get(midIndex);
-        if (point[dim] <= midVal)
+        if ((!this->AxisReversed[dim] && point[dim] <= midVal) ||
+            (this->AxisReversed[dim] && point[dim] >= midVal))
         {
           maxIndex = midIndex;
           maxVal = midVal;
@@ -278,6 +290,8 @@ private:
   viskores::Id3 PointDimensions;
   viskores::Vec3f MinPoint;
   viskores::Vec3f MaxPoint;
+  viskores::Vec3f LastPoint;
+  bool AxisReversed[3];
   viskores::Id Dimensions;
 };
 } //namespace exec

--- a/viskores/exec/SplineEvaluateRectilinearGrid.h
+++ b/viskores/exec/SplineEvaluateRectilinearGrid.h
@@ -47,6 +47,7 @@ public:
     : Bounds(bounds)
     , Field(field.PrepareForInput(device, token))
   {
+    auto coordsControlPortal = rectCoords.ReadPortal();
     auto coordsExecPortal = rectCoords.PrepareForInput(device, token);
 
     this->AxisPortals[0] = coordsExecPortal.GetFirstPortal();
@@ -56,6 +57,13 @@ public:
     this->NumX = this->AxisPortals[0].GetNumberOfValues();
     this->NumY = this->AxisPortals[1].GetNumberOfValues();
     this->NumZ = this->AxisPortals[2].GetNumberOfValues();
+
+    this->AxisReversed[0] = coordsControlPortal.GetFirstPortal().Get(this->NumX - 1) <
+      coordsControlPortal.GetFirstPortal().Get(0);
+    this->AxisReversed[1] = coordsControlPortal.GetSecondPortal().Get(this->NumY - 1) <
+      coordsControlPortal.GetSecondPortal().Get(0);
+    this->AxisReversed[2] = coordsControlPortal.GetThirdPortal().Get(this->NumZ - 1) <
+      coordsControlPortal.GetThirdPortal().Get(0);
   }
 
   VISKORES_EXEC viskores::ErrorCode Evaluate(const viskores::Vec3f& point,
@@ -68,9 +76,12 @@ public:
     auto y = point[1];
     auto z = point[2];
 
-    viskores::Id iu = this->FindIndex(this->AxisPortals[0], this->NumX, point[0]);
-    viskores::Id iv = this->FindIndex(this->AxisPortals[1], this->NumY, point[1]);
-    viskores::Id iw = this->FindIndex(this->AxisPortals[2], this->NumZ, point[2]);
+    viskores::Id iu =
+      this->FindIndex(this->AxisPortals[0], this->NumX, point[0], this->AxisReversed[0]);
+    viskores::Id iv =
+      this->FindIndex(this->AxisPortals[1], this->NumY, point[1], this->AxisReversed[1]);
+    viskores::Id iw =
+      this->FindIndex(this->AxisPortals[2], this->NumZ, point[2], this->AxisReversed[2]);
 
     VISKORES_ASSERT(this->NumX >= 4 && this->NumY >= 4);
 
@@ -166,26 +177,27 @@ public:
 private:
   VISKORES_EXEC viskores::Id FindIndex(const AxisPortalType& axis,
                                        const viskores::Id& N,
-                                       viskores::FloatDefault val) const
+                                       viskores::FloatDefault val,
+                                       bool axisReversed) const
   {
-    // 1) Binary search for the largest index i with coords[i] <= val
+    // 1) Find the last logical index not past val in the axis direction.
     viskores::Id left = 0;
     viskores::Id right = N - 1;
     while (left <= right)
     {
       viskores::Id mid = left + (right - left) / 2;
-      if (axis.Get(mid) <= val)
+      if ((!axisReversed && axis.Get(mid) <= val) || (axisReversed && axis.Get(mid) >= val))
       {
-        // mid is still ≤ val, so it might be our i
+        // This coordinate is at or before val in the axis direction.
         left = mid + 1;
       }
       else
       {
-        // coords[mid] > val, so the index we want is below mid
+        // This coordinate is after val in the axis direction.
         right = mid - 1;
       }
     }
-    // when loop ends, `right` is the last index where coords[right] <= val
+    // `right` is the last logical index not past val.
     viskores::Id i = right;
 
     // 2) Clamp i into [1, N-3]
@@ -205,11 +217,11 @@ private:
                                                     viskores::FloatDefault p3,
                                                     viskores::FloatDefault x) const
   {
-    // 1) Compute interval lengths
+    // 1) Compute signed interval lengths
     viskores::FloatDefault h0 = x1 - x0;
     viskores::FloatDefault h1 = x2 - x1;
     viskores::FloatDefault h2 = x3 - x2;
-    VISKORES_ASSERT(h0 > 0.0f && h1 > 0.0f && h2 > 0.0f);
+    VISKORES_ASSERT((h0 > 0.0f && h1 > 0.0f && h2 > 0.0f) || (h0 < 0.0f && h1 < 0.0f && h2 < 0.0f));
 
 
     // 2) Compute right‐hand sides for second‐derivative system
@@ -249,6 +261,7 @@ private:
   viskores::Id NumX;
   viskores::Id NumY;
   viskores::Id NumZ;
+  bool AxisReversed[3];
 };
 } //namespace exec
 } //namespace viskores


### PR DESCRIPTION
Fixes #151 by supporting strictly monotonic decreasing axes in rectilinear coordinate systems.

- Updates CellLocatorRectilinearGrid to handle independently increasing or decreasing axes.
- Updates rectilinear spline evaluation to support decreasing axes.
- Rejects non-monotonic axes and duplicate coordinate values with ErrorBadValue.
- Adds mixed-direction 2D and 3D locator tests and decreasing-axis spline tests.
- Preserves the existing public monotonicity API behavior.