### PR TITLE
Restrict dependabot to security-only updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,7 @@ updates:
     directory: /
     schedule:
       interval: daily
+    open-pull-requests-limit: 0
     groups:
       github-actions:
         patterns:
@@ -21,6 +22,7 @@ updates:
     directory: /Utilities/CI
     schedule:
       interval: daily
+    open-pull-requests-limit: 0
     groups:
       pip-utilities-ci:
         patterns:
@@ -30,6 +32,7 @@ updates:
     directory: /docs/users-guide
     schedule:
       interval: daily
+    open-pull-requests-limit: 0
     groups:
       pip-docs-users-guide:
         patterns:


### PR DESCRIPTION
## Summary
- Set `open-pull-requests-limit: 0` on all three dependabot.yml entries (github-actions, pip Utilities/CI, pip docs/users-guide) to disable routine version-update pull requests
- Security-alert pull requests are unaffected, controlled separately via repo Settings > Code security > Dependabot security updates

## Test plan
- [ ] Verify YAML is valid (`python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"`)
- [ ] Confirm no routine dependabot PRs are opened after merge
- [ ] Confirm Dependabot security updates remain enabled in repo settings