### PR TITLE
WIP: Check sphinx/breathe versions

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -41,6 +41,7 @@ build:
     - cmake -B build -S . -DViskores_ENABLE_DOCUMENTATION=ON -DViskores_ENABLE_USERS_GUIDE=ON -DViskores_USERS_GUIDE_INCLUDE_TODOS=OFF
     - cmake --build build --target ViskoresDoxygenDocs
     - cp -f ./build/docs/users-guide/ViskoresUsersGuideHTML.cache/conf.py docs/users-guide/conf.py
+    - python docs/users-guide/patch_breathe.py
 
 sphinx:
   configuration: docs/users-guide/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -31,6 +31,11 @@ build:
     python: '3.10'
   jobs:
     post_install:
+    - python --version
+    - python -m sphinx --version
+    - python -c "import breathe; print(breathe.__version__)"
+    - doxygen --version
+    - cmake --version
     - git submodule init
     - git submodule update
     - cmake -B build -S . -DViskores_ENABLE_DOCUMENTATION=ON -DViskores_ENABLE_USERS_GUIDE=ON -DViskores_USERS_GUIDE_INCLUDE_TODOS=OFF

--- a/docs/users-guide/patch_breathe.py
+++ b/docs/users-guide/patch_breathe.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+import breathe.file_state_cache
+import breathe.parser
+import breathe.path_handler
+import breathe.project
+import breathe.renderer.sphinxrenderer
+
+def remove_resolve(module):
+  old = ").resolve()"
+  new = ").absolute()"
+
+  path = Path(module.__file__)
+
+  text = path.read_text()
+  if old not in text:
+    raise RuntimeError(f"Expected .resolve() call not found in {path}")
+
+  path.write_text(text.replace(old, new))
+  print(f"Patched {path}")
+
+remove_resolve(breathe.file_state_cache)
+remove_resolve(breathe.parser)
+remove_resolve(breathe.path_handler)
+remove_resolve(breathe.project)
+remove_resolve(breathe.renderer.sphinxrenderer)

--- a/docs/users-guide/requirements.in
+++ b/docs/users-guide/requirements.in
@@ -18,7 +18,7 @@
 # root directory of this repository.
 
 breathe==4.35.0
-Sphinx==7.2.6
+Sphinx==7.3.7
 sphinx-rtd-theme==1.3.0
 sphinxcontrib-moderncmakedomain==3.27.0
 sphinxcontrib-packages==1.1.2

--- a/docs/users-guide/requirements.in
+++ b/docs/users-guide/requirements.in
@@ -17,8 +17,8 @@
 # The resulting requirements are copied to the requirements-doc.txt file in the
 # root directory of this repository.
 
-breathe==4.35.0
-Sphinx==7.3.7
+breathe==4.36.0
+Sphinx==7.2.6
 sphinx-rtd-theme==1.3.0
 sphinxcontrib-moderncmakedomain==3.27.0
 sphinxcontrib-packages==1.1.2

--- a/docs/users-guide/requirements.txt
+++ b/docs/users-guide/requirements.txt
@@ -47,7 +47,7 @@ requests==2.34.2
     # via sphinx
 snowballstemmer==3.1.1
     # via sphinx
-sphinx==7.2.6
+sphinx==7.3.7
     # via
     #   -r requirements.in
     #   breathe

--- a/docs/users-guide/requirements.txt
+++ b/docs/users-guide/requirements.txt
@@ -16,7 +16,7 @@ alabaster==0.7.16
     # via sphinx
 babel==2.18.0
     # via sphinx
-breathe==4.35.0
+breathe==4.36.0
     # via -r requirements.in
 certifi==2026.7.22
     # via requests
@@ -26,7 +26,6 @@ distro==1.9.0
     # via sphinxcontrib-packages
 docutils==0.18.1
     # via
-    #   breathe
     #   sphinx
     #   sphinx-rtd-theme
 idna==3.18
@@ -47,7 +46,7 @@ requests==2.34.2
     # via sphinx
 snowballstemmer==3.1.1
     # via sphinx
-sphinx==7.3.7
+sphinx==7.2.6
     # via
     #   -r requirements.in
     #   breathe


### PR DESCRIPTION
The dependabot is trying to update the python modules for the user's guide, but when it does the readthedocs build locks up. Trying to narrow down what update is causing the problem.

Failures can be seen at #429 and elsewhere.