### PR TITLE
ANARI device: Apply image region and aspect parameters to the perspective camera

### DIFF
--- a/docs/changelog/anari-apply-imageRegion-and-aspect-parameters.md
+++ b/docs/changelog/anari-apply-imageRegion-and-aspect-parameters.md
@@ -1,0 +1,5 @@
+## Applied imageRegion and aspect parameters to the perspective camera
+
+The ANARI device now applies the `imageRegion` and `aspect` parameters to the perspective camera.
+
+Both parameters are optional: If you do not explictly set `imageRegion` using `anariSetParameter`, the full viewport is rendered by default. If you do not explicitly set `aspect`, the device calculates the aspect ratio automatically using the camera's width and height.

--- a/viskores/rendering/Camera.h
+++ b/viskores/rendering/Camera.h
@@ -346,6 +346,24 @@ public:
   VISKORES_CONT
   viskores::Float32 GetZoom() const { return this->Camera3D.Zoom; }
 
+  /// @brief The aspect ratio of the camera
+  ///
+  /// If the aspect ratio is not explicitly overwritten by `SetAspectRatio`, it will be
+  /// computed from the width and height of the rendered image.
+  ///
+  /// Setting the aspect ratio changes the mode to 3D.
+  ///
+  VISKORES_CONT
+  viskores::Float32 GetAspectRatio() const { return this->Camera3D.AspectRatio; }
+
+  /// @copydoc GetAspectRatio
+  VISKORES_CONT
+  void SetAspectRatio(viskores::Float32 aspect)
+  {
+    this->SetModeTo3D();
+    this->Camera3D.AspectRatio = aspect;
+  }
+
   /// @brief Moves the camera as if a point was dragged along a sphere.
   ///
   /// `TrackballRotate()` takes the normalized screen coordinates (in the range

--- a/viskores/rendering/anari-device/camera/Camera.cpp
+++ b/viskores/rendering/anari-device/camera/Camera.cpp
@@ -56,6 +56,11 @@ void Camera::finalize()
   // no-op
 }
 
+viskores::Float32 Camera::imageRegionToViewport(viskores::Float32 value) const
+{
+  return 2.f * value - 1.f;
+}
+
 UnknownCamera::UnknownCamera(ViskoresDeviceGlobalState* s)
   : Camera(s){};
 

--- a/viskores/rendering/anari-device/camera/Camera.h
+++ b/viskores/rendering/anari-device/camera/Camera.h
@@ -44,6 +44,8 @@ protected:
   viskores::Vec3f_32 m_direction;
   viskores::Vec3f_32 m_up;
   viskores::Vec4f_32 m_imageRegion;
+
+  viskores::Float32 imageRegionToViewport(viskores::Float32 value) const;
 };
 
 struct UnknownCamera : public Camera

--- a/viskores/rendering/anari-device/camera/Perspective.cpp
+++ b/viskores/rendering/anari-device/camera/Perspective.cpp
@@ -44,14 +44,14 @@ viskores::rendering::Camera Perspective::camera(const viskores::Bounds& bounds) 
   camera.SetLookAt(this->m_position + (length * this->m_direction));
   camera.SetViewUp(this->m_up);
   camera.SetFieldOfView(anari::degrees(this->m_fovy));
+
   camera.SetClippingRange((this->m_near > 0) ? this->m_near : (0.01f * length),
                           (this->m_far > 0) ? this->m_far : (1000.f * length));
-#if 0
-  camera.SetViewport(this->m_imageRegion[0],
-                     this->m_imageRegion[2],
-                     this->m_imageRegion[1],
-                     this->m_imageRegion[3]);
-#endif
+
+  camera.SetViewport(imageRegionToViewport(this->m_imageRegion[0]),
+                     imageRegionToViewport(this->m_imageRegion[2]),
+                     imageRegionToViewport(this->m_imageRegion[1]),
+                     imageRegionToViewport(this->m_imageRegion[3]));
 
   // TODO: The aspect parameter is ignored. This is handled elsewhere
 

--- a/viskores/rendering/anari-device/camera/Perspective.cpp
+++ b/viskores/rendering/anari-device/camera/Perspective.cpp
@@ -23,7 +23,14 @@ void Perspective::commitParameters()
   Camera::commitParameters();
 
   this->m_fovy = this->getParam("fovy", viskores::Pi_3f());
-  this->m_aspect = this->getParam("aspect", viskores::Float32(1));
+  if (hasParam("aspect", ANARI_FLOAT32))
+  {
+    m_aspect = this->getParam<viskores::Float32>("aspect", 1.f);
+  }
+  else
+  {
+    m_aspect.reset();
+  }
   this->m_near = this->getParam("near", viskores::Float32(-1));
   this->m_far = this->getParam("far", viskores::Float32(-1));
 }
@@ -45,6 +52,11 @@ viskores::rendering::Camera Perspective::camera(const viskores::Bounds& bounds) 
   camera.SetViewUp(this->m_up);
   camera.SetFieldOfView(anari::degrees(this->m_fovy));
 
+  if (this->m_aspect.has_value())
+  {
+    camera.SetAspectRatio(this->m_aspect.value());
+  }
+
   camera.SetClippingRange((this->m_near > 0) ? this->m_near : (0.01f * length),
                           (this->m_far > 0) ? this->m_far : (1000.f * length));
 
@@ -52,8 +64,6 @@ viskores::rendering::Camera Perspective::camera(const viskores::Bounds& bounds) 
                      imageRegionToViewport(this->m_imageRegion[2]),
                      imageRegionToViewport(this->m_imageRegion[1]),
                      imageRegionToViewport(this->m_imageRegion[3]));
-
-  // TODO: The aspect parameter is ignored. This is handled elsewhere
 
   return camera;
 }

--- a/viskores/rendering/anari-device/camera/Perspective.h
+++ b/viskores/rendering/anari-device/camera/Perspective.h
@@ -10,6 +10,8 @@
 
 #pragma once
 
+#include <optional>
+
 #include "Camera.h"
 
 namespace viskores_device
@@ -25,7 +27,7 @@ struct Perspective : public Camera
 
 private:
   viskores::Float32 m_fovy;
-  viskores::Float32 m_aspect;
+  std::optional<viskores::Float32> m_aspect;
   viskores::Float32 m_near;
   viskores::Float32 m_far;
 };

--- a/viskores/rendering/raytracing/Camera.cxx
+++ b/viskores/rendering/raytracing/Camera.cxx
@@ -48,6 +48,7 @@ public:
   PixelData(viskores::Int32 width,
             viskores::Int32 height,
             viskores::Float32 fovY,
+            viskores::Float32 aspect,
             viskores::Vec3f_32 look,
             viskores::Vec3f_32 up,
             viskores::Float32 _zoom,
@@ -65,7 +66,7 @@ public:
     , BoundingBox(boundingBox)
   {
     viskores::Float32 thy = tanf((fovY * viskores::Pi_180f()) * .5f);
-    viskores::Float32 thx = (thy * width) / height;
+    viskores::Float32 thx = (aspect > 0.f) ? thy * aspect : (thy * width) / height;
     viskores::Vec3f_32 ru = viskores::Cross(look, up);
     viskores::Normalize(ru);
 
@@ -164,6 +165,7 @@ public:
   PerspectiveRayGenJitter(viskores::Int32 width,
                           viskores::Int32 height,
                           viskores::Float32 fovY,
+                          viskores::Float32 aspect,
                           viskores::Vec3f_32 look,
                           viskores::Vec3f_32 up,
                           viskores::Float32 _zoom,
@@ -172,7 +174,7 @@ public:
     , h(height)
   {
     viskores::Float32 thy = tanf((fovY * 3.1415926f / 180.f) * .5f);
-    viskores::Float32 thx = (thy * width) / height;
+    viskores::Float32 thx = (aspect > 0.f) ? thy * aspect : (thy * width) / height;
     viskores::Vec3f_32 ru = viskores::Cross(up, look);
     viskores::Normalize(ru);
 
@@ -338,6 +340,7 @@ public:
   PerspectiveRayGen(viskores::Int32 width,
                     viskores::Int32 height,
                     viskores::Float32 fovY,
+                    viskores::Float32 aspect,
                     viskores::Vec3f_32 look,
                     viskores::Vec3f_32 up,
                     viskores::Float32 panx,
@@ -363,7 +366,7 @@ public:
     , SubsetWidth(subsetWidth)
   {
     viskores::Float32 thy = tanf((fovY * viskores::Pi_180f()) * .5f);
-    viskores::Float32 thx = (thy * width) / height;
+    viskores::Float32 thx = (aspect > 0.f) ? thy * aspect : (thy * width) / height;
 
     viskores::Vec3f_32 ru = viskores::Cross(look, up);
     viskores::Normalize(ru);
@@ -442,17 +445,19 @@ viskores::Matrix<viskores::Float32, 4, 4> Camera3DStruct::CreateProjectionMatrix
   viskores::Id width,
   viskores::Id height,
   viskores::Float32 nearPlane,
-  viskores::Float32 farPlane) const
+  viskores::Float32 farPlane,
+  viskores::Float32 aspect) const
 {
   viskores::Matrix<viskores::Float32, 4, 4> matrix;
   viskores::MatrixIdentity(matrix);
 
-  viskores::Float32 AspectRatio = viskores::Float32(width) / viskores::Float32(height);
+  viskores::Float32 aspectRatio =
+    (aspect > 0.f) ? aspect : (viskores::Float32(width) / viskores::Float32(height));
   viskores::Float32 fovRad = this->FieldOfView * viskores::Pi_180f();
   fovRad = viskores::Tan(fovRad * 0.5f);
   viskores::Float32 size = nearPlane * fovRad;
-  viskores::Float32 left = -size * AspectRatio;
-  viskores::Float32 right = size * AspectRatio;
+  viskores::Float32 left = -size * aspectRatio;
+  viskores::Float32 right = size * aspectRatio;
   viskores::Float32 bottom = -size;
   viskores::Float32 top = size;
 
@@ -722,6 +727,7 @@ void Camera::GetPixelData(const viskores::cont::CoordinateSystem& coords,
   viskores::worklet::DispatcherMapField<PixelData>(PixelData(this->Width,
                                                              this->Height,
                                                              this->Camera3D.FieldOfView,
+                                                             this->Camera3D.AspectRatio,
                                                              this->LookDirection,
                                                              this->Camera3D.ViewUp,
                                                              this->Camera3D.Zoom,
@@ -804,6 +810,7 @@ VISKORES_CONT void Camera::CreateRaysImpl(Ray<Precision>& rays, const viskores::
     invoke(PerspectiveRayGen{ this->Width,
                               this->Height,
                               this->Camera3D.FieldOfView,
+                              this->Camera3D.AspectRatio,
                               this->LookDirection,
                               this->Camera3D.ViewUp,
                               this->Camera3D.XPan,
@@ -1004,7 +1011,7 @@ void Camera::UpdateViewProjectionMatrix() const
   else
   {
     projection = this->Camera3D.CreateProjectionMatrix(
-      this->Width, this->Height, this->NearPlane, this->FarPlane);
+      this->Width, this->Height, this->NearPlane, this->FarPlane, this->Camera3D.AspectRatio);
     modelview = this->Camera3D.CreateViewMatrix();
   }
   this->ViewProjectionMat = viskores::MatrixMultiply(projection, modelview);
@@ -1040,7 +1047,10 @@ void Camera::CreateDebugRayImp(viskores::Vec2i_32 pixel, Ray<Precision>& rays)
 
 
   viskores::Float32 thy = tanf((this->Camera3D.FieldOfView * viskores::Pi_180f()) * .5f);
-  viskores::Float32 thx = (thy * this->Width) / this->Height;
+  viskores::Float32 thx = (this->Camera3D.AspectRatio > 0.f)
+    ? thy * this->Camera3D.AspectRatio
+    : thy * (thy * this->Width) / this->Height;
+
   viskores::Vec3f_32 ru = viskores::Cross(this->LookDirection, this->Camera3D.ViewUp);
   viskores::Normalize(ru);
 

--- a/viskores/rendering/raytracing/Camera.cxx
+++ b/viskores/rendering/raytracing/Camera.cxx
@@ -324,6 +324,10 @@ public:
   viskores::Int32 h;
   viskores::Float32 panX;
   viskores::Float32 panY;
+  viskores::Float32 ViewportLeft;
+  viskores::Float32 ViewportRight;
+  viskores::Float32 ViewportBottom;
+  viskores::Float32 ViewportTop;
   viskores::Int32 Minx;
   viskores::Int32 Miny;
   viskores::Int32 SubsetWidth;
@@ -339,6 +343,10 @@ public:
                     viskores::Float32 panx,
                     viskores::Float32 pany,
                     viskores::Float32 _zoom,
+                    viskores::Float32 viewportLeft,
+                    viskores::Float32 viewportRight,
+                    viskores::Float32 viewportBottom,
+                    viskores::Float32 viewportTop,
                     viskores::Int32 subsetWidth,
                     viskores::Int32 minx,
                     viskores::Int32 miny)
@@ -346,6 +354,10 @@ public:
     , h(height)
     , panX(panx)
     , panY(pany)
+    , ViewportLeft(viewportLeft)
+    , ViewportRight(viewportRight)
+    , ViewportBottom(viewportBottom)
+    , ViewportTop(viewportTop)
     , Minx(minx)
     , Miny(miny)
     , SubsetWidth(subsetWidth)
@@ -396,8 +408,15 @@ public:
     pixelIndex = static_cast<viskores::Id>(j * w + i);
 
     viskores::Vec<Precision, 3> ray_dir = nlook +
-      delta_x * ((2.f * Precision(i) - panX * Precision(w) - Precision(w)) / 2.0f) +
-      delta_y * ((2.f * Precision(j) - panY * Precision(h) - Precision(h)) / 2.0f);
+      delta_x *
+        (((Precision(ViewportRight) - Precision(ViewportLeft)) * Precision(i) +
+          (Precision(ViewportLeft) - Precision(panX)) * Precision(w)) /
+         2.0f) +
+      delta_y *
+        (((Precision(ViewportTop) - Precision(ViewportBottom)) * Precision(j) +
+          (Precision(ViewportBottom) - Precision(panY)) * Precision(h)) /
+         2.0f);
+
     // avoid some numerical issues
     for (viskores::Int32 d = 0; d < 3; ++d)
     {
@@ -660,6 +679,12 @@ viskores::Vec3f_32 Camera::GetPosition() const
   return this->Camera3D.Position;
 }
 
+VISKORES_CONT bool Camera::HasFullViewport() const
+{
+  return (this->ViewportLeft == -1.0f) && (this->ViewportRight == 1.0f) &&
+    (this->ViewportBottom == -1.0f) && (this->ViewportTop == 1.0f);
+}
+
 VISKORES_CONT viskores::Matrix<viskores::Float32, 4, 4>& Camera::GetViewProjectionMatrix() const
 {
   this->UpdateViewProjectionMatrix();
@@ -772,6 +797,9 @@ VISKORES_CONT void Camera::CreateRaysImpl(Ray<Precision>& rays, const viskores::
   }
   else
   {
+    viskores::Float32 vl, vr, vb, vt;
+    this->GetViewport(vl, vr, vb, vt);
+
     //Create the ray direction
     invoke(PerspectiveRayGen{ this->Width,
                               this->Height,
@@ -781,6 +809,10 @@ VISKORES_CONT void Camera::CreateRaysImpl(Ray<Precision>& rays, const viskores::
                               this->Camera3D.XPan,
                               this->Camera3D.YPan,
                               this->Camera3D.Zoom,
+                              vl,
+                              vr,
+                              vb,
+                              vt,
                               this->SubsetWidth,
                               this->SubsetMinX,
                               this->SubsetMinY },
@@ -910,7 +942,10 @@ VISKORES_CONT void Camera::UpdateDimensions(Ray<Precision>& rays,
   bool imageSubsetModeOn = boundingBox.IsNonEmpty();
 
   //Find the pixel footprint
-  if (imageSubsetModeOn && !this->IsOrthogonalProjection)
+  bool usePixelFootprint =
+    imageSubsetModeOn && !this->IsOrthogonalProjection && this->HasFullViewport();
+
+  if (usePixelFootprint)
   {
     // Note:
     // Use clipping range provided, the subsetting does take into consideration

--- a/viskores/rendering/raytracing/Camera.h
+++ b/viskores/rendering/raytracing/Camera.h
@@ -29,6 +29,7 @@ public:
     , Position(0.0f, 0.0f, 1.0f)
     , ViewUp(0.0f, 1.0f, 0.0f)
     , FieldOfView(60.0f)
+    , AspectRatio(0.0f)
     , XPan(0.0f)
     , YPan(0.0f)
     , Zoom(1.0f)
@@ -41,12 +42,14 @@ public:
     viskores::Id width,
     viskores::Id height,
     viskores::Float32 nearPlane,
-    viskores::Float32 farPlane) const;
+    viskores::Float32 farPlane,
+    viskores::Float32 aspect = 0.f) const;
 
   viskores::Vec3f_32 LookAt;
   viskores::Vec3f_32 Position;
   viskores::Vec3f_32 ViewUp;
   viskores::Float32 FieldOfView;
+  viskores::Float32 AspectRatio;
   viskores::Float32 XPan;
   viskores::Float32 YPan;
   viskores::Float32 Zoom;

--- a/viskores/rendering/raytracing/Camera.h
+++ b/viskores/rendering/raytracing/Camera.h
@@ -248,6 +248,8 @@ public:
     top = this->ViewportTop;
   }
 
+  VISKORES_CONT bool HasFullViewport() const;
+
   VISKORES_CONT viskores::Matrix<viskores::Float32, 4, 4>& GetViewProjectionMatrix() const;
 
   VISKORES_CONT


### PR DESCRIPTION
In this PR, I have implemented the handling of the `aspect` and `imageRegion` parameters for the perspective camera of the ANARI device. This is useful, e.g., for a multi-screen setup where setting both parameters is necessary to make sure the transitions between screens are seamless (which is also how we've noticed the parameters are not handled yet in the first place).

**ImageRegion**
The `imageRegion`  parameter is now converted from range [0,1] to [-1,1] through the new `imageRegionToViewport` method and the`PerspectiveRayGen` worklet in `viskores/rendering/raytracing/Camera.cxx` was updated so it can handle viewports which are not full.

**Aspect**
I  turned `m_aspect` into a `std::optional` (as is done in the helide device) and added the new attribute `AspectRatio` to `Camera3DStruct` in `viskores/rendering/raytracing/Camera.h`.
Now, if the user explicitly sets the `aspect` parameter, the ratio is passed directly to the affected worklets/methods in `viskores/rendering/raytracing/Camera.cxx`. Otherwise, `AspectRatio` remains 0 (which is its default to ensure the new changes only affect the ANARI renderer) and the aspect ratio is calculated using the image width and height exactly as before.

As always, I'd be happy to hear your thoughts and any feedback you might have on this approach.