### PR TITLE
Fix an intermittent FPE in testing

### DIFF
--- a/viskores/exec/testing/UnitTestParametricCoordinates.cxx
+++ b/viskores/exec/testing/UnitTestParametricCoordinates.cxx
@@ -109,7 +109,10 @@ void TestPCoordsSample(const PointWCoordsType& pointWCoords, CellShapeTag shape)
 
   const viskores::IdComponent numPoints = pointWCoords.GetNumberOfComponents();
 
-  std::uniform_real_distribution<viskores::FloatDefault> randomDist;
+  // Keep every weight positive so that their sum is safe to use as a
+  // normalization factor. The default distribution includes zero, which can
+  // make totalWeight zero for single-point cells.
+  std::uniform_real_distribution<viskores::FloatDefault> randomDist(0.01f, 1.0f);
 
   for (viskores::IdComponent trial = 0; trial < 5; trial++)
   {


### PR DESCRIPTION
The UnitTestParametricCoordinates test intermittently fails with a floating point exception (FPE) signal. This attempts to fix the problem by altering a random number generator to ensure that it never picks a 0 that can be used in a denominator.

I am not convinced this will (completely) fix the problem. The failure happens more often than I would expect a 0 to be randomly picked, but it is a possible point of failure that we can rule out.

Assisted-by: Codex