### PR TITLE
Fix issue with cuda::is_commutative_v on MSVC

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -82,9 +82,9 @@
   extends:
     - .docker_image
 
-.ubuntu2404_cuda130: &ubuntu2404_cuda130
+.ubuntu2404_cuda133: &ubuntu2404_cuda133
   image:
-    name: "ghcr.io/viskores/viskores:ci-ubuntu2404_cuda13.0-20250820"
+    name: "ghcr.io/viskores/viskores:ci-ubuntu2404_cuda13.3-20260903"
   extends:
     - .docker_image
 

--- a/.gitlab/ci/docker/ubuntu2404_cuda13.3.dockerfile
+++ b/.gitlab/ci/docker/ubuntu2404_cuda13.3.dockerfile
@@ -7,7 +7,7 @@
 ##============================================================================
 
 
-FROM docker.io/nvidia/cuda:13.0.0-devel-ubuntu24.04
+FROM docker.io/nvidia/cuda:13.3.1-devel-ubuntu24.04
 LABEL maintainer "Vicente Adolfo Bolea Sanchez<vicente.bolea@gmail.com>"
 
 # Base dependencies for building VTK-m projects

--- a/.gitlab/ci/ubuntu2404.yml
+++ b/.gitlab/ci/ubuntu2404.yml
@@ -48,9 +48,9 @@ ubuntu2404_gcc14:
     paths:
       - viskores-install.tar.gz
 
-ubuntu2404_gcc14_cuda130:
+ubuntu2404_gcc14_cuda133:
   extends:
-    - .ubuntu2404_cuda130
+    - .ubuntu2404_cuda133
     - .cmake_build_linux
     - .run_automatically
     - .uo_cpu_tags

--- a/.gitlab/ci/vtk-contract.yml
+++ b/.gitlab/ci/vtk-contract.yml
@@ -49,12 +49,12 @@ vtk_serial:
 vtk_cuda:
   extends:
     - .vtk_contract_base
-    - .ubuntu2404_cuda130
+    - .ubuntu2404_cuda133
     - .run_automatically
     - .uo_cpu_tags
   variables:
     CCACHE_RESHARE: "true"
     CMAKE_ARGS: "-DVTK_USE_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=75"
   needs:
-    - job: ubuntu2404_gcc14_cuda130
+    - job: ubuntu2404_gcc14_cuda133
       artifacts: true

--- a/viskores/exec/cuda/internal/WrappedOperators.h
+++ b/viskores/exec/cuda/internal/WrappedOperators.h
@@ -209,13 +209,10 @@ struct WrappedBinaryPredicate
 //
 //
 #if THRUST_VERSION >= 300300
-namespace cuda
-{
 template <typename T, typename F>
-inline constexpr bool
+inline constexpr bool ::cuda::
   is_commutative_v<::viskores::exec::cuda::internal::WrappedBinaryOperator<T, F>, T> =
     ::cuda::std::is_arithmetic<T>::value;
-}
 #else // THRUST_VERSION < 300300
 VISKORES_THRUST_NAMESPACE_BEGIN
 namespace detail

--- a/viskores/exec/cuda/internal/WrappedOperators.h
+++ b/viskores/exec/cuda/internal/WrappedOperators.h
@@ -200,13 +200,10 @@ struct WrappedBinaryPredicate
 //
 //
 #if THRUST_VERSION >= 300300
-namespace cuda
-{
 template <typename T, typename F>
-inline constexpr bool
+inline constexpr bool ::cuda::
   is_commutative_v<::viskores::exec::cuda::internal::WrappedBinaryOperator<T, F>, T> =
     ::cuda::std::is_arithmetic<T>::value;
-}
 #else // THRUST_VERSION < 300300
 VISKORES_THRUST_NAMESPACE_BEGIN
 namespace detail


### PR DESCRIPTION
There is an apparent issue when compiling with MSVC and Cuda 13.3 in that our overload of `cuda::is_commutative_v` breaks. This change attempts to fix the issue by overloading in the global namespace.

See https://github.com/microsoft/vcpkg/pull/53088#issuecomment-5276446630 for details.