### PR TITLE
Avoid ambiguity errors when compiling with ROCm 6.4.1

### DIFF
--- a/viskores/rendering/anari-device/frame/Frame.cpp
+++ b/viskores/rendering/anari-device/frame/Frame.cpp
@@ -146,7 +146,7 @@ void Frame::commitParameters()
   m_objIdType = getParam<anari::DataType>("channel.objectId", ANARI_UNKNOWN);
   m_instIdType = getParam<anari::DataType>("channel.instanceId", ANARI_UNKNOWN);
 
-  m_frameData.size = getParam<uint2>("size", uint2(10));
+  m_frameData.size = getParam<anari::math::uint2>("size", anari::math::uint2(10));
 }
 
 void Frame::finalize()

--- a/viskores/rendering/anari-device/frame/Frame.h
+++ b/viskores/rendering/anari-device/frame/Frame.h
@@ -68,7 +68,7 @@ private:
   struct FrameData
   {
     int frameID{ 0 };
-    uint2 size;
+    anari::math::uint2 size;
   } m_frameData;
 
   anari::DataType m_colorType{ ANARI_UNKNOWN };

--- a/viskores/rendering/anari-device/scene/surface/material/sampler/Image1DSampler.cpp
+++ b/viskores/rendering/anari-device/scene/surface/material/sampler/Image1DSampler.cpp
@@ -154,7 +154,8 @@ void Image1DSampler::commitParameters()
 
   mat4 inTransform = this->getParam("inTransform", mat4(linalg::identity));
   this->m_inTransform = toViskoresMatrix(inTransform);
-  float4 inOffset = this->getParam("inOffset", float4(0.f, 0.f, 0.f, 0.f));
+  anari::math::float4 inOffset =
+    this->getParam("inOffset", anari::math::float4(0.f, 0.f, 0.f, 0.f));
   this->m_inOffset = { inOffset[0], inOffset[1], inOffset[2], inOffset[3] };
 
   this->m_colorArray = this->getParamObject<Array1D>("image");

--- a/viskores/rendering/anari-device/scene/surface/material/sampler/Sampler.cpp
+++ b/viskores/rendering/anari-device/scene/surface/material/sampler/Sampler.cpp
@@ -82,7 +82,8 @@ void Sampler::commitParameters()
 {
   mat4 outTransform = this->getParam("outTransform", mat4(linalg::identity));
   this->m_outTransform = toViskoresMatrix(outTransform);
-  float4 outOffset = this->getParam("outOffset", float4(0.f, 0.f, 0.f, 0.f));
+  anari::math::float4 outOffset =
+    this->getParam("outOffset", anari::math::float4(0.f, 0.f, 0.f, 0.f));
   this->m_outOffset = { outOffset[0], outOffset[1], outOffset[2], outOffset[3] };
 }
 

--- a/viskores/rendering/anari-device/scene/volume/spatial_field/StructuredRegularField.cpp
+++ b/viskores/rendering/anari-device/scene/volume/spatial_field/StructuredRegularField.cpp
@@ -28,9 +28,9 @@ void StructuredRegularField::commitParameters()
   // called again if the array contents change.
   this->m_dataArray = getParamObject<Array3D>("data");
 
-  float3 origin = getParam("origin", float3{ 0, 0, 0 });
-  float3 spacing = getParam("spacing", float3{ 1, 1, 1 });
-  uint3 dimensions = this->m_dataArray->size();
+  anari::math::float3 origin = getParam("origin", anari::math::float3{ 0, 0, 0 });
+  anari::math::float3 spacing = getParam("spacing", anari::math::float3{ 1, 1, 1 });
+  anari::math::uint3 dimensions = this->m_dataArray->size();
 
   this->m_dataSet = viskores::cont::DataSetBuilderUniform::Create(
     viskores::Id3{ static_cast<viskores::Id>(dimensions[0]),


### PR DESCRIPTION
Some ANARI type definitions clash with type definitons in ROCm which leads to compilation errors like:
```
~/viskores/viskores/rendering/anari-device/scene/surface/material/sampler/Sampler.cpp:85:3: error: reference to 'float4' is ambiguous
   85 |   float4 outOffset = this->getParam("outOffset", float4(0.f, 0.f, 0.f, 0.f));
      |   ^
/opt/rocm-6.4.1/include/hip/amd_detail/amd_hip_vector_types.h:1194:1: note: candidate found by name lookup is 'float4'
 1194 | __MAKE_VECTOR_TYPE__(float, float);
      | ^
/opt/rocm-6.4.1/include/hip/amd_detail/amd_hip_vector_types.h:1161:15: note: expanded from macro '__MAKE_VECTOR_TYPE__'
 1161 |         using CUDA_name##4 = HIP_vector_type<T, 4>;
      |               ^
<scratch space>:212:1: note: expanded from here
  212 | float4
      | ^
~/anari-sdk/0.15.0/include/anari/anari_cpp/ext/linalg.h:617:86: note: candidate found by name lookup is 'linalg::aliases::float4'
  617 |         typedef vec<int,4> int4; typedef vec<unsigned,4> uint4; typedef vec<float,4> float4; typedef vec<double,4> double4;
```

To avoid this the `anari::math` namespace is used explicitly in the affected code locations in this PR.