### PR TITLE
Anari interop volumerender

### DIFF
--- a/viskores/rendering/anari-device/scene/volume/TransferFunction1D.cpp
+++ b/viskores/rendering/anari-device/scene/volume/TransferFunction1D.cpp
@@ -162,6 +162,12 @@ void TransferFunction1D::finalize()
     static_cast<viskores::Float32>(viskores::Magnitude(bounds.MaxCorner() - bounds.MinCorner()));
   constexpr viskores::IdComponent numberOfSamples = 200;
   this->m_sampleDistance = static_cast<viskores::Float32>(diagonalLength / numberOfSamples);
+  if (this->m_unitDistance <= 0.f)
+  {
+    this->reportMessage(ANARI_SEVERITY_WARNING,
+                        "'unitDistance' must be positive; using a small positive value");
+    this->m_unitDistance = 1e-6f;
+  }
 
   // Reset and fill color table
   viskores::cont::ColorTable colorTable{ viskores::ColorSpace::RGB };
@@ -229,26 +235,6 @@ void TransferFunction1D::finalize()
     colorTable.AddPointAlpha(1, this->m_alpha);
   }
 
-  // The alpha channel provided by ANARI is actually meant to be interpreted as
-  // a transparency coefficient whereas the Viskores volume mapper uses the
-  // alpha channel as the opacity between two samples. The relationship between
-  // the two is:
-  //
-  // opacity = 1 - exp(-transparency * distance)
-  //
-  // Generally, the distance here will be the uniform sample distance used in
-  // the ray stepper. However, the units of the color distance might not be the
-  // same as the spatial units. This is given by ANARI's unit distance
-  // parameter, which can be used to convert the spatial units.
-  viskores::Float32 alphaSampleDistance = this->m_sampleDistance / this->m_unitDistance;
-  for (viskores::IdComponent pointId = 0; pointId < colorTable.GetNumberOfPointsAlpha(); ++pointId)
-  {
-    viskores::Vec4f_64 alphaPoint;
-    colorTable.GetPointAlpha(pointId, alphaPoint);
-    alphaPoint[1] = 1.0f - viskores::Exp(-alphaSampleDistance * alphaPoint[1]);
-    colorTable.UpdatePointAlpha(pointId, alphaPoint);
-  }
-
   colorTable.RescaleToRange(this->m_valueRange);
 
   // Now that we have the color table, build a simple map array that the render caster
@@ -265,13 +251,16 @@ void TransferFunction1D::finalize()
   this->m_colorMap.Allocate(1024);
   auto portal = this->m_colorMap.WritePortal();
   auto colorPortal = temp.ReadPortal();
+  const viskores::Float32 alphaSampleDistance = this->m_sampleDistance / this->m_unitDistance;
   for (viskores::Id i = 0; i < 1024; ++i)
   {
     auto color = colorPortal.Get(i);
+    viskores::Float32 opacity = color[3] * conversionToFloatSpace;
+    opacity = opacity >= 1.f ? 1.f : 1.f - viskores::Pow(1.f - opacity, alphaSampleDistance);
     viskores::Vec4f_32 t(color[0] * conversionToFloatSpace,
                          color[1] * conversionToFloatSpace,
                          color[2] * conversionToFloatSpace,
-                         color[3] * conversionToFloatSpace);
+                         opacity);
     portal.Set(i, t);
   }
 }

--- a/viskores/rendering/anari-device/scene/volume/TransferFunction1D.cpp
+++ b/viskores/rendering/anari-device/scene/volume/TransferFunction1D.cpp
@@ -256,6 +256,28 @@ void TransferFunction1D::finalize()
   {
     auto color = colorPortal.Get(i);
     viskores::Float32 opacity = color[3] * conversionToFloatSpace;
+    // The opacity given is based on the unit distance. We need to scale that
+    // to be the opacity for the sampling distance of the ray caster. This
+    // scaling is nonlinear.
+    //
+    // Opacity (α) scales exponentially with respect to the distance the ray
+    // travels through the material (d).
+    //
+    // α = 1 - exp(-τ·d)
+    //
+    // where τ is the "transparency coefficient" based on the absorption of the
+    // material, which is independent of the distance. Flipping this relationship,
+    // we get
+    //
+    // τ = -(1/d)·ln(1-α).
+    //
+    // We are given a unit distance, d_u, and an opacity based on that
+    // sampling distance, α_u. That means τ = -(1/d_u)·ln(1-α_u). Returning to
+    // the first equation defining α and substituting this τ and the ray caster's
+    // sample distance, d_s, we get the following opacity for the sample
+    // distance.
+    //
+    // α_s = 1 - (1 - α_u)^(d_s/d_u)
     opacity = opacity >= 1.f ? 1.f : 1.f - viskores::Pow(1.f - opacity, alphaSampleDistance);
     viskores::Vec4f_32 t(color[0] * conversionToFloatSpace,
                          color[1] * conversionToFloatSpace,


### PR DESCRIPTION
Correct the ANARI volume opacity conversion to account for the renderer’s sample distance and the volume’s unitDistance. The conversion is now applied after transfer-function sampling using the ANARI opacity relationship, which preserves interpolation behavior. Invalid nonpositive unitDistance values are also handled.
This reduces the volume test’s SSIM error from 0.376137 to 0.230263. The existing Helide baseline threshold still fails because of additional rendering differences.

Further experiments (not included in this PR) had these results.
- Matching Helide’s MT19937 jitter reduces the error to 0.197168
- Also matching Helide’s sample distance reduces it to 0.0703201
- Using a floating-point transfer-function lookup reduces it to 0.0581116
- Removing the additional Viskores ray-start offset reduces it to 0.0350807, below the 0.05 threshold

Alternative jitter patterns did not provide the same improvement. Hash-based jitter produced 0.224755, while Viskores’ Philox-based generators produced approximately 0.226. This indicates that matching the existing baseline depends on reproducing Helide’s specific sampling pattern rather than simply adding statistically uniform jitter.