### PR TITLE
Remove special Hints.h declaration in CMake

### DIFF
--- a/viskores/cont/CMakeLists.txt
+++ b/viskores/cont/CMakeLists.txt
@@ -315,11 +315,6 @@ viskores_library( NAME viskores_cont
               DEVICE_SOURCES ${device_sources}
             )
 
-target_sources(viskores_cont
-  PRIVATE
-    internal/Hints.h
-)
-
 add_subdirectory(internal)
 add_subdirectory(arg)
 


### PR DESCRIPTION
For perhaps obsolete reasons, there was a special condition that added `viskores/cont/internal/Hints.h` as a source to the `viskores_cont` target. This is unnecessary and inconsistent with the rest of the headers in that directory.