### PR TITLE
external.yml: scope statuses:write to the job that needs it

### DIFF
--- a/.github/workflows/external.yml
+++ b/.github/workflows/external.yml
@@ -13,11 +13,13 @@ on:
 
 permissions:
   contents: read
-  statuses: write
 
 jobs:
   generate_statuses:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write
     steps:
       - uses: actions/checkout@v4
       - uses: Kitware/cdash-status@release


### PR DESCRIPTION
Fixes OpenSSF Scorecard Token-Permissions finding (score 9) on
`.github/workflows/external.yml:16`: workflow-level `statuses: write`
granted write access to every job, not just `generate_statuses`.
Moves it into that job's own `permissions:` block.