### PR TITLE
Fix CodeQL multiplication-converted-to-larger-type alerts

### DIFF
--- a/viskores/cont/ArrayHandleRuntimeVec.h
+++ b/viskores/cont/ArrayHandleRuntimeVec.h
@@ -512,7 +512,7 @@ struct ArrayExtractComponentImpl<viskores::cont::StorageTagRuntimeVec>
     return viskores::cont::ArrayHandleStride<typename viskores::VecTraits<T>::BaseComponentType>(
       dest.GetBasicArray(),
       dest.GetNumberOfValues() / numComponents,
-      dest.GetStride() * numComponents,
+      static_cast<viskores::Id>(dest.GetStride()) * numComponents,
       dest.GetOffset() + (dest.GetStride() * (componentIndex / NUM_SUB_COMPONENTS)),
       dest.GetModulo(),
       dest.GetDivisor());

--- a/viskores/cont/CellLocatorTwoLevel.cxx
+++ b/viskores/cont/CellLocatorTwoLevel.cxx
@@ -333,7 +333,8 @@ struct DimensionsToCount
 {
   VISKORES_EXEC viskores::Id operator()(const DimVec3& dim) const
   {
-    return dim[0] * dim[1] * dim[2];
+    return static_cast<viskores::Id>(dim[0]) * static_cast<viskores::Id>(dim[1]) *
+      static_cast<viskores::Id>(dim[2]);
   }
 };
 
@@ -401,8 +402,9 @@ VISKORES_CONT void CellLocatorTwoLevel::Build()
   binIds.ReleaseResources();
 
   // 6: Compute level-2 dimensions
-  viskores::Id numberOfBins =
-    this->TopLevel.Dimensions[0] * this->TopLevel.Dimensions[1] * this->TopLevel.Dimensions[2];
+  viskores::Id numberOfBins = static_cast<viskores::Id>(this->TopLevel.Dimensions[0]) *
+    static_cast<viskores::Id>(this->TopLevel.Dimensions[1]) *
+    static_cast<viskores::Id>(this->TopLevel.Dimensions[2]);
   viskores::cont::ArrayCopy(viskores::cont::make_ArrayHandleConstant(DimVec3(0), numberOfBins),
                             this->LeafDimensions);
   GenerateBinsL1 generateL1(this->TopLevel.BinSize, this->DensityL2);

--- a/viskores/exec/ConnectivityExtrude.h
+++ b/viskores/exec/ConnectivityExtrude.h
@@ -124,7 +124,8 @@ public:
   VISKORES_EXEC
   viskores::Id GetNumberOfElements() const
   {
-    return this->NumberOfPointsPerPlane * this->NumberOfPlanes;
+    return static_cast<viskores::Id>(this->NumberOfPointsPerPlane) *
+      static_cast<viskores::Id>(this->NumberOfPlanes);
   }
 
   VISKORES_EXEC

--- a/viskores/filter/contour/worklet/MIR.h
+++ b/viskores/filter/contour/worklet/MIR.h
@@ -2299,7 +2299,8 @@ public:
       {
         if (orgID.Get(orgPos1 + originalInd) == lowest)
         {
-          totalVolForColor -= orgVF.Get(orgPos1 + originalInd) * orgVols.Get(cellID);
+          totalVolForColor -= static_cast<viskores::Float64>(orgVF.Get(orgPos1 + originalInd)) *
+            static_cast<viskores::Float64>(orgVols.Get(cellID));
           originalInd++;
         }
       }

--- a/viskores/filter/image_processing/worklet/ComputeMoments.h
+++ b/viskores/filter/image_processing/worklet/ComputeMoments.h
@@ -38,7 +38,8 @@ public:
     : RadiusDiscrete(viskores::IdComponent(_radius / (_spacing[0] - 1e-10)),
                      viskores::IdComponent(_radius / (_spacing[1] - 1e-10)),
                      viskores::IdComponent(_radius / (_spacing[2] - 1e-10)))
-    , SpacingProduct(_spacing[0] * _spacing[1])
+    , SpacingProduct(static_cast<viskores::Float64>(_spacing[0]) *
+                     static_cast<viskores::Float64>(_spacing[1]))
     , p(_p)
     , q(_q)
   {

--- a/viskores/rendering/ScalarRenderer.cxx
+++ b/viskores/rendering/ScalarRenderer.cxx
@@ -131,7 +131,8 @@ ScalarRenderer::Result ScalarRenderer::Render(const viskores::rendering::Camera&
   std::vector<ArrayF32> res;
   std::vector<std::string> names;
   const size_t numBuffers = rays.Buffers.size();
-  viskores::Id expandSize = Internals->Width * Internals->Height;
+  viskores::Id expandSize =
+    static_cast<viskores::Id>(Internals->Width) * static_cast<viskores::Id>(Internals->Height);
 
   for (size_t i = 0; i < numBuffers; ++i)
   {

--- a/viskores/rendering/raytracing/Camera.cxx
+++ b/viskores/rendering/raytracing/Camera.cxx
@@ -945,9 +945,11 @@ VISKORES_CONT void Camera::UpdateDimensions(Ray<Precision>& rays,
   }
 
   // resize rays and buffers
-  if (rays.NumRays != SubsetWidth * SubsetHeight)
+  viskores::Id subsetSize =
+    static_cast<viskores::Id>(SubsetWidth) * static_cast<viskores::Id>(SubsetHeight);
+  if (rays.NumRays != subsetSize)
   {
-    RayOperations::Resize(rays, this->SubsetHeight * this->SubsetWidth);
+    RayOperations::Resize(rays, subsetSize);
   }
 }
 

--- a/viskores/rendering/raytracing/CylinderIntersector.cxx
+++ b/viskores/rendering/raytracing/CylinderIntersector.cxx
@@ -180,6 +180,7 @@ public:
                               const vec3& q,
                               float r) const
   {
+    using ComponentType = typename vec3::ComponentType;
     float t = 0;
     vec3 d = q - p;
     vec3 m = ray_start - p;
@@ -225,7 +226,7 @@ public:
       else
         t = 0;
 
-      return vec3(1, t * nlen, 0);
+      return vec3(1, static_cast<ComponentType>(t) * nlen, 0);
     }
     viskores::Float32 b = ddotd * mdotn - ndotd * mdotd;
     viskores::Float32 discr = b * b - a * c;
@@ -249,8 +250,9 @@ public:
       }
       t = (ddotd - mdotd) / ndotd;
 
-      return vec3(
-        k + ddotd - 2 * mdotd + t * (2 * (mdotn - ndotd) + t * ndotn) <= 0.0f, t * nlen, 0);
+      return vec3(k + ddotd - 2 * mdotd + t * (2 * (mdotn - ndotd) + t * ndotn) <= 0.0f,
+                  static_cast<ComponentType>(t) * nlen,
+                  0);
     }
     else if (u < 0.0f)
     {
@@ -260,9 +262,9 @@ public:
       }
       t = -mdotd / ndotd;
 
-      return vec3(k + 2 * t * (mdotn + t * ndotn) <= 0.0f, t * nlen, 0);
+      return vec3(k + 2 * t * (mdotn + t * ndotn) <= 0.0f, static_cast<ComponentType>(t) * nlen, 0);
     }
-    return vec3(1, t * nlen, 0);
+    return vec3(1, static_cast<ComponentType>(t) * nlen, 0);
   }
 
   template <typename Precision>

--- a/viskores/rendering/raytracing/SphereIntersector.cxx
+++ b/viskores/rendering/raytracing/SphereIntersector.cxx
@@ -168,7 +168,7 @@ public:
       if (dot1 >= 0)
       {
         Precision d = viskores::dot(l, l) - dot1 * dot1;
-        Precision r2 = radius * radius;
+        Precision r2 = static_cast<Precision>(radius) * static_cast<Precision>(radius);
         if (d <= r2)
         {
           Precision tch = viskores::Sqrt(r2 - d);


### PR DESCRIPTION
Fixes CodeQL alerts 40-58 ("Multiplication result converted to larger type") by casting operands to the destination width before multiplying.