### PR TITLE
CodeQL: exclude conf.py from Python analysis

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,10 @@
+##============================================================================
+##  The contents of this file are covered by the Viskores license. See
+##  LICENSE.txt for details.
+##
+##  By contributing to this file, all contributors agree to the Developer
+##  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+##============================================================================
+
+paths-ignore:
+  - docs/users-guide/conf.py

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,7 +42,7 @@ jobs:
       matrix:
         include:
           - language: cpp
-            build-mode: autobuild
+            build-mode: manual
           - language: python
             build-mode: none
         # CodeQL supports [ $supported-codeql-languages ]
@@ -63,21 +63,23 @@ jobs:
           # By default, queries listed here will override any specified in a config file.
           # Prefix the list here with "+" to use these queries and those in the config file.
 
-      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-      # If this step fails, then you should remove it and run the build manually (see below)
-      - name: Autobuild
-        if: matrix.build-mode == 'autobuild'
-        uses: github/codeql-action/autobuild@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+      - name: Install Ninja
+        if: matrix.build-mode == 'manual'
+        run: sudo apt-get update && sudo apt-get install -y ninja-build
 
-      # ℹ️ Command-line programs to run using the OS shell.
-      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-
-      #   If the Autobuild fails above, remove it and uncomment the following three lines.
-      #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
-
-      # - run: |
-      #   echo "Run, Build Application using script"
-      #   ./location_of_script_within_repo/buildscript.sh
+      # Only build the core library, skipping tests, examples, and
+      # benchmarks, which are not needed for the CodeQL analysis and
+      # otherwise dominate the job's runtime.
+      - name: Configure and build (C++)
+        if: matrix.build-mode == 'manual'
+        run: |
+          cmake -S . -B build -GNinja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DViskores_ENABLE_TESTING=OFF \
+            -DViskores_ENABLE_EXAMPLES=OFF \
+            -DViskores_ENABLE_BENCHMARKS=OFF \
+            -DViskores_ENABLE_DOCUMENTATION=OFF
+          cmake --build build -j"$(nproc)"
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -58,6 +58,7 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
+          config-file: ./.github/codeql/codeql-config.yml
           # If you wish to specify custom queries, you can do so here or in a config file.
           # By default, queries listed here will override any specified in a config file.
           # Prefix the list here with "+" to use these queries and those in the config file.


### PR DESCRIPTION
Excludes docs/users-guide/conf.py from CodeQL's Python analysis since it cannot be parsed.