### PR TITLE
Bump sphinx

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,7 +17,7 @@ build:
   - cmake
   - make
   tools:
-    python: '3.10'
+    python: '3.13'
   jobs:
     post_install:
     - git submodule init

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -22,6 +22,7 @@ build:
     post_install:
     - git submodule init
     - git submodule update
+    - python Utilities/Scripts/patch-breathe.py # Patch breathe 4.36.0. See patch_breathe.py for details.
     - cmake -B build -S . -DViskores_ENABLE_DOCUMENTATION=ON -DViskores_ENABLE_USERS_GUIDE=ON -DViskores_USERS_GUIDE_INCLUDE_TODOS=OFF
     - cmake --build build --target ViskoresDoxygenDocs
     - cp -f ./build/docs/users-guide/ViskoresUsersGuideHTML.cache/conf.py docs/users-guide/conf.py

--- a/Utilities/Scripts/patch-breathe.py
+++ b/Utilities/Scripts/patch-breathe.py
@@ -1,0 +1,70 @@
+##============================================================================
+##  The contents of this file are covered by the Viskores license. See
+##  LICENSE.txt for details.
+##
+##  By contributing to this file, all contributors agree to the Developer
+##  Certificate of Origin Version 1.1 (DCO 1.1) as stated in DCO.txt.
+##============================================================================
+
+# This code patches the `breathe` package to execute faster. This is designed to
+# explicitly patch breathe version 4.36.0. Problems might occur if applied to
+# any other version.
+#
+# The problem with breathe 4.36.0 is reported at
+# https://github.com/breathe-doc/breathe/issues/1069 .
+# The issue that occurs is that this version of breathe is using the
+# `pathlib.Path.resolve()` method in several places, and that can slow things
+# down significantly in situations where disk access is slow such as in
+# containers or networked drives. This script works by finding instances
+# of the `resolve()` method and replace them with `absolute()`. For this
+# specific version of breathe, this text substitution correctly modifies the
+# code. Things might break in other versions.
+#
+# This code is executed in `.readthedocs.yaml` during the building of the guide
+# by readthedocs.org. It modifies the locally-installed version of breathe. You
+# can also execute it locally to patch your pip-installed packages. The change
+# may have less effect on a local system.
+#
+# If the version of breathe changes in docs/users-guide/requirements.txt, then
+# this script should be modified or removed and .readthedocs.yaml should be
+# modified.
+
+from pathlib import Path
+
+import breathe
+
+expected_version = "4.36.0"
+if breathe.__version__ != expected_version:
+  print("Incorrect version:", breathe.__version__)
+  print("This patch script is designed to work specifically with", expected_version)
+  print("If the version of breathe was changed in docs/users-guide/requirements.txt,")
+  print("then this patch should be updated or removed. If removed, be sure to remove")
+  print("the corresponding line from .readthedocs.yaml.")
+  exit(1)
+
+print("Patching breathe", breathe.__version__)
+
+import breathe.file_state_cache
+import breathe.parser
+import breathe.path_handler
+import breathe.project
+import breathe.renderer.sphinxrenderer
+
+def remove_resolve(module):
+  old = ").resolve()"
+  new = ").absolute()"
+
+  path = Path(module.__file__)
+
+  text = path.read_text()
+  if old not in text:
+    raise RuntimeError(f"Expected .resolve() call not found in {path}")
+
+  path.write_text(text.replace(old, new))
+  print(f"Patched {path}")
+
+remove_resolve(breathe.file_state_cache)
+remove_resolve(breathe.parser)
+remove_resolve(breathe.path_handler)
+remove_resolve(breathe.project)
+remove_resolve(breathe.renderer.sphinxrenderer)

--- a/docs/users-guide/requirements.in
+++ b/docs/users-guide/requirements.in
@@ -17,9 +17,9 @@
 # The resulting requirements are copied to the requirements-doc.txt file in the
 # root directory of this repository.
 
-breathe==4.35.0
-Sphinx==7.2.6
-sphinx-rtd-theme==1.3.0
-sphinxcontrib-moderncmakedomain==3.27.0
-sphinxcontrib-packages==1.1.2
+breathe==4.36.0
+Sphinx==7.3.7
+sphinx-rtd-theme==3.1.0
+sphinxcontrib-moderncmakedomain==3.29.0
+sphinxcontrib-packages==1.2.1
 readthedocs-sphinx-search==0.3.2

--- a/docs/users-guide/requirements.txt
+++ b/docs/users-guide/requirements.txt
@@ -16,7 +16,7 @@ alabaster==0.7.16
     # via sphinx
 babel==2.18.0
     # via sphinx
-breathe==4.35.0
+breathe==4.36.0
     # via -r requirements.in
 certifi==2026.7.22
     # via requests
@@ -26,7 +26,6 @@ distro==1.9.0
     # via sphinxcontrib-packages
 docutils==0.18.1
     # via
-    #   breathe
     #   sphinx
     #   sphinx-rtd-theme
 idna==3.18
@@ -47,7 +46,7 @@ requests==2.34.2
     # via sphinx
 snowballstemmer==3.1.1
     # via sphinx
-sphinx==7.2.6
+sphinx==7.3.7
     # via
     #   -r requirements.in
     #   breathe
@@ -55,7 +54,7 @@ sphinx==7.2.6
     #   sphinxcontrib-jquery
     #   sphinxcontrib-moderncmakedomain
     #   sphinxcontrib-packages
-sphinx-rtd-theme==1.3.0
+sphinx-rtd-theme==3.1.0
     # via -r requirements.in
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
@@ -67,9 +66,9 @@ sphinxcontrib-jquery==4.1
     # via sphinx-rtd-theme
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-moderncmakedomain==3.27.0
+sphinxcontrib-moderncmakedomain==3.29.0
     # via -r requirements.in
-sphinxcontrib-packages==1.1.2
+sphinxcontrib-packages==1.2.1
     # via -r requirements.in
 sphinxcontrib-qthelp==2.0.0
     # via sphinx


### PR DESCRIPTION
Bumps the versions of Sphinx packages. This bump was originally requested by @dependabot in PRs like #429. However, a problem with the new version of breathe causes the readthedocs build to timeout (see https://github.com/breathe-doc/breathe/issues/1069). Thus, a patch to breathe is also added.