### PR TITLE
dependabot: group updates into a single PR per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,13 +12,25 @@ updates:
     directory: /
     schedule:
       interval: daily
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: pip
     directory: /Utilities/CI
     schedule:
       interval: daily
+    groups:
+      pip-utilities-ci:
+        patterns:
+          - "*"
 
   - package-ecosystem: pip
     directory: /docs/users-guide
     schedule:
       interval: daily
+    groups:
+      pip-docs-users-guide:
+        patterns:
+          - "*"


### PR DESCRIPTION
Each dependabot-tracked ecosystem (github-actions, pip in
Utilities/CI, pip in docs/users-guide) currently opens one PR per
outdated dependency. Adds a catch-all group per ecosystem so
dependabot combines them into a single PR instead.