### PR TITLE
Ensure the depth passed to ANARI is the Euclidean distance to the camera

### DIFF
--- a/docs/changelog/pass-euclidean-distance-to-camera-to-anari.md
+++ b/docs/changelog/pass-euclidean-distance-to-camera-to-anari.md
@@ -1,0 +1,3 @@
+## Use the Euclidean distances to the camera as depth buffer for ANARI
+
+To adhere to the ANARI specification, Viskores now sets the `channel.depth` parameter of the ANARI camera to the Euclidean distances to the camera.

--- a/viskores/rendering/Canvas.h
+++ b/viskores/rendering/Canvas.h
@@ -99,7 +99,7 @@ public:
 
   /// @brief Change the size of the image.
   VISKORES_CONT
-  void ResizeBuffers(viskores::Id width, viskores::Id height);
+  virtual void ResizeBuffers(viskores::Id width, viskores::Id height);
 
   /// @brief Specify the background color.
   VISKORES_CONT

--- a/viskores/rendering/CanvasRayTracer.cxx
+++ b/viskores/rendering/CanvasRayTracer.cxx
@@ -23,6 +23,18 @@ namespace rendering
 namespace internal
 {
 
+struct ClearDistancesToCamera : public viskores::worklet::WorkletMapField
+{
+  using ControlSignature = void(FieldOut);
+  using ExecutionSignature = void(_1);
+
+  VISKORES_CONT
+  ClearDistancesToCamera() {}
+
+  VISKORES_EXEC
+  void operator()(viskores::Float32& distance) const { distance = viskores::Infinity32(); }
+}; // struct ClearDistancesToCamera
+
 class SurfaceConverter : public viskores::worklet::WorkletMapField
 {
   viskores::Matrix<viskores::Float32, 4, 4> ViewProjMat;
@@ -36,9 +48,15 @@ public:
   {
   }
 
-  using ControlSignature =
-    void(FieldIn, WholeArrayInOut, FieldIn, FieldIn, FieldIn, WholeArrayInOut, WholeArrayInOut);
-  using ExecutionSignature = void(_1, _2, _3, _4, _5, _6, _7, WorkIndex);
+  using ControlSignature = void(FieldIn,
+                                WholeArrayInOut,
+                                FieldIn,
+                                FieldIn,
+                                FieldIn,
+                                WholeArrayInOut,
+                                WholeArrayInOut,
+                                WholeArrayInOut);
+  using ExecutionSignature = void(_1, _2, _3, _4, _5, _6, _7, _8, WorkIndex);
   template <typename Precision,
             typename ColorPortalType,
             typename DepthBufferPortalType,
@@ -49,10 +67,13 @@ public:
                                 const viskores::Vec<Precision, 3>& origin,
                                 const viskores::Vec<Precision, 3>& dir,
                                 DepthBufferPortalType& depthBuffer,
+                                DepthBufferPortalType& distancesToCamera,
                                 ColorBufferPortalType& colorBuffer,
                                 const viskores::Id& index) const
   {
     viskores::Float32 depth = viskores::NegativeInfinity32();
+    viskores::Float32 distanceToCamera = viskores::Infinity32();
+
     const bool hasProjectedDepth = (inDepth >= Precision{ 0 });
     if (hasProjectedDepth)
     {
@@ -81,6 +102,8 @@ public:
       }
     }
 
+    distanceToCamera = static_cast<viskores::Float32>(inDepth);
+
     viskores::Vec4f_32 color;
     color[0] = static_cast<viskores::Float32>(colorBufferIn.Get(index * 4 + 0));
     color[1] = static_cast<viskores::Float32>(colorBufferIn.Get(index * 4 + 1));
@@ -102,13 +125,22 @@ public:
     {
       color[i] = viskores::Min(1.f, viskores::Max(color[i], 0.f));
     }
+
     // The existing depth should already been feed into the ray mapper
     // so no color contribution will exist past the existing depth.
-
-    if (this->WriteDepth && hasProjectedDepth && (depth <= currentDepth))
+    if (this->WriteDepth && hasProjectedDepth)
     {
-      depthBuffer.Set(pixelIndex, depth);
+      if (depth <= currentDepth)
+      {
+        depthBuffer.Set(pixelIndex, depth);
+      }
+
+      if (distanceToCamera <= distancesToCamera.Get(pixelIndex))
+      {
+        distancesToCamera.Set(pixelIndex, distanceToCamera);
+      }
     }
+
     colorBuffer.Set(pixelIndex, color);
   }
 }; //class SurfaceConverter
@@ -131,11 +163,13 @@ VISKORES_CONT void WriteToCanvas(const viskores::rendering::raytracing::Ray<Prec
             rays.Origin,
             rays.Dir,
             canvas->GetDepthBuffer(),
+            canvas->GetDistancesToCamera(),
             canvas->GetColorBuffer());
 
   //Force the transfer so the vectors contain data from device
   canvas->GetColorBuffer().WritePortal().Get(0);
   canvas->GetDepthBuffer().WritePortal().Get(0);
+  canvas->GetDistancesToCamera().WritePortal().Get(0);
 }
 
 } // namespace internal
@@ -143,9 +177,19 @@ VISKORES_CONT void WriteToCanvas(const viskores::rendering::raytracing::Ray<Prec
 CanvasRayTracer::CanvasRayTracer(viskores::Id width, viskores::Id height)
   : Canvas(width, height)
 {
+  this->ResizeBuffers(width, height);
 }
 
 CanvasRayTracer::~CanvasRayTracer() {}
+
+void CanvasRayTracer::Clear()
+{
+  this->Canvas::Clear();
+
+  internal::ClearDistancesToCamera worklet;
+  viskores::worklet::DispatcherMapField<internal::ClearDistancesToCamera> dispatcher(worklet);
+  dispatcher.Invoke(this->GetDistancesToCamera());
+}
 
 void CanvasRayTracer::WriteToCanvas(
   const viskores::rendering::raytracing::Ray<viskores::Float32>& rays,
@@ -169,5 +213,27 @@ viskores::rendering::Canvas* CanvasRayTracer::NewCopy() const
 {
   return new viskores::rendering::CanvasRayTracer(*this);
 }
+
+const Canvas::DepthBufferType& CanvasRayTracer::GetDistancesToCamera() const
+{
+  return this->DistancesToCamera;
+}
+
+Canvas::DepthBufferType& CanvasRayTracer::GetDistancesToCamera()
+{
+  return this->DistancesToCamera;
+}
+
+void CanvasRayTracer::ResizeBuffers(viskores::Id width, viskores::Id height)
+{
+  this->Canvas::ResizeBuffers(width, height);
+
+  viskores::Id numPixels = width * height;
+  if (this->DistancesToCamera.GetNumberOfValues() != numPixels)
+  {
+    this->DistancesToCamera.Allocate(numPixels);
+  }
+}
+
 }
 }

--- a/viskores/rendering/CanvasRayTracer.h
+++ b/viskores/rendering/CanvasRayTracer.h
@@ -31,6 +31,8 @@ public:
 
   viskores::rendering::Canvas* NewCopy() const override;
 
+  void Clear() override;
+
   void WriteToCanvas(const viskores::rendering::raytracing::Ray<viskores::Float32>& rays,
                      const viskores::cont::ArrayHandle<viskores::Float32>& colors,
                      const viskores::rendering::Camera& camera,
@@ -40,6 +42,21 @@ public:
                      const viskores::cont::ArrayHandle<viskores::Float64>& colors,
                      const viskores::rendering::Camera& camera,
                      bool writeDepth = true);
+
+  /// @brief Get the distances to the camera for each pixel.
+  VISKORES_CONT
+  const DepthBufferType& GetDistancesToCamera() const;
+
+  /// @copydoc GetDistancesToCamera
+  VISKORES_CONT
+  DepthBufferType& GetDistancesToCamera();
+
+  /// @brief Change the size of the image.
+  VISKORES_CONT
+  void ResizeBuffers(viskores::Id width, viskores::Id height) override;
+
+private:
+  DepthBufferType DistancesToCamera;
 }; // class CanvasRayTracer
 }
 } // namespace viskores::rendering

--- a/viskores/rendering/anari-device/frame/Frame.cpp
+++ b/viskores/rendering/anari-device/frame/Frame.cpp
@@ -317,7 +317,8 @@ void* Frame::map(std::string_view channel,
   else if (channel == "channel.depth")
   {
     *pixelType = ANARI_FLOAT32;
-    viskores::cont::ArrayHandleBasic<viskores::Float32> basicArray = this->Canvas.GetDepthBuffer();
+    viskores::cont::ArrayHandleBasic<viskores::Float32> basicArray =
+      this->Canvas.GetDistancesToCamera();
     // Note: Although we are returning a non-const pointer, this is
     // essentially a mistake in the ANARI API. Client code is not supposed
     // to modify the buffer.


### PR DESCRIPTION
It's really exciting that there is a viskores device for ANARI now!

While playing around with it, I've noticed, however, that the depth buffer channel of the viskores device does not seem to align with the definition in the [ANARI specification](https://registry.khronos.org/ANARI/specs/1.1/ANARI-1.1.html#:~:text=channel%2Edepth) which states that `channel.depth` should be the "euclidean distance to the camera (not to the image plane)".

To resolve this (and to ensure that, from a user side, different ANARI devices do not have to be treated differently), I have added a buffer called `DistancesToCamera` to the `Canvas` class which is filled with the minimum distances passed to the `WriteToCanvas` methods in the `SurfaceConverter` worklet. This buffer is then passed to ANARI in the `map` method of the `Frame` class instead of the original `DepthBuffer`.

Please let me know what you think of this change.