### PR TITLE
Parallelize partitioned global field ranges

### DIFF
--- a/docs/changelog/threaded-partitioned-histogram.md
+++ b/docs/changelog/threaded-partitioned-histogram.md
@@ -1,0 +1,6 @@
+## Support threaded partitioned histograms
+
+`FieldRangeGlobalCompute` can now compute ranges for local partitions concurrently before reducing
+them across MPI ranks. Partitioned `Histogram` uses this common implementation and initializes its
+shared bin width before concurrently processing partitions, allowing it to safely use the standard
+multithreaded filter settings.

--- a/viskores/cont/FieldRangeGlobalCompute.cxx
+++ b/viskores/cont/FieldRangeGlobalCompute.cxx
@@ -9,16 +9,45 @@
 #include <viskores/cont/FieldRangeGlobalCompute.h>
 
 #include <viskores/cont/EnvironmentTracker.h>
+#include <viskores/cont/RuntimeDeviceTracker.h>
 
 #include <viskores/thirdparty/diy/diy.h>
 
 #include <algorithm>
+#include <atomic>
 #include <functional>
+#include <future>
+#include <utility>
+#include <vector>
 
 namespace viskores
 {
 namespace cont
 {
+
+namespace
+{
+
+void MergeRanges(std::vector<viskores::Range>& result,
+                 const viskores::cont::ArrayHandle<viskores::Range>& ranges)
+{
+  result.resize(std::max(result.size(), static_cast<std::size_t>(ranges.GetNumberOfValues())));
+  auto portal = ranges.ReadPortal();
+  std::transform(viskores::cont::ArrayPortalToIteratorBegin(portal),
+                 viskores::cont::ArrayPortalToIteratorEnd(portal),
+                 result.begin(),
+                 result.begin(),
+                 std::plus<viskores::Range>());
+}
+
+void MergeRanges(std::vector<viskores::Range>& result, const std::vector<viskores::Range>& ranges)
+{
+  result.resize(std::max(result.size(), ranges.size()));
+  std::transform(
+    ranges.begin(), ranges.end(), result.begin(), result.begin(), std::plus<viskores::Range>());
+}
+
+} // anonymous namespace
 
 //-----------------------------------------------------------------------------
 VISKORES_CONT
@@ -38,7 +67,56 @@ viskores::cont::ArrayHandle<viskores::Range> FieldRangeGlobalCompute(
   const std::string& name,
   viskores::cont::Field::Association assoc)
 {
-  auto lrange = viskores::cont::FieldRangeCompute(pds, name, assoc);
+  return viskores::cont::FieldRangeGlobalCompute(pds, name, assoc, 1);
+}
+
+//-----------------------------------------------------------------------------
+VISKORES_CONT
+viskores::cont::ArrayHandle<viskores::Range> FieldRangeGlobalCompute(
+  const viskores::cont::PartitionedDataSet& pds,
+  const std::string& name,
+  viskores::cont::Field::Association assoc,
+  viskores::Id numberOfThreads)
+{
+  const viskores::Id numberOfPartitions = pds.GetNumberOfPartitions();
+  const viskores::Id threads =
+    std::min(numberOfPartitions, std::max(numberOfThreads, viskores::Id{ 1 }));
+  if (threads < 2)
+  {
+    auto lrange = viskores::cont::FieldRangeCompute(pds, name, assoc);
+    return viskores::cont::detail::MergeRangesGlobal(lrange);
+  }
+
+  std::atomic<viskores::Id> nextPartition{ 0 };
+  auto computeRanges = [&]()
+  {
+    ScopedRuntimeDeviceTracker tracker;
+    tracker.SetThreadFriendlyMemAlloc(true);
+
+    std::vector<viskores::Range> ranges;
+    viskores::Id partitionIndex = nextPartition.fetch_add(1);
+    while (partitionIndex < numberOfPartitions)
+    {
+      MergeRanges(ranges,
+                  viskores::cont::FieldRangeCompute(pds.GetPartition(partitionIndex), name, assoc));
+      partitionIndex = nextPartition.fetch_add(1);
+    }
+    return ranges;
+  };
+
+  std::vector<std::future<std::vector<viskores::Range>>> futures(static_cast<std::size_t>(threads));
+  for (auto& future : futures)
+  {
+    future = std::async(std::launch::async, computeRanges);
+  }
+
+  std::vector<viskores::Range> localRanges;
+  for (auto& future : futures)
+  {
+    MergeRanges(localRanges, future.get());
+  }
+
+  auto lrange = viskores::cont::make_ArrayHandleMove(std::move(localRanges));
   return viskores::cont::detail::MergeRangesGlobal(lrange);
 }
 

--- a/viskores/cont/FieldRangeGlobalCompute.h
+++ b/viskores/cont/FieldRangeGlobalCompute.h
@@ -57,6 +57,19 @@ viskores::cont::ArrayHandle<viskores::Range> FieldRangeGlobalCompute(
   const viskores::cont::PartitionedDataSet& pds,
   const std::string& name,
   viskores::cont::Field::Association assoc = viskores::cont::Field::Association::Any);
+
+/// Returns the range for a field from a PartitionedDataSet. The range for the local partitions
+/// may be computed concurrently using up to `numberOfThreads` threads before the ranges are
+/// reduced across ranks. If `numberOfThreads` is less than 2, local partitions are processed
+/// sequentially. The caller is responsible for selecting a thread count appropriate for the
+/// active device.
+VISKORES_CONT_EXPORT
+VISKORES_CONT
+viskores::cont::ArrayHandle<viskores::Range> FieldRangeGlobalCompute(
+  const viskores::cont::PartitionedDataSet& pds,
+  const std::string& name,
+  viskores::cont::Field::Association assoc,
+  viskores::Id numberOfThreads);
 //@}
 
 }

--- a/viskores/cont/testing/UnitTestFieldRangeGlobalCompute.cxx
+++ b/viskores/cont/testing/UnitTestFieldRangeGlobalCompute.cxx
@@ -10,6 +10,8 @@
 #include <viskores/cont/ArrayPortalToIterators.h>
 #include <viskores/cont/EnvironmentTracker.h>
 #include <viskores/cont/FieldRangeGlobalCompute.h>
+#include <viskores/cont/RuntimeDeviceTracker.h>
+#include <viskores/cont/serial/DeviceAdapterSerial.h>
 #include <viskores/cont/testing/Testing.h>
 
 #include <algorithm>
@@ -183,6 +185,14 @@ void TryRangeGlobalComputePDS(const ValueType& min, const ValueType& max)
   viskores::cont::ArrayHandle<viskores::Range> ranges =
     viskores::cont::FieldRangeGlobalCompute(mb, "pointvar");
   Validate(ranges, min, max);
+
+  {
+    viskores::cont::ScopedRuntimeDeviceTracker tracker(viskores::cont::DeviceAdapterTagSerial{});
+    viskores::cont::ArrayHandle<viskores::Range> threadedRanges =
+      viskores::cont::FieldRangeGlobalCompute(
+        mb, "pointvar", viskores::cont::Field::Association::Any, 4);
+    Validate(threadedRanges, min, max);
+  }
 }
 
 static void TestFieldRangeGlobalCompute()

--- a/viskores/filter/Filter.h
+++ b/viskores/filter/Filter.h
@@ -391,6 +391,9 @@ public:
 protected:
   viskores::cont::Invoker Invoke;
 
+  VISKORES_CONT
+  virtual viskores::Id DetermineNumberOfThreads(const viskores::cont::PartitionedDataSet& input);
+
   /// @brief Create the output data set for `DoExecute`.
   ///
   /// This form of `CreateResult` will create an output data set with the same cell
@@ -853,9 +856,6 @@ private:
     template <typename T>
     using type = viskores::Vec<T, VecSize>;
   };
-
-  VISKORES_CONT
-  virtual viskores::Id DetermineNumberOfThreads(const viskores::cont::PartitionedDataSet& input);
 
   void ResizeIfNeeded(size_t index_st);
 

--- a/viskores/filter/density_estimate/Histogram.cxx
+++ b/viskores/filter/density_estimate/Histogram.cxx
@@ -19,6 +19,8 @@
 
 #include <viskores/thirdparty/diy/diy.h>
 
+#include <type_traits>
+
 namespace viskores
 {
 namespace filter
@@ -206,7 +208,10 @@ VISKORES_CONT viskores::cont::DataSet Histogram::DoExecute(const viskores::cont:
                 delta,
                 binArray);
 
-    this->BinDelta = static_cast<viskores::Float64>(delta);
+    if (!this->InExecutePartitions)
+    {
+      this->BinDelta = static_cast<viskores::Float64>(delta);
+    }
   };
 
   fieldArray.CastAndCallForTypesWithFloatFallback<viskores::TypeListFieldScalar,
@@ -238,13 +243,30 @@ VISKORES_CONT void Histogram::PreExecute(const viskores::cont::PartitionedDataSe
   }
   else
   {
+    const viskores::Id numberOfThreads =
+      this->GetRunMultiThreadedFilter() ? this->DetermineNumberOfThreads(input) : viskores::Id{ 1 };
     auto handle = viskores::cont::FieldRangeGlobalCompute(
-      input, this->GetActiveFieldName(), this->GetActiveFieldAssociation());
+      input, this->GetActiveFieldName(), this->GetActiveFieldAssociation(), numberOfThreads);
     if (handle.GetNumberOfValues() != 1)
     {
       throw viskores::cont::ErrorFilterExecution("expecting scalar field.");
     }
     this->ComputedRange = handle.ReadPortal().Get(0);
+  }
+
+  if (input.GetNumberOfPartitions() > 0)
+  {
+    const auto& fieldArray = this->GetFieldFromDataSet(input.GetPartition(0)).GetData();
+    auto setBinDelta = [&](const auto& concrete)
+    {
+      using T = typename std::decay_t<decltype(concrete)>::ValueType;
+      const T fieldRange =
+        static_cast<T>(this->ComputedRange.Max) - static_cast<T>(this->ComputedRange.Min);
+      const T delta = fieldRange / static_cast<T>(this->NumberOfBins);
+      this->BinDelta = static_cast<viskores::Float64>(delta);
+    };
+    // Dispatch on an empty instance to resolve the float fallback type without copying values.
+    this->CastAndCallScalarField(fieldArray.NewInstance(), setBinDelta);
   }
   this->InExecutePartitions = true;
 }

--- a/viskores/filter/density_estimate/testing/UnitTestPartitionedDataSetHistogramFilter.cxx
+++ b/viskores/filter/density_estimate/testing/UnitTestPartitionedDataSetHistogramFilter.cxx
@@ -10,6 +10,8 @@
 
 #include <viskores/cont/DataSet.h>
 #include <viskores/cont/PartitionedDataSet.h>
+#include <viskores/cont/RuntimeDeviceTracker.h>
+#include <viskores/cont/serial/DeviceAdapterSerial.h>
 #include <viskores/cont/testing/Testing.h>
 
 #include <viskores/thirdparty/diy/environment.h>
@@ -83,10 +85,18 @@ void AddField(viskores::cont::DataSet& dataset,
 }
 }
 
-static void TestPartitionedDataSetHistogram()
+struct HistogramResult
 {
-  // init random seed.
-  std::srand(100);
+  viskores::cont::ArrayHandle<viskores::Id> Bins;
+  viskores::Float64 BinDelta;
+};
+
+static HistogramResult RunPartitionedDataSetHistogram(bool runMultiThreaded)
+{
+  uid = 1;
+
+  // Use the serial device so filter-level partition threading is enabled.
+  viskores::cont::ScopedRuntimeDeviceTracker tracker(viskores::cont::DeviceAdapterTagSerial{});
 
   viskores::cont::PartitionedDataSet mb;
 
@@ -104,6 +114,9 @@ static void TestPartitionedDataSetHistogram()
 
   viskores::filter::density_estimate::Histogram histogram;
   histogram.SetActiveField("double");
+  // Explicitly select each scheduler path so their shared results can be compared.
+  histogram.SetThreadsPerCPU(2);
+  histogram.SetRunMultiThreadedFilter(runMultiThreaded);
   auto result = histogram.Execute(mb);
   VISKORES_TEST_ASSERT(result.GetNumberOfPartitions() == 1, "Expecting 1 partition.");
 
@@ -125,6 +138,17 @@ static void TestPartitionedDataSetHistogram()
     std::cout << " " << binsPortal.Get(cc);
   }
   std::cout << std::endl;
+  return { bins, histogram.GetBinDelta() };
+}
+
+static void TestPartitionedDataSetHistogram()
+{
+  const auto sequential = RunPartitionedDataSetHistogram(false);
+  const auto threaded = RunPartitionedDataSetHistogram(true);
+  VISKORES_TEST_ASSERT(test_equal_ArrayHandles(sequential.Bins, threaded.Bins),
+                       "Sequential and threaded histograms differ");
+  VISKORES_TEST_ASSERT(test_equal(sequential.BinDelta, threaded.BinDelta),
+                       "Sequential and threaded bin deltas differ");
 }
 
 int UnitTestPartitionedDataSetHistogramFilter(int argc, char* argv[])


### PR DESCRIPTION
This is split from #384 in response to review feedback.

### Summary

- Add an optional threaded local-partition path to `FieldRangeGlobalCompute`.
- Let derived filters reuse the base filter scheduler's device-aware thread count.
- Use the common range implementation from partitioned `Histogram`.
- Initialize `Histogram`'s shared bin width before partition workers start.

### Implementation

The new `FieldRangeGlobalCompute` overload accepts a maximum worker count. Each worker computes ranges from local partitions, the local results are merged after the workers finish, and the existing MPI reduction then produces the global range. The original overload remains sequential and unchanged for existing callers.

`Filter::DetermineNumberOfThreads` is now protected, matching its documented role as an overridable scheduler hook. `Histogram` uses that policy when partition threading is enabled, so OpenMP and TBB execution still avoid nested filter-level threading.

The shared histogram bin width is resolved once before partition workers start. Per-partition executions no longer write it concurrently.

### Testing

- `UnitTestFieldRangeGlobalCompute_mpi` with three ranks and explicit threaded local range computation
- `UnitTestHistogramFilter`
- `UnitTestPartitionedDataSetHistogramFilter`, comparing complete sequential and two-worker histograms and bin widths
- 100 repeated threaded Histogram runs and 20 repeated three-rank `FieldRangeGlobalCompute` runs on a compute node
