### PR TITLE
Fix color range for ANARI sampler

### DIFF
--- a/docs/changelog/anari-color-range.md
+++ b/docs/changelog/anari-color-range.md
@@ -1,0 +1,11 @@
+## Fixed color range for ANARI sampler
+
+The ANARI device ignored the inTransform and inOffset parameters of the 1D
+sampler. Instead, it scaled the incoming field by its computed range. However,
+the ANARI device should rely on the the client to provide the proper transform
+for the colormap lookup.
+
+The device now does an inverse transform of the color range values 0 and 1 to
+use as the effective minimum and maximum of the field range. This replicates the
+scaling of the inTransform as long as it only transforms 1D values, which is all
+that is supported anyway.

--- a/viskores/rendering/anari-device/scene/surface/Surface.cpp
+++ b/viskores/rendering/anari-device/scene/surface/Surface.cpp
@@ -44,7 +44,29 @@ void Surface::finalize()
   }
 
   this->m_dataSet = this->m_geometry->getDataSet();
-  this->m_material->getColors(this->m_dataSet, this->m_field, this->m_colorMap);
+
+  Mat4f_32 inFieldTransform;
+  viskores::Vec4f_32 inFieldOffset;
+  this->m_material->getColors(
+    this->m_dataSet, this->m_field, this->m_colorMap, inFieldTransform, inFieldOffset);
+
+  bool inverseValid;
+  Mat4f_32 inverseTransform = viskores::MatrixInverse(inFieldTransform, inverseValid);
+
+  if (inverseValid)
+  {
+    auto transformRange = [&](viskores::Float32 x)
+    {
+      auto transformed = viskores::MatrixMultiply(inverseTransform, { x, 0, 0, 1 }) - inFieldOffset;
+      return transformed[0] / transformed[3];
+    };
+    this->m_fieldRange = { transformRange(0), transformRange(1) };
+  }
+  else
+  {
+    reportMessage(ANARI_SEVERITY_WARNING, "inTransform for sampler is not invertible");
+    this->m_fieldRange = { 0, 1 };
+  }
 }
 
 const Geometry* Surface::geometry() const
@@ -60,7 +82,7 @@ const Material* Surface::material() const
 void Surface::render(viskores::rendering::Canvas& canvas,
                      const viskores::rendering::Camera& camera) const
 {
-  this->m_geometry->render(canvas, camera, this->m_field, this->m_colorMap);
+  this->m_geometry->render(canvas, camera, this->m_field, this->m_colorMap, this->m_fieldRange);
 }
 
 viskores::Bounds Surface::bounds() const

--- a/viskores/rendering/anari-device/scene/surface/Surface.h
+++ b/viskores/rendering/anari-device/scene/surface/Surface.h
@@ -36,6 +36,8 @@ struct Surface : public Object
 
   viskores::Bounds bounds() const;
 
+  viskores::Range fieldRange() const { return this->m_fieldRange; }
+
   bool isValid() const override;
 
 private:
@@ -46,6 +48,7 @@ private:
   viskores::cont::DataSet m_dataSet;
   viskores::cont::Field m_field;
   viskores::cont::ArrayHandle<viskores::Vec4f_32> m_colorMap;
+  viskores::Range m_fieldRange;
 };
 
 } // namespace viskores_device

--- a/viskores/rendering/anari-device/scene/surface/geometry/Cylinder.cpp
+++ b/viskores/rendering/anari-device/scene/surface/geometry/Cylinder.cpp
@@ -182,12 +182,12 @@ void Cylinder::finalize()
 void Cylinder::render(viskores::rendering::Canvas& canvas,
                       const viskores::rendering::Camera& camera,
                       const viskores::cont::Field& field,
-                      const viskores::cont::ArrayHandle<viskores::Vec4f_32>& colorMap) const
+                      const viskores::cont::ArrayHandle<viskores::Vec4f_32>& colorMap,
+                      const viskores::Range& fieldRange) const
 {
   viskores::rendering::raytracing::RayTracer tracer;
 
   viskores::Bounds shapeBounds;
-  viskores::Range scalarRange = field.GetRange().ReadPortal().Get(0);
 
   if (this->m_cylinderIntersector)
   {
@@ -211,7 +211,7 @@ void Cylinder::render(viskores::rendering::Canvas& canvas,
   viskores::rendering::raytracing::RayOperations::MapCanvasToRays(
     rays, camera.CreateRaytracingCamera(width, height), canvasRT->GetDepthBuffer());
 
-  tracer.SetField(field, scalarRange);
+  tracer.SetField(field, fieldRange);
   tracer.SetColorMap(colorMap);
   tracer.SetShadingOn(true);
   tracer.Render(rays);

--- a/viskores/rendering/anari-device/scene/surface/geometry/Cylinder.h
+++ b/viskores/rendering/anari-device/scene/surface/geometry/Cylinder.h
@@ -41,11 +41,11 @@ struct Cylinder : public Geometry
 
   bool isValid() const override;
 
-  virtual void render(
-    viskores::rendering::Canvas& canvas,
-    const viskores::rendering::Camera& camera,
-    const viskores::cont::Field& field,
-    const viskores::cont::ArrayHandle<viskores::Vec4f_32>& colorMap) const override;
+  virtual void render(viskores::rendering::Canvas& canvas,
+                      const viskores::rendering::Camera& camera,
+                      const viskores::cont::Field& field,
+                      const viskores::cont::ArrayHandle<viskores::Vec4f_32>& colorMap,
+                      const viskores::Range& fieldRange) const override;
 
 private:
   viskores::UInt8 ParseCaps(const std::string& caps);

--- a/viskores/rendering/anari-device/scene/surface/geometry/Geometry.cpp
+++ b/viskores/rendering/anari-device/scene/surface/geometry/Geometry.cpp
@@ -130,7 +130,8 @@ bool UnknownGeometry::isValid() const
 void UnknownGeometry::render(viskores::rendering::Canvas&,
                              const viskores::rendering::Camera&,
                              const viskores::cont::Field&,
-                             const viskores::cont::ArrayHandle<viskores::Vec4f_32>&) const
+                             const viskores::cont::ArrayHandle<viskores::Vec4f_32>&,
+                             const viskores::Range&) const
 {
   // invalid
 }

--- a/viskores/rendering/anari-device/scene/surface/geometry/Geometry.h
+++ b/viskores/rendering/anari-device/scene/surface/geometry/Geometry.h
@@ -38,7 +38,8 @@ struct Geometry : public Object
   virtual void render(viskores::rendering::Canvas& canvas,
                       const viskores::rendering::Camera& camera,
                       const viskores::cont::Field& field,
-                      const viskores::cont::ArrayHandle<viskores::Vec4f_32>& colorMap) const = 0;
+                      const viskores::cont::ArrayHandle<viskores::Vec4f_32>& colorMap,
+                      const viskores::Range& fieldRange) const = 0;
 
   // This struct helps manage a set of parameters providing arrays of data that
   // will be attached to fields on a Viskores dataset created by this geometry.
@@ -89,7 +90,8 @@ struct UnknownGeometry : public Geometry
   virtual void render(viskores::rendering::Canvas&,
                       const viskores::rendering::Camera&,
                       const viskores::cont::Field&,
-                      const viskores::cont::ArrayHandle<viskores::Vec4f_32>&) const override;
+                      const viskores::cont::ArrayHandle<viskores::Vec4f_32>&,
+                      const viskores::Range&) const override;
 };
 
 } // namespace viskores_device

--- a/viskores/rendering/anari-device/scene/surface/geometry/Quad.cpp
+++ b/viskores/rendering/anari-device/scene/surface/geometry/Quad.cpp
@@ -106,7 +106,8 @@ void Quad::finalize()
 void Quad::render(viskores::rendering::Canvas& canvas,
                   const viskores::rendering::Camera& camera,
                   const viskores::cont::Field& field,
-                  const viskores::cont::ArrayHandle<viskores::Vec4f_32>& colorMap) const
+                  const viskores::cont::ArrayHandle<viskores::Vec4f_32>& colorMap,
+                  const viskores::Range& fieldRange) const
 {
   viskores::rendering::raytracing::RayTracer tracer;
   viskores::rendering::raytracing::QuadExtractor quadExtractor;
@@ -115,7 +116,6 @@ void Quad::render(viskores::rendering::Canvas& canvas,
   viskores::cont::CoordinateSystem coords = data.GetCoordinateSystem();
 
   viskores::Bounds shapeBounds;
-  viskores::Range scalarRange = field.GetRange().ReadPortal().Get(0);
 
   quadExtractor.ExtractCells(data.GetCellSet());
 
@@ -143,7 +143,7 @@ void Quad::render(viskores::rendering::Canvas& canvas,
   viskores::rendering::raytracing::RayOperations::MapCanvasToRays(
     rays, camera.CreateRaytracingCamera(width, height), canvasRT->GetDepthBuffer());
 
-  tracer.SetField(field, scalarRange);
+  tracer.SetField(field, fieldRange);
   tracer.SetColorMap(colorMap);
   tracer.SetShadingOn(true);
   tracer.Render(rays);

--- a/viskores/rendering/anari-device/scene/surface/geometry/Quad.h
+++ b/viskores/rendering/anari-device/scene/surface/geometry/Quad.h
@@ -24,11 +24,11 @@ struct Quad : Geometry
 
   bool isValid() const override;
 
-  virtual void render(
-    viskores::rendering::Canvas& canvas,
-    const viskores::rendering::Camera& camera,
-    const viskores::cont::Field& field,
-    const viskores::cont::ArrayHandle<viskores::Vec4f_32>& colorMap) const override;
+  virtual void render(viskores::rendering::Canvas& canvas,
+                      const viskores::rendering::Camera& camera,
+                      const viskores::cont::Field& field,
+                      const viskores::cont::ArrayHandle<viskores::Vec4f_32>& colorMap,
+                      const viskores::Range& fieldRange) const override;
 
 private:
   helium::ChangeObserverPtr<Array1D> m_index;

--- a/viskores/rendering/anari-device/scene/surface/geometry/Sphere.cpp
+++ b/viskores/rendering/anari-device/scene/surface/geometry/Sphere.cpp
@@ -115,7 +115,8 @@ void Sphere::SetupIndexBased()
 void Sphere::render(viskores::rendering::Canvas& canvas,
                     const viskores::rendering::Camera& camera,
                     const viskores::cont::Field& field,
-                    const viskores::cont::ArrayHandle<viskores::Vec4f_32>& colorMap) const
+                    const viskores::cont::ArrayHandle<viskores::Vec4f_32>& colorMap,
+                    const viskores::Range& fieldRange) const
 {
   viskores::rendering::raytracing::RayTracer tracer;
   viskores::rendering::raytracing::SphereExtractor sphereExtractor;
@@ -124,7 +125,6 @@ void Sphere::render(viskores::rendering::Canvas& canvas,
   viskores::cont::CoordinateSystem coords = data.GetCoordinateSystem();
 
   viskores::Bounds shapeBounds;
-  viskores::Range scalarRange = field.GetRange().ReadPortal().Get(0);
 
   if (this->m_dataSet.HasField("radius"))
   {
@@ -168,7 +168,7 @@ void Sphere::render(viskores::rendering::Canvas& canvas,
   viskores::rendering::raytracing::RayOperations::MapCanvasToRays(
     rays, camera.CreateRaytracingCamera(width, height), canvasRT->GetDepthBuffer());
 
-  tracer.SetField(field, scalarRange);
+  tracer.SetField(field, fieldRange);
   tracer.GetCamera() = rayCamera;
   tracer.SetColorMap(colorMap);
   tracer.Render(rays);

--- a/viskores/rendering/anari-device/scene/surface/geometry/Sphere.h
+++ b/viskores/rendering/anari-device/scene/surface/geometry/Sphere.h
@@ -23,11 +23,11 @@ struct Sphere : public Geometry
   void commitParameters() override;
   void finalize() override;
 
-  virtual void render(
-    viskores::rendering::Canvas& canvas,
-    const viskores::rendering::Camera& camera,
-    const viskores::cont::Field& field,
-    const viskores::cont::ArrayHandle<viskores::Vec4f_32>& colorMap) const override;
+  virtual void render(viskores::rendering::Canvas& canvas,
+                      const viskores::rendering::Camera& camera,
+                      const viskores::cont::Field& field,
+                      const viskores::cont::ArrayHandle<viskores::Vec4f_32>& colorMap,
+                      const viskores::Range& fieldRange) const override;
 
 private:
   void SetupIndexBased();

--- a/viskores/rendering/anari-device/scene/surface/geometry/Triangle.cpp
+++ b/viskores/rendering/anari-device/scene/surface/geometry/Triangle.cpp
@@ -123,7 +123,8 @@ void Triangle::finalize()
 void Triangle::render(viskores::rendering::Canvas& canvas,
                       const viskores::rendering::Camera& camera,
                       const viskores::cont::Field& field,
-                      const viskores::cont::ArrayHandle<viskores::Vec4f_32>& colorMap) const
+                      const viskores::cont::ArrayHandle<viskores::Vec4f_32>& colorMap,
+                      const viskores::Range& fieldRange) const
 {
   viskores::rendering::raytracing::RayTracer tracer;
   viskores::rendering::raytracing::TriangleExtractor triExtractor;
@@ -132,7 +133,6 @@ void Triangle::render(viskores::rendering::Canvas& canvas,
   viskores::cont::CoordinateSystem coords = data.GetCoordinateSystem();
 
   viskores::Bounds shapeBounds;
-  viskores::Range scalarRange = field.GetRange().ReadPortal().Get(0);
 
   triExtractor.ExtractCells(data.GetCellSet());
 
@@ -163,7 +163,7 @@ void Triangle::render(viskores::rendering::Canvas& canvas,
   viskores::rendering::raytracing::RayOperations::MapCanvasToRays(
     rays, camera.CreateRaytracingCamera(width, height), canvasRT->GetDepthBuffer());
 
-  tracer.SetField(field, scalarRange);
+  tracer.SetField(field, fieldRange);
 
   tracer.SetColorMap(colorMap);
   tracer.SetShadingOn(true);

--- a/viskores/rendering/anari-device/scene/surface/geometry/Triangle.h
+++ b/viskores/rendering/anari-device/scene/surface/geometry/Triangle.h
@@ -24,11 +24,11 @@ struct Triangle : Geometry
 
   bool isValid() const override;
 
-  virtual void render(
-    viskores::rendering::Canvas& canvas,
-    const viskores::rendering::Camera& camera,
-    const viskores::cont::Field& field,
-    const viskores::cont::ArrayHandle<viskores::Vec4f_32>& colorMap) const override;
+  virtual void render(viskores::rendering::Canvas& canvas,
+                      const viskores::rendering::Camera& camera,
+                      const viskores::cont::Field& field,
+                      const viskores::cont::ArrayHandle<viskores::Vec4f_32>& colorMap,
+                      const viskores::Range& fieldRange) const override;
 
 private:
   helium::ChangeObserverPtr<Array1D> m_index;

--- a/viskores/rendering/anari-device/scene/surface/material/Material.cpp
+++ b/viskores/rendering/anari-device/scene/surface/material/Material.cpp
@@ -26,7 +26,9 @@ struct UnknownMaterial : viskores_device::Material
 
   void getColors(const viskores::cont::DataSet& data,
                  viskores::cont::Field& field,
-                 viskores::cont::ArrayHandle<viskores::Vec4f_32>& colorMap) const override;
+                 viskores::cont::ArrayHandle<viskores::Vec4f_32>& colorMap,
+                 viskores_device::Mat4f_32& inFieldTransform,
+                 viskores::Vec4f_32& inFieldOffset) const override;
 };
 
 UnknownMaterial::UnknownMaterial(viskores_device::ViskoresDeviceGlobalState* d)
@@ -50,7 +52,9 @@ bool UnknownMaterial::isValid() const
 
 void UnknownMaterial::getColors(const viskores::cont::DataSet&,
                                 viskores::cont::Field&,
-                                viskores::cont::ArrayHandle<viskores::Vec4f_32>&) const
+                                viskores::cont::ArrayHandle<viskores::Vec4f_32>&,
+                                viskores_device::Mat4f_32&,
+                                viskores::Vec4f_32&) const
 {
   // invalid
 }

--- a/viskores/rendering/anari-device/scene/surface/material/Material.h
+++ b/viskores/rendering/anari-device/scene/surface/material/Material.h
@@ -27,7 +27,9 @@ struct Material : public Object
 
   virtual void getColors(const viskores::cont::DataSet& data,
                          viskores::cont::Field& field,
-                         viskores::cont::ArrayHandle<viskores::Vec4f_32>& colorMap) const = 0;
+                         viskores::cont::ArrayHandle<viskores::Vec4f_32>& colorMap,
+                         Mat4f_32& inFieldTransform,
+                         viskores::Vec4f_32& inFieldOffset) const = 0;
 };
 
 } // namespace viskores_device

--- a/viskores/rendering/anari-device/scene/surface/material/MatteMaterial.cpp
+++ b/viskores/rendering/anari-device/scene/surface/material/MatteMaterial.cpp
@@ -45,11 +45,13 @@ void MatteMaterial::finalize()
 
 void MatteMaterial::getColors(const viskores::cont::DataSet& data,
                               viskores::cont::Field& field,
-                              viskores::cont::ArrayHandle<viskores::Vec4f_32>& colorMap) const
+                              viskores::cont::ArrayHandle<viskores::Vec4f_32>& colorMap,
+                              Mat4f_32& inFieldTransform,
+                              viskores::Vec4f_32& inFieldOffset) const
 {
   if (this->m_sampler && this->m_sampler->isValid())
   {
-    if (this->m_sampler->getColors(data, field, colorMap))
+    if (this->m_sampler->getColors(data, field, colorMap, inFieldTransform, inFieldOffset))
     {
       return;
     }
@@ -64,6 +66,8 @@ void MatteMaterial::getColors(const viskores::cont::DataSet& data,
                                  viskores::cont::Field::Association::Points,
                                  viskores::cont::make_ArrayHandleConstant(
                                    viskores::Float32{ 0.0f }, data.GetNumberOfPoints()) };
+  viskores::MatrixIdentity(inFieldTransform);
+  inFieldOffset = viskores::Vec4f_32{ 0 };
 }
 
 } // namespace viskores_device

--- a/viskores/rendering/anari-device/scene/surface/material/MatteMaterial.h
+++ b/viskores/rendering/anari-device/scene/surface/material/MatteMaterial.h
@@ -38,7 +38,9 @@ struct MatteMaterial : public Material
 
   void getColors(const viskores::cont::DataSet& data,
                  viskores::cont::Field& field,
-                 viskores::cont::ArrayHandle<viskores::Vec4f_32>& colorMap) const override;
+                 viskores::cont::ArrayHandle<viskores::Vec4f_32>& colorMap,
+                 Mat4f_32& inFieldTransform,
+                 viskores::Vec4f_32& inFieldOffset) const override;
 
 private:
   helium::ChangeObserverPtr<Sampler> m_sampler;

--- a/viskores/rendering/anari-device/scene/surface/material/sampler/Image1DSampler.cpp
+++ b/viskores/rendering/anari-device/scene/surface/material/sampler/Image1DSampler.cpp
@@ -193,7 +193,9 @@ void Image1DSampler::finalize()
 
 bool Image1DSampler::getColors(const viskores::cont::DataSet& data,
                                viskores::cont::Field& field,
-                               viskores::cont::ArrayHandle<viskores::Vec4f_32>& colorMap) const
+                               viskores::cont::ArrayHandle<viskores::Vec4f_32>& colorMap,
+                               Mat4f_32& inFieldTransform,
+                               viskores::Vec4f_32& inFieldOffset) const
 {
   if (!data.HasField(this->inAttribute()))
   {
@@ -221,6 +223,8 @@ bool Image1DSampler::getColors(const viskores::cont::DataSet& data,
 
   field = viskores::cont::Field{ attribField.GetName(), attribField.GetAssociation(), attribArray };
   colorMap = this->m_colorMap;
+  inFieldTransform = this->m_inTransform;
+  inFieldOffset = this->m_inOffset;
   return true;
 }
 

--- a/viskores/rendering/anari-device/scene/surface/material/sampler/Image1DSampler.h
+++ b/viskores/rendering/anari-device/scene/surface/material/sampler/Image1DSampler.h
@@ -37,7 +37,9 @@ struct Image1DSampler : public Sampler
 
   bool getColors(const viskores::cont::DataSet& data,
                  viskores::cont::Field& field,
-                 viskores::cont::ArrayHandle<viskores::Vec4f_32>& colorMap) const override;
+                 viskores::cont::ArrayHandle<viskores::Vec4f_32>& colorMap,
+                 Mat4f_32& inFieldTransform,
+                 viskores::Vec4f_32& inFieldOffset) const override;
 
 private:
   Mat4f_32 m_inTransform;

--- a/viskores/rendering/anari-device/scene/surface/material/sampler/Sampler.cpp
+++ b/viskores/rendering/anari-device/scene/surface/material/sampler/Sampler.cpp
@@ -24,7 +24,9 @@ struct UnknownSampler : viskores_device::Sampler
 
   bool getColors(const viskores::cont::DataSet& data,
                  viskores::cont::Field& field,
-                 viskores::cont::ArrayHandle<viskores::Vec4f_32>& colorMap) const override;
+                 viskores::cont::ArrayHandle<viskores::Vec4f_32>& colorMap,
+                 viskores_device::Mat4f_32& inFieldTransform,
+                 viskores::Vec4f_32& inFieldOffset) const override;
 };
 
 UnknownSampler::UnknownSampler(viskores_device::ViskoresDeviceGlobalState* d)
@@ -48,7 +50,9 @@ bool UnknownSampler::isValid() const
 
 bool UnknownSampler::getColors(const viskores::cont::DataSet&,
                                viskores::cont::Field&,
-                               viskores::cont::ArrayHandle<viskores::Vec4f_32>&) const
+                               viskores::cont::ArrayHandle<viskores::Vec4f_32>&,
+                               viskores_device::Mat4f_32&,
+                               viskores::Vec4f_32&) const
 {
   // invalid
   return false;

--- a/viskores/rendering/anari-device/scene/surface/material/sampler/Sampler.h
+++ b/viskores/rendering/anari-device/scene/surface/material/sampler/Sampler.h
@@ -35,7 +35,9 @@ struct Sampler : public Object
 
   virtual bool getColors(const viskores::cont::DataSet& data,
                          viskores::cont::Field& field,
-                         viskores::cont::ArrayHandle<viskores::Vec4f_32>& colorMap) const = 0;
+                         viskores::cont::ArrayHandle<viskores::Vec4f_32>& colorMap,
+                         Mat4f_32& inFieldTransform,
+                         viskores::Vec4f_32& inFieldOffset) const = 0;
 
 private:
   Mat4f_32 m_outTransform;


### PR DESCRIPTION
The ANARI device ignored the inTransform and inOffset parameters of the 1D sampler. Instead, it scaled the incoming field by its computed range. However, the ANARI device should rely on the the client to provide the proper transform for the colormap lookup.

The device now does an inverse transform of the color range values 0 and 1 to use as the effective minimum and maximum of the field range. This replicates the scaling of the inTransform as long as it only transforms 1D values, which is all that is supported anyway.